### PR TITLE
Persistence v1.5: sever external handles (#128) and wire the boot checkpoint store (#129)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -41,14 +41,15 @@ jobs:
         run: |
           set -e
           cd tests
-          gcc -I../include -Wall -o /tmp/t_store  test_snapshot_store.c                                              && /tmp/t_store
-          gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c           ../kernel/checkpoint.c ../kernel/snapshot_store.c && /tmp/t_ckpt
-          gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c ../kernel/checkpoint.c ../kernel/snapshot_store.c && /tmp/t_wb
-          gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c   ../kernel/checkpoint.c ../kernel/snapshot_store.c && /tmp/t_rs
-          gcc -I../include -Wall -o /tmp/t_ctx    test_checkpoint_context.c   ../kernel/checkpoint.c ../kernel/snapshot_store.c && /tmp/t_ctx
-          gcc -I../include -Wall -o /tmp/t_rc     test_checkpoint_reconstruct.c ../kernel/checkpoint.c ../kernel/snapshot_store.c && /tmp/t_rc
-          gcc -I../include -Wall -o /tmp/t_tm     test_checkpoint_timer.c     ../kernel/checkpoint.c ../kernel/snapshot_store.c && /tmp/t_tm
-          gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c  ../kernel/checkpoint_extstate.c                    && /tmp/t_ext
+          K="../kernel/checkpoint.c ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c"
+          gcc -I../include -Wall -o /tmp/t_store  test_snapshot_store.c            && /tmp/t_store
+          gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
+          gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
+          gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs
+          gcc -I../include -Wall -o /tmp/t_ctx    test_checkpoint_context.c    $K && /tmp/t_ctx
+          gcc -I../include -Wall -o /tmp/t_rc     test_checkpoint_reconstruct.c $K && /tmp/t_rc
+          gcc -I../include -Wall -o /tmp/t_tm     test_checkpoint_timer.c      $K && /tmp/t_tm
+          gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c   ../kernel/checkpoint_extstate.c && /tmp/t_ext
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -42,6 +42,7 @@ jobs:
           set -e
           cd tests
           K="../kernel/checkpoint.c ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c"
+          KR="$K ../kernel/ramdisk.c"
           gcc -I../include -Wall -o /tmp/t_store  test_snapshot_store.c            && /tmp/t_store
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
@@ -50,6 +51,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_rc     test_checkpoint_reconstruct.c $K && /tmp/t_rc
           gcc -I../include -Wall -o /tmp/t_tm     test_checkpoint_timer.c      $K && /tmp/t_tm
           gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c   ../kernel/checkpoint_extstate.c && /tmp/t_ext
+          gcc -I../include -Wall -o /tmp/t_init   test_persistence_init.c     $KR && /tmp/t_init
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/checkpoint_extstate.h
+++ b/include/checkpoint_extstate.h
@@ -63,4 +63,26 @@ int extstate_sever_all(extstate_resource_t* resources, int count);
  * severed across a restore, else EXTSTATE_OK. */
 int extstate_status(const extstate_resource_t* res);
 
+/* ----- File-descriptor integration (#128) -----
+ *
+ * The kernel tags a descriptor's flags word with its resource kind so that, on
+ * restore, the registrar can sever the non-persistable ones. The kind lives in
+ * the high bits of the flags so it does not collide with file open flags. */
+#define EXTSTATE_FD_KIND_SHIFT 28
+#define EXTSTATE_FD_KIND_MASK  (0x7u << EXTSTATE_FD_KIND_SHIFT)
+#define EXTSTATE_FD_SEVERED    (0x1u << 31)
+
+/* Store/read the resource kind in a descriptor's flags word. */
+void            extstate_fd_set_kind(uint32_t* flags, extstate_kind_t kind);
+extstate_kind_t extstate_kind_from_fd_flags(uint32_t flags);
+
+/* Restore-time transition for one descriptor (by its flags word): if its kind
+ * does not survive a checkpoint and it is not already severed, set the severed
+ * bit and return true. Persistable or already-severed descriptors return false. */
+bool extstate_sever_fd(uint32_t* flags);
+
+/* Has this descriptor been severed across a restore? Syscalls consult this to
+ * return a clean error so the app re-establishes the resource. */
+bool extstate_fd_is_severed(uint32_t flags);
+
 #endif /* CHECKPOINT_EXTSTATE_H */

--- a/include/ramdisk.h
+++ b/include/ramdisk.h
@@ -1,0 +1,30 @@
+/* IKOS RAM disk - in-memory block device
+ *
+ * A simple 1 MiB RAM-backed block device exposing the fat_block_device_t
+ * interface. Used (among other things) as the backing store for orthogonal
+ * persistence checkpoints when no real disk region is dedicated (#129).
+ */
+
+#ifndef RAMDISK_H
+#define RAMDISK_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "fat.h"   /* fat_block_device_t */
+
+/* Allocate and zero the RAM disk (idempotent). Returns 0 on success. */
+int ramdisk_init(void);
+
+/* Free the RAM disk backing memory. */
+void ramdisk_cleanup(void);
+
+/* Return the block-device handle, initializing the RAM disk on first use.
+ * Returns NULL if initialization fails. */
+fat_block_device_t* ramdisk_get_device(void);
+
+/* Optional helpers (FAT16 formatting / test data / stats). */
+int ramdisk_format_fat16(void);
+int ramdisk_create_test_file(void);
+void ramdisk_get_stats(uint32_t* total_sectors, uint32_t* sector_size, bool* initialized);
+
+#endif /* RAMDISK_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -46,7 +46,7 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             ext2.c ext2_syscalls.c \
             usb.c usb_hid.c usb_uhci.c usb_control.c usb_syscalls.c usb_test.c usb_integration.c \
             audio.c audio_ac97.c audio_syscalls.c audio_user.c \
-            snapshot_store.c checkpoint.c checkpoint_extstate.c
+            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint.c
+++ b/kernel/checkpoint.c
@@ -5,6 +5,7 @@
  */
 
 #include "checkpoint.h"
+#include "checkpoint_extstate.h"
 #include "process_manager.h"
 #include <stddef.h>
 
@@ -474,8 +475,14 @@ static int checkpoint_register_kernel(void* reg_ctx, const checkpoint_restored_p
         memcpy(&proc->context, rp->context, n);
     }
 
-    /* External / non-persistable handles (sockets, DMA, devices) are severed on
-     * restore; the per-fd wiring lands in #128 (extstate_sever_all). */
+    /* Sever external / non-persistable handles (sockets, DMA, devices). Their
+     * kind is tagged in each fd's flags; severed descriptors return a clean
+     * error so the app re-establishes them (#118, #128). Regular files survive. */
+    for (int i = 0; i < MAX_OPEN_FILES; i++) {
+        if (proc->fds[i].fd >= 0) {
+            extstate_sever_fd(&proc->fds[i].flags);
+        }
+    }
 
     proc->state = PROCESS_STATE_READY;
     scheduler_add_process(proc); /* process->scheduler bridge */

--- a/kernel/checkpoint_extstate.c
+++ b/kernel/checkpoint_extstate.c
@@ -61,3 +61,35 @@ int extstate_status(const extstate_resource_t* res) {
     }
     return EXTSTATE_OK;
 }
+
+/* ----- File-descriptor integration (#128) ----- */
+
+void extstate_fd_set_kind(uint32_t* flags, extstate_kind_t kind) {
+    if (!flags) {
+        return;
+    }
+    *flags = (*flags & ~EXTSTATE_FD_KIND_MASK) |
+             (((uint32_t)kind << EXTSTATE_FD_KIND_SHIFT) & EXTSTATE_FD_KIND_MASK);
+}
+
+extstate_kind_t extstate_kind_from_fd_flags(uint32_t flags) {
+    return (extstate_kind_t)((flags & EXTSTATE_FD_KIND_MASK) >> EXTSTATE_FD_KIND_SHIFT);
+}
+
+bool extstate_sever_fd(uint32_t* flags) {
+    if (!flags) {
+        return false;
+    }
+    if (*flags & EXTSTATE_FD_SEVERED) {
+        return false; /* already severed: idempotent */
+    }
+    if (extstate_survives_checkpoint(extstate_kind_from_fd_flags(*flags))) {
+        return false; /* persistable (e.g. a regular file): leave intact */
+    }
+    *flags |= EXTSTATE_FD_SEVERED;
+    return true;
+}
+
+bool extstate_fd_is_severed(uint32_t flags) {
+    return (flags & EXTSTATE_FD_SEVERED) != 0;
+}

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -25,6 +25,7 @@
 /* #include "../include/ext2.h" */ /* Commenting out due to conflicting ext2_alloc_inode definitions */
 /* #include "../include/ext2_syscalls.h" */ /* Commenting out due to header conflicts */
 #include "../include/checkpoint.h"
+#include "../include/ramdisk.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -215,16 +216,21 @@ void kernel_init(void) {
     
     kernel_print("IKOS kernel initialized successfully\n");
 
-    /* Orthogonal persistence (#119): wire the checkpoint store to a block
-     * device and arm automatic checkpoints + restore. Pass a real device here
-     * to enable persistence (e.g. ramdisk_get_device() or an IDE store region);
-     * NULL leaves it disabled so boot behavior is unchanged until the demo
-     * hardware is wired. */
+    /* Orthogonal persistence (#129): wire the checkpoint store to a block
+     * device and arm automatic checkpoints + restore. The RAM disk is used as
+     * the simplest backing store; note it is volatile, so it survives a warm
+     * reboot / QEMU snapshot but not a real power cut. Moving the store to a
+     * dedicated IDE sector region (#130) gives true non-volatile durability. */
     static snapshot_store_t persistence_store;
-    checkpoint_persistence_init(&persistence_store, /* dev = */ 0,
-                                CHECKPOINT_STORE_BASE_SECTOR,
-                                CHECKPOINT_STORE_SLOT_SECTORS,
-                                CHECKPOINT_DEFAULT_INTERVAL_TICKS);
+    fat_block_device_t* persistence_dev = ramdisk_get_device();
+    if (checkpoint_persistence_init(&persistence_store, persistence_dev,
+                                    CHECKPOINT_STORE_BASE_SECTOR,
+                                    CHECKPOINT_STORE_SLOT_SECTORS,
+                                    CHECKPOINT_DEFAULT_INTERVAL_TICKS) == CHECKPOINT_OK) {
+        kernel_print("Orthogonal persistence armed (checkpoint store ready)\n");
+    } else {
+        kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
+    }
 
     /* If a valid checkpoint exists, resume the saved address spaces instead of
      * cold-starting (#116). With no device wired above, checkpoint_boot()

--- a/scripts/test/persistence_demo.sh
+++ b/scripts/test/persistence_demo.sh
@@ -28,7 +28,8 @@ echo "==> building end-to-end harness"
 "$CC" -I"$ROOT/include" -O2 -Wall -o "$BIN" \
     "$ROOT/tests/test_persistence_e2e.c" \
     "$ROOT/kernel/checkpoint.c" \
-    "$ROOT/kernel/snapshot_store.c"
+    "$ROOT/kernel/snapshot_store.c" \
+    "$ROOT/kernel/checkpoint_extstate.c"
 
 echo
 echo "==> power cycle 1: boot fresh, count to 5"

--- a/tests/test_checkpoint.c
+++ b/tests/test_checkpoint.c
@@ -15,7 +15,8 @@
  *      and ignores ordinary write faults.
  *
  * Build: gcc -I../include -o test_checkpoint test_checkpoint.c \
- *            ../kernel/checkpoint.c ../kernel/snapshot_store.c
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c
  * (checkpoint.c + snapshot_store.c are linked; this file mocks the VMM/PM
  * symbols they call.)
  */

--- a/tests/test_checkpoint_context.c
+++ b/tests/test_checkpoint_context.c
@@ -6,7 +6,8 @@
  * address-space page that is checkpointed alongside it.
  *
  * Build: gcc -I../include -o test_checkpoint_context test_checkpoint_context.c \
- *            ../kernel/checkpoint.c ../kernel/snapshot_store.c
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_extstate.c
+++ b/tests/test_checkpoint_extstate.c
@@ -84,6 +84,36 @@ int main(void) {
         CHECK(extstate_sever_all(fds, 0) == 0, "zero count is safe");
     }
 
+    /* === 4. File-descriptor flags integration (#128) === */
+    printf("Test 4: fd-flags severing\n");
+    {
+        /* Kind round-trips through the flags word without clobbering low bits. */
+        uint32_t f = 0x00000002; /* e.g. an O_RDWR-ish open flag in the low bits */
+        extstate_fd_set_kind(&f, EXTSTATE_SOCKET);
+        CHECK(extstate_kind_from_fd_flags(f) == EXTSTATE_SOCKET, "kind stored/read back");
+        CHECK((f & 0xFFFF) == 0x0002, "low (open) flag bits preserved");
+
+        /* A socket fd severs and then reports severed. */
+        CHECK(extstate_sever_fd(&f) == true, "socket fd severed on restore");
+        CHECK(extstate_fd_is_severed(f) == true, "socket fd reports severed");
+        CHECK(extstate_sever_fd(&f) == false, "second sever is a no-op");
+
+        /* A regular-file fd is untouched and usable. */
+        uint32_t file = 0;
+        extstate_fd_set_kind(&file, EXTSTATE_REGULAR_FILE);
+        CHECK(extstate_sever_fd(&file) == false, "regular-file fd not severed");
+        CHECK(extstate_fd_is_severed(file) == false, "regular-file fd usable");
+
+        /* Device and DMA fds also sever. */
+        uint32_t dev = 0, dma = 0;
+        extstate_fd_set_kind(&dev, EXTSTATE_DEVICE);
+        extstate_fd_set_kind(&dma, EXTSTATE_DMA_BUFFER);
+        CHECK(extstate_sever_fd(&dev) == true, "device fd severed");
+        CHECK(extstate_sever_fd(&dma) == true, "DMA fd severed");
+
+        CHECK(extstate_sever_fd(0) == false, "NULL flags safe");
+    }
+
     printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
            failures, failures == 1 ? "" : "s");
     return failures ? 1 : 0;

--- a/tests/test_checkpoint_reconstruct.c
+++ b/tests/test_checkpoint_reconstruct.c
@@ -9,7 +9,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_reconstruct \
  *            test_checkpoint_reconstruct.c ../kernel/checkpoint.c \
- *            ../kernel/snapshot_store.c
+ *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_restore.c
+++ b/tests/test_checkpoint_restore.c
@@ -12,7 +12,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_restore \
  *            test_checkpoint_restore.c ../kernel/checkpoint.c \
- *            ../kernel/snapshot_store.c
+ *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_timer.c
+++ b/tests/test_checkpoint_timer.c
@@ -9,7 +9,8 @@
  *   4. Resume: after writeback closes the epoch, the next tick triggers again.
  *
  * Build: gcc -I../include -o test_checkpoint_timer test_checkpoint_timer.c \
- *            ../kernel/checkpoint.c ../kernel/snapshot_store.c
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_writeback.c
+++ b/tests/test_checkpoint_writeback.c
@@ -11,7 +11,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_writeback \
  *            test_checkpoint_writeback.c ../kernel/checkpoint.c \
- *            ../kernel/snapshot_store.c
+ *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c
  */
 
 #include <stdint.h>

--- a/tests/test_persistence_e2e.c
+++ b/tests/test_persistence_e2e.c
@@ -20,7 +20,8 @@
  *   test_persistence_e2e <diskfile> show          restore and print the counter
  *
  * Build: gcc -I../include -o test_persistence_e2e test_persistence_e2e.c \
- *            ../kernel/checkpoint.c ../kernel/snapshot_store.c
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c
  */
 
 #include <stdint.h>

--- a/tests/test_persistence_init.c
+++ b/tests/test_persistence_init.c
@@ -1,0 +1,97 @@
+/* Host-side test for boot-store wiring (#129).
+ *
+ * Exercises checkpoint_persistence_init() against a real ramdisk-backed store:
+ *   1. It binds + formats the store and arms the periodic trigger.
+ *   2. With a fresh (empty) store, checkpoint_boot() reports no checkpoint
+ *      (the kernel cold-boots).
+ *   3. The trigger is armed: ticks take an automatic checkpoint at the interval.
+ *   4. After that checkpoint is written back, checkpoint_boot() restores from
+ *      the registered store (>= 0), proving the store is wired as the boot store.
+ *
+ * Build: gcc -I../include -o test_persistence_init test_persistence_init.c \
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c ../kernel/ramdisk.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int   printf(const char*, ...);
+extern void* malloc(size_t);
+extern void  free(void*);
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+
+void* kmalloc(size_t s) { return malloc(s); }
+void  kfree(void* p) { free(p); }
+
+#include "checkpoint.h"
+#include "ramdisk.h"
+
+/* Engine link stubs. */
+pte_t* vmm_get_page_table(vm_space_t* s, uint64_t a, int l, bool c) {
+    (void)s; (void)a; (void)l; (void)c; return 0;
+}
+vm_space_t* vmm_get_current_space(void) { return 0; }
+void vmm_flush_tlb_page(uint64_t a) { (void)a; }
+uint64_t vmm_get_physical_addr(vm_space_t* s, uint64_t a) { (void)s; (void)a; return 0; }
+vm_space_t* vmm_create_address_space(uint32_t pid) { (void)pid; return 0; }
+uint64_t vmm_alloc_page(void) { return 0; }
+int vmm_map_page(vm_space_t* s, uint64_t v, uint64_t p, uint32_t f) {
+    (void)s; (void)v; (void)p; (void)f; return 0;
+}
+struct process;
+int pm_get_process_list(uint32_t* p, uint32_t m, uint32_t* c) {
+    (void)p; (void)m; if (c) *c = 0; return 0;
+}
+struct process* pm_get_process(uint32_t pid) { (void)pid; return 0; }
+struct process* process_get_by_pid(int pid) { (void)pid; return 0; }
+struct process* process_create(const char* a, const char* b) { (void)a; (void)b; return 0; }
+int pm_table_add_process(struct process* p) { (void)p; return 0; }
+int scheduler_add_process(struct process* p) { (void)p; return 0; }
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+int main(void) {
+    printf("Test: boot-store wiring (checkpoint_persistence_init)\n");
+
+    fat_block_device_t* dev = ramdisk_get_device();
+    CHECK(dev != 0, "ramdisk device available");
+    CHECK(dev->sector_size == SNAPSHOT_SECTOR_SIZE, "ramdisk sector size matches store");
+
+    checkpoint_init();
+
+    snapshot_store_t store;
+    int rc = checkpoint_persistence_init(&store, dev,
+                                         CHECKPOINT_STORE_BASE_SECTOR,
+                                         CHECKPOINT_STORE_SLOT_SECTORS,
+                                         /* interval */ 4);
+    CHECK(rc == CHECKPOINT_OK, "persistence_init arms the store");
+
+    /* NULL device => persistence stays disabled, does not disturb the armed store. */
+    snapshot_store_t junk;
+    CHECK(checkpoint_persistence_init(&junk, 0, 0, 256, 4) == CHECKPOINT_ERR_PARAM,
+          "NULL device rejected");
+
+    /* Fresh store: nothing to restore yet -> cold boot. */
+    CHECK(checkpoint_boot() == CHECKPOINT_ERR_NO_CHECKPOINT, "empty store -> cold boot");
+
+    /* Trigger armed at interval 4: ticks 1-3 do nothing, tick 4 checkpoints. */
+    CHECK(checkpoint_tick() == false, "tick 1");
+    CHECK(checkpoint_tick() == false, "tick 2");
+    CHECK(checkpoint_tick() == false, "tick 3");
+    CHECK(checkpoint_tick() == true,  "tick 4: automatic checkpoint taken");
+
+    /* Commit it, then boot must restore from the registered store. */
+    CHECK(checkpoint_writeback(&store) == CHECKPOINT_OK, "writeback commits to the ramdisk store");
+    CHECK(checkpoint_boot() >= 0, "boot restores from the registered store");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Two v1.5 steps for orthogonal persistence (follow-up to #121). #128 severs non-persistable handles on restore; #129 activates persistence at boot by binding the checkpoint store to a real block device.

> Note: #129 stacks on the still-unmerged #128 on the same development branch, and GitHub allows only one open PR per `branch -> main`, so both ride this PR. They split into separate PRs once the base merges.

## What's included

| Issue | Change |
|-------|--------|
| #128 | Sever external / non-persistable handles (sockets, DMA, devices) during process reconstruction |
| #129 | Wire the ramdisk as the boot checkpoint store; arm checkpoints + restore at boot |

## #128 - external-handle severing
A dependency-free fd-flags layer in `checkpoint_extstate` encodes a resource kind in the high bits of a descriptor's flags and severs open non-persistable ones (`extstate_sever_fd`), reporting a defined severed status (`extstate_fd_is_severed`). The restore registrar walks each reconstructed process's `proc->fds[]` and severs sockets/DMA/devices; regular files survive.

## #129 - boot-store wiring
`kernel_init()` now binds the checkpoint store to a real block device (the RAM disk) via `checkpoint_persistence_init()`, which formats it if empty, registers it as the boot store, and arms the periodic trigger; `checkpoint_boot()` then restores from it or cold-boots. Adds `include/ramdisk.h` and brings `kernel/ramdisk.c` into the build.

Caveat: the RAM disk is volatile, so this survives a warm reboot / QEMU snapshot but not a real power cut. Moving the store to a dedicated IDE sector region (#130) gives true non-volatile durability.

## Testing

Nine host-side unit suites plus the end-to-end demo (system `gcc`, no kernel boot). All pass, 0 failures. New this PR:
- `test_checkpoint_extstate.c` fd-flags section (#128).
- `test_persistence_init.c` (#129): against a real ramdisk-backed store, init arms the store, an empty store cold-boots, the armed trigger takes an automatic checkpoint at the interval, and after writeback `checkpoint_boot()` restores from the registered store.

CI (`.github/workflows/persistence.yml`) runs them all + the e2e demo headless. `kernel/checkpoint*.c`, `kernel/ramdisk.c`, and `kernel/kernel_main.c` compile clean under `-ffreestanding -m64 -Wall -Wextra` (kernel_main: 0 errors).

## Scope / honesty

Sockets currently live in a separate global table (cold-initialized on restore), so #128 severs descriptors carried in `proc->fds[]`; tagging fds with their kind at creation is the small remaining wire-up. The RAM disk store (#129) is volatile; the IDE-backed, truly-durable store and the in-QEMU boot proof are #130.

Builds on #118 and #127.