### PR TITLE
Persistence v1.5: IDE-backed durable store + QEMU boot demo (#130)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -52,6 +52,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_tm     test_checkpoint_timer.c      $K && /tmp/t_tm
           gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c   ../kernel/checkpoint_extstate.c && /tmp/t_ext
           gcc -I../include -Wall -o /tmp/t_init   test_persistence_init.c     $KR && /tmp/t_init
+          gcc -I../include -Wall -o /tmp/t_ide    test_checkpoint_ide.c       ../kernel/checkpoint_ide.c ../kernel/snapshot_store.c && /tmp/t_ide
 
   e2e-demo:
     runs-on: ubuntu-latest
@@ -60,3 +61,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: End-to-end "yank power, it remembers" demo
         run: bash scripts/test/persistence_demo.sh
+      - name: In-QEMU boot demo (skips gracefully if QEMU is unavailable)
+        run: bash scripts/test/qemu_persistence_demo.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ valid checkpoint exists, the kernel reloads it instead of cold-starting.
 
 Full design: [`docs/architecture/orthogonal-persistence.md`](docs/architecture/orthogonal-persistence.md).
 
+### Try it
+
+```bash
+# Headless proof against the real checkpoint engine (no emulator needed):
+./scripts/test/persistence_demo.sh
+
+# The real thing in QEMU (boots IKOS, cuts power, reboots, resumes):
+./scripts/test/qemu_persistence_demo.sh   # needs qemu-system-x86_64 + a built image
+```
+
+The checkpoint store can live on the volatile RAM disk (survives a warm reboot) or, for
+true power-cut durability, on a real IDE disk via `checkpoint_ide_bind`.
+
 ## ✅ What actually works vs. roadmap
 
 Being honest about maturity:
@@ -65,9 +78,12 @@ Being honest about maturity:
 | Restore + boot decision (restore vs cold boot) | ✅ implemented, unit-tested |
 | Periodic checkpoint trigger (scheduler tick) | ✅ implemented, unit-tested |
 | External-state policy (sockets/DMA/devices severed on restore) | ✅ implemented, unit-tested |
+| Context persistence + process-table/scheduler reconstruction on restore | ✅ implemented, unit-tested |
 | End-to-end "yank power" proof over a file-backed disk | ✅ passing in CI |
-| Full in-kernel boot (store wired to a block device, runnable in QEMU) | 🚧 wired and compiling; not yet booted end-to-end |
-| Process register/scheduler-state resume (runnable restored processes) | 🚧 page + address-space restore done; full process resume in progress |
+| Boot store wired to a block device (RAM disk, volatile) | ✅ implemented, unit-tested |
+| IDE-backed durable store (survives a real power cut) | 🚧 adapter implemented + unit-tested; in-kernel wiring + QEMU boot pending |
+| Process register/scheduler-state resume actually executing | 🚧 table/context restore done; scheduler bridge + QEMU boot pending |
+| In-QEMU boot demo + README GIF | 🚧 script ready; needs QEMU + a bootable image |
 | Persisting kernel-internal and driver state | 🔭 v2 (v1 cold-inits the kernel/drivers and restores user spaces on top) |
 
 The broader subsystems below describe the project's overall scope; several are partial

--- a/include/checkpoint_ide.h
+++ b/include/checkpoint_ide.h
@@ -1,0 +1,32 @@
+/* IKOS Orthogonal Persistence - IDE-backed checkpoint store (#130)
+ *
+ * Adapts an IDE drive to the fat_block_device_t interface so the checkpoint
+ * store can live on a real, NON-VOLATILE disk (unlike the volatile RAM disk
+ * used in #129). A checkpoint written here survives an actual power cut.
+ *
+ * The IDE device is held as an opaque pointer so this header stays decoupled
+ * from the IDE driver headers (and is host-testable with a mock backend).
+ */
+
+#ifndef CHECKPOINT_IDE_H
+#define CHECKPOINT_IDE_H
+
+#include <stdint.h>
+#include "fat.h"   /* fat_block_device_t */
+
+/* Binds one IDE drive (controller + master/slave selector) as the backend of a
+ * fat_block_device_t. Stored in the block device's private_data. */
+typedef struct {
+    void*   ide;    /* ide_device_t* (opaque here) */
+    uint8_t drive;  /* 0 = master, 1 = slave */
+} checkpoint_ide_binding_t;
+
+/* Fill *bdev so it reads/writes 512-byte sectors via the given IDE drive,
+ * recording the binding in *binding. total_sectors bounds the device. Returns
+ * bdev, or NULL on bad arguments. */
+fat_block_device_t* checkpoint_ide_bind(fat_block_device_t* bdev,
+                                        checkpoint_ide_binding_t* binding,
+                                        void* ide, uint8_t drive,
+                                        uint64_t total_sectors);
+
+#endif /* CHECKPOINT_IDE_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -46,7 +46,7 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             ext2.c ext2_syscalls.c \
             usb.c usb_hid.c usb_uhci.c usb_control.c usb_syscalls.c usb_test.c usb_integration.c \
             audio.c audio_ac97.c audio_syscalls.c audio_user.c \
-            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c
+            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_ide.c
+++ b/kernel/checkpoint_ide.c
@@ -1,0 +1,46 @@
+/* IKOS Orthogonal Persistence - IDE-backed checkpoint store (#130)
+ *
+ * See include/checkpoint_ide.h. Bridges fat_block_device_t sector I/O to the
+ * IDE driver's ide_read_sectors/ide_write_sectors.
+ */
+
+#include "checkpoint_ide.h"
+#include "ide_driver.h"   /* ide_device_t, ide_read_sectors/ide_write_sectors, IDE_SUCCESS */
+
+static int ide_bdev_read(void* device, uint32_t sector, uint32_t count, void* buffer) {
+    checkpoint_ide_binding_t* b = (checkpoint_ide_binding_t*)device;
+    if (!b || !b->ide || !buffer) {
+        return -1;
+    }
+    int rc = ide_read_sectors((ide_device_t*)b->ide, b->drive,
+                              (uint64_t)sector, (uint16_t)count, buffer);
+    return rc == IDE_SUCCESS ? 0 : -1;
+}
+
+static int ide_bdev_write(void* device, uint32_t sector, uint32_t count, const void* buffer) {
+    checkpoint_ide_binding_t* b = (checkpoint_ide_binding_t*)device;
+    if (!b || !b->ide || !buffer) {
+        return -1;
+    }
+    int rc = ide_write_sectors((ide_device_t*)b->ide, b->drive,
+                               (uint64_t)sector, (uint16_t)count, buffer);
+    return rc == IDE_SUCCESS ? 0 : -1;
+}
+
+fat_block_device_t* checkpoint_ide_bind(fat_block_device_t* bdev,
+                                        checkpoint_ide_binding_t* binding,
+                                        void* ide, uint8_t drive,
+                                        uint64_t total_sectors) {
+    if (!bdev || !binding || !ide) {
+        return 0;
+    }
+    binding->ide = ide;
+    binding->drive = drive;
+
+    bdev->read_sectors = ide_bdev_read;
+    bdev->write_sectors = ide_bdev_write;
+    bdev->sector_size = 512;
+    bdev->total_sectors = (uint32_t)total_sectors;
+    bdev->private_data = binding;
+    return bdev;
+}

--- a/scripts/test/qemu_persistence_demo.sh
+++ b/scripts/test/qemu_persistence_demo.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Orthogonal-persistence QEMU demo (#130): the real "yank power, it remembers".
+#
+# Unlike scripts/test/persistence_demo.sh (which proves the persistence modules
+# headless over a file-backed disk), this boots the actual IKOS kernel in QEMU
+# with a NON-VOLATILE disk image as the checkpoint store, runs the persistent
+# counter, simulates a power cut by hard-resetting QEMU, reboots from the same
+# image, and shows the counter resuming.
+#
+# Requirements (not present in every CI environment):
+#   - qemu-system-x86_64
+#   - a bootable IKOS image with persistence wired to an IDE store region
+#     (checkpoint_ide_bind over the QEMU -drive), built by the top-level Makefile
+#
+# If QEMU is unavailable this script explains how to run it and exits 0 so it
+# does not break CI on machines without an emulator.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+QEMU="${QEMU:-qemu-system-x86_64}"
+DISK="${DISK:-$ROOT/build/persistence.img}"
+KERNEL_IMG="${KERNEL_IMG:-$ROOT/build/ikos.img}"
+RUN_SECS="${RUN_SECS:-6}"
+
+if ! command -v "$QEMU" >/dev/null 2>&1; then
+    cat <<EOF
+[skip] $QEMU not found - cannot run the in-QEMU persistence demo here.
+
+To run it on a machine with QEMU:
+  1. Build a bootable IKOS image with persistence wired to an IDE store
+     region (checkpoint_ide_bind over a QEMU -drive). See #130.
+  2. Create a persistent disk image for the checkpoint store:
+       qemu-img create -f raw "$DISK" 16M
+  3. Boot, let the counter advance, then HARD RESET (the "power cut"):
+       $QEMU -drive file=$KERNEL_IMG,format=raw,if=ide,index=0 \\
+             -drive file=$DISK,format=raw,if=ide,index=1 -serial stdio
+     Kill the VM (Ctrl-C) after the counter passes a few thousand.
+  4. Reboot from the SAME images:
+       $QEMU -drive file=$KERNEL_IMG,format=raw,if=ide,index=0 \\
+             -drive file=$DISK,format=raw,if=ide,index=1 -serial stdio
+     The counter resumes near where it stopped instead of restarting at 0.
+
+To capture the README GIF:
+  asciinema rec -c "$QEMU ... -serial stdio" persistence.cast
+  agg persistence.cast docs/persistence-demo.gif
+EOF
+    exit 0
+fi
+
+if [ ! -f "$KERNEL_IMG" ]; then
+    echo "[skip] kernel image $KERNEL_IMG not built; run 'make' first."
+    exit 0
+fi
+
+# --- Real run (on a machine that has QEMU + a bootable image) ---
+echo "==> creating checkpoint-store disk image"
+command -v qemu-img >/dev/null 2>&1 && qemu-img create -f raw "$DISK" 16M >/dev/null
+
+run_qemu() {
+    timeout "${RUN_SECS}s" "$QEMU" \
+        -drive file="$KERNEL_IMG",format=raw,if=ide,index=0 \
+        -drive file="$DISK",format=raw,if=ide,index=1 \
+        -serial stdio -display none 2>/dev/null || true
+}
+
+echo "==> boot 1: run the counter, then 'cut power'"
+OUT1="$(run_qemu)"
+echo "$OUT1" | tail -3
+
+echo "==> boot 2: reboot from the same disk image"
+OUT2="$(run_qemu)"
+echo "$OUT2" | tail -3
+
+LAST1="$(echo "$OUT1" | sed -n 's/.*count = \([0-9]\+\).*/\1/p' | tail -1)"
+FIRST2="$(echo "$OUT2" | sed -n 's/.*count = \([0-9]\+\).*/\1/p' | head -1)"
+if [ -n "${LAST1:-}" ] && [ -n "${FIRST2:-}" ] && [ "$FIRST2" -ge 1 ]; then
+    echo "PASSED: boot 1 reached $LAST1; boot 2 resumed at $FIRST2 (not 0)"
+    exit 0
+fi
+echo "FAILED: counter did not resume across the simulated power cut"
+exit 1

--- a/tests/test_checkpoint_ide.c
+++ b/tests/test_checkpoint_ide.c
@@ -1,0 +1,105 @@
+/* Host-side test for the IDE-backed checkpoint store adapter (#130).
+ *
+ * checkpoint_ide_bind() adapts an IDE drive to fat_block_device_t. This test
+ * binds a MOCK ide backend (an in-memory disk) and drives a real snapshot store
+ * through it - begin/add_page/commit then load/next - proving the adapter
+ * correctly bridges store sector I/O to ide_read_sectors/ide_write_sectors,
+ * including the sector->LBA and count mapping.
+ *
+ * Build: gcc -I../include -o test_checkpoint_ide test_checkpoint_ide.c \
+ *            ../kernel/checkpoint_ide.c ../kernel/snapshot_store.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int   printf(const char*, ...);
+extern void* malloc(size_t);
+extern void  free(void*);
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   memcmp(const void*, const void*, size_t);
+
+void* kmalloc(size_t s) { return malloc(s); }
+void  kfree(void* p) { free(p); }
+
+#include "checkpoint_ide.h"
+#include "snapshot_store.h"
+
+/* ---- Mock IDE backend: an in-memory disk addressed by LBA. ---- */
+#define IDE_SECTORS 2048
+#define IDE_SUCCESS 0
+static uint8_t g_ide_disk[IDE_SECTORS * 512];
+static uint64_t g_last_lba;      /* records the mapping the adapter produced */
+static uint16_t g_last_count;
+
+/* These symbols match the IDE driver's signatures; checkpoint_ide.c calls them.
+ * The first arg is ide_device_t* in the kernel; here it is an opaque token. */
+int ide_read_sectors(void* dev, uint8_t drive, uint64_t lba, uint16_t count, void* buf) {
+    (void)dev; (void)drive;
+    g_last_lba = lba; g_last_count = count;
+    if (lba + count > IDE_SECTORS) return -1;
+    memcpy(buf, g_ide_disk + lba * 512, (size_t)count * 512);
+    return IDE_SUCCESS;
+}
+int ide_write_sectors(void* dev, uint8_t drive, uint64_t lba, uint16_t count, const void* buf) {
+    (void)dev; (void)drive;
+    g_last_lba = lba; g_last_count = count;
+    if (lba + count > IDE_SECTORS) return -1;
+    memcpy(g_ide_disk + lba * 512, buf, (size_t)count * 512);
+    return IDE_SUCCESS;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+int main(void) {
+    printf("Test: IDE-backed checkpoint store adapter\n");
+
+    memset(g_ide_disk, 0, sizeof(g_ide_disk));
+
+    /* Bind a mock IDE drive as a block device. */
+    int dummy_ide; /* stands in for ide_device_t */
+    fat_block_device_t bdev;
+    checkpoint_ide_binding_t binding;
+    fat_block_device_t* dev = checkpoint_ide_bind(&bdev, &binding, &dummy_ide, 0, IDE_SECTORS);
+    CHECK(dev == &bdev, "bind returns the block device");
+    CHECK(dev->sector_size == 512, "sector size is 512");
+    CHECK(dev->private_data == &binding, "binding stored in private_data");
+    CHECK(checkpoint_ide_bind(&bdev, &binding, 0, 0, IDE_SECTORS) == 0, "NULL ide rejected");
+
+    /* A read goes through to ide_read_sectors with sector mapped to LBA. */
+    uint8_t sec[512];
+    dev->read_sectors(dev->private_data, 17, 1, sec);
+    CHECK(g_last_lba == 17 && g_last_count == 1, "sector maps to LBA/count");
+
+    /* Drive a full checkpoint through the adapter. */
+    snapshot_store_t store;
+    CHECK(snapshot_store_init(&store, dev, 0, 256) == SNAPSHOT_OK, "store init over IDE");
+    CHECK(snapshot_store_format(&store) == SNAPSHOT_OK, "store format");
+
+    snapshot_writer_t w;
+    CHECK(snapshot_store_begin(&store, 42, &w) == SNAPSHOT_OK, "begin checkpoint");
+    uint8_t page[SNAPSHOT_PAGE_SIZE];
+    for (int i = 0; i < SNAPSHOT_PAGE_SIZE; i++) page[i] = (uint8_t)(i * 7 + 3);
+    CHECK(snapshot_writer_add_page(&w, 5, 0x400000, 0, page) == SNAPSHOT_OK, "add page");
+    CHECK(snapshot_store_commit(&w) == SNAPSHOT_OK, "commit");
+
+    /* Read it back through the adapter. */
+    snapshot_reader_t r;
+    CHECK(snapshot_store_load(&store, &r) == SNAPSHOT_OK, "load from IDE-backed store");
+    CHECK(r.epoch == 42 && r.record_count == 1, "epoch + record count");
+    uint8_t out[SNAPSHOT_PAGE_SIZE];
+    snapshot_page_record_t rec; rec.page_data = out;
+    CHECK(snapshot_reader_next(&r, &rec) == SNAPSHOT_OK, "read the page back");
+    CHECK(rec.pid == 5 && rec.virt_addr == 0x400000, "metadata round-trips");
+    CHECK(memcmp(out, page, SNAPSHOT_PAGE_SIZE) == 0, "page contents round-trip through IDE");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Moves orthogonal persistence toward the real "yank power, it remembers" in QEMU. #129 wired the boot store to the **volatile** RAM disk; this adds a **non-volatile IDE-backed store** (survives an actual power cut) and the QEMU boot demo + README docs. Part of the v1.5 follow-up to #121.

## What's included

- **`checkpoint_ide` adapter** (`include/checkpoint_ide.h`, `kernel/checkpoint_ide.c`): a `fat_block_device_t` over an IDE drive, so the checkpoint store can live on real, non-volatile disk. The IDE handle is opaque (`void*`) so the header stays decoupled from the IDE driver and is host-testable.
- **`scripts/test/qemu_persistence_demo.sh`**: boots IKOS in QEMU with a persistent disk image, runs the counter, hard-resets ("power cut"), reboots from the same image, and checks the counter resumed. Skips gracefully (exit 0) when QEMU is unavailable, printing how to run it and capture the README GIF.
- **README**: a "Try it" section (headless + QEMU demos), a durable-vs-volatile store note, and a refreshed status table.

## Testing

`tests/test_checkpoint_ide.c` drives a full checkpoint (begin/add_page/commit then load/next) through the IDE adapter over a mock in-memory IDE backend, proving the sector->LBA mapping and a clean page round-trip. All ten checkpoint/store unit suites plus the headless e2e demo pass, 0 failures; the QEMU script skips cleanly here. `kernel/checkpoint_ide.c` and `kernel/ramdisk.c` compile clean under `-ffreestanding -m64 -Wall -Wextra`; `kernel_main.c` still 0 errors. CI builds + runs the new test, adds the modules to the freestanding check, and runs the QEMU demo step (which self-skips without an emulator).

## Scope / honesty

No QEMU is available in this environment, so the in-QEMU boot and the GIF capture are **scripted and documented but not executed here**. The substantive, verifiable part - the durable IDE block-device adapter - is implemented and unit-tested via a full store round-trip. In-kernel wiring of the IDE store into `kernel_init` (replacing/Preferring it over the ramdisk) and the actual QEMU boot + GIF remain to be done on a machine with QEMU and a bootable image.

Builds on #129.