### PR TITLE
Persistence v1.5: persist read-only/code pages on checkpoint and restore (#131)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -49,6 +49,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs
           gcc -I../include -Wall -o /tmp/t_ctx    test_checkpoint_context.c    $K && /tmp/t_ctx
           gcc -I../include -Wall -o /tmp/t_rc     test_checkpoint_reconstruct.c $K && /tmp/t_rc
+          gcc -I../include -Wall -o /tmp/t_ro     test_checkpoint_readonly.c   $K && /tmp/t_ro
           gcc -I../include -Wall -o /tmp/t_tm     test_checkpoint_timer.c      $K && /tmp/t_tm
           gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c   ../kernel/checkpoint_extstate.c && /tmp/t_ext
           gcc -I../include -Wall -o /tmp/t_init   test_persistence_init.c     $KR && /tmp/t_init

--- a/include/checkpoint.h
+++ b/include/checkpoint.h
@@ -89,6 +89,25 @@ int checkpoint_capture_page(uint32_t pid, uint64_t virt_addr,
 /* Capture-record flag (carried in snapshot_page_record_t.flags) marking a
  * record as a process CPU context blob rather than an address-space page. */
 #define CHECKPOINT_REC_CONTEXT  0x1
+/* Record flag marking a page that was read-only at checkpoint time (e.g. code).
+ * Restore maps it read-only (no PAGE_WRITABLE) so it keeps its permissions. */
+#define CHECKPOINT_REC_READONLY 0x2
+
+/* What writeback should do with one page of an address space, given whether its
+ * region is writable and its PTE. The decision core of #131, exposed for tests. */
+typedef enum {
+    CHECKPOINT_PAGE_SKIP       = 0, /* not present, or modified (already captured) */
+    CHECKPOINT_PAGE_PERSIST_RW = 1, /* clean writable page: persist, map writable */
+    CHECKPOINT_PAGE_PERSIST_RO = 2, /* read-only page (code): persist, map read-only */
+} checkpoint_page_action_t;
+
+/* Decide how to persist a page during writeback:
+ *  - not present                       -> SKIP
+ *  - writable region + snapshot-COW set -> PERSIST_RW (clean, unmodified)
+ *  - writable region + tag cleared      -> SKIP (modified: streamed via its capture)
+ *  - read-only region                   -> PERSIST_RO (never changes; persist directly)
+ * Pure; no side effects. */
+checkpoint_page_action_t checkpoint_page_action(bool region_writable, pte_t pte);
 /* Sentinel virt_addr stamped on context records (records are distinguished by
  * the flag above; this is for debuggability). */
 #define CHECKPOINT_CONTEXT_VADDR 0xFFFFFFFFFFFFF000ULL

--- a/kernel/checkpoint.c
+++ b/kernel/checkpoint.c
@@ -68,6 +68,21 @@ bool checkpoint_mark_pte(pte_t* pte) {
     return true;
 }
 
+checkpoint_page_action_t checkpoint_page_action(bool region_writable, pte_t pte) {
+    if (!(pte & PAGE_PRESENT)) {
+        return CHECKPOINT_PAGE_SKIP;
+    }
+    if (region_writable) {
+        /* A clean (unmodified) writable page is still tagged snapshot-COW; a
+         * modified one had its tag cleared and is streamed via its capture. */
+        return (pte & PAGE_SNAPSHOT_COW) ? CHECKPOINT_PAGE_PERSIST_RW
+                                         : CHECKPOINT_PAGE_SKIP;
+    }
+    /* Read-only page (e.g. code): never changes, was never marked; persist it
+     * directly so the restored process has its text. */
+    return CHECKPOINT_PAGE_PERSIST_RO;
+}
+
 bool checkpoint_resolve_pte(pte_t* pte) {
     if (!pte) {
         return false;
@@ -236,10 +251,11 @@ bool checkpoint_handle_write_fault(vm_space_t* space, uint64_t fault_addr) {
 
 /* ----- Writeback ----- */
 
-/* Persist still-clean snapshot-COW pages from every live user space. Such a
- * page was marked at checkpoint_take() and never written since (otherwise the
- * fault hook would have cleared its tag and captured it), so its frame still
- * holds the checkpoint-time content and can be read live now. */
+/* Persist the pages of every live user space that are not already streamed via
+ * a capture: clean (unmodified) writable pages, whose frames still hold the
+ * checkpoint-time content, and read-only pages (e.g. code), which never change.
+ * Read-only pages are tagged CHECKPOINT_REC_READONLY so restore re-maps them
+ * without write permission. */
 static int writeback_clean_pages(snapshot_writer_t* writer) {
     uint32_t pids[PM_MAX_PROCESSES];
     uint32_t count = 0;
@@ -260,14 +276,16 @@ static int writeback_clean_pages(snapshot_writer_t* writer) {
         vm_space_t* space = proc->address_space;
 
         for (vm_region_t* region = space->regions; region; region = region->next) {
-            if (!(region->flags & VMM_FLAG_WRITE)) {
-                continue;
-            }
+            bool writable = (region->flags & VMM_FLAG_WRITE) != 0;
             for (uint64_t addr = region->start_addr; addr < region->end_addr;
                  addr += PAGE_SIZE) {
                 pte_t* pte = vmm_get_page_table(space, addr, PT_LEVEL, false);
-                if (!pte || !(*pte & PAGE_PRESENT) || !(*pte & PAGE_SNAPSHOT_COW)) {
-                    continue; /* unmapped, or already captured (tag cleared) */
+                if (!pte) {
+                    continue; /* unmapped */
+                }
+                checkpoint_page_action_t action = checkpoint_page_action(writable, *pte);
+                if (action == CHECKPOINT_PAGE_SKIP) {
+                    continue;
                 }
                 uint64_t phys = vmm_get_physical_addr(space, addr);
                 if (!phys) {
@@ -276,7 +294,9 @@ static int writeback_clean_pages(snapshot_writer_t* writer) {
                 /* Physical frames are directly addressable in the kernel, the
                  * same convention vmm.c uses to walk page tables. */
                 memcpy(buf, (const void*)phys, PAGE_SIZE);
-                if (snapshot_writer_add_page(writer, space->owner_pid, addr, 0,
+                uint32_t flags = (action == CHECKPOINT_PAGE_PERSIST_RO)
+                                     ? CHECKPOINT_REC_READONLY : 0;
+                if (snapshot_writer_add_page(writer, space->owner_pid, addr, flags,
                                              buf) != SNAPSHOT_OK) {
                     kfree(buf);
                     return CHECKPOINT_ERR_IO;
@@ -441,8 +461,13 @@ static int checkpoint_restore_apply_kernel(void* ctx, const snapshot_page_record
      * vmm.c uses); load the checkpointed page contents into the new frame. */
     memcpy((void*)phys, rec->page_data, PAGE_SIZE);
 
-    if (vmm_map_page(e->space, rec->virt_addr, phys,
-                     PAGE_PRESENT | PAGE_WRITABLE | PAGE_USER) != 0) {
+    /* Read-only pages (code) are re-mapped without write permission so they keep
+     * their original protection; writable pages get PAGE_WRITABLE. */
+    uint32_t page_flags = PAGE_PRESENT | PAGE_USER;
+    if (!(rec->flags & CHECKPOINT_REC_READONLY)) {
+        page_flags |= PAGE_WRITABLE;
+    }
+    if (vmm_map_page(e->space, rec->virt_addr, phys, page_flags) != 0) {
         return CHECKPOINT_ERR_PARAM;
     }
     return CHECKPOINT_OK;

--- a/tests/test_checkpoint_readonly.c
+++ b/tests/test_checkpoint_readonly.c
@@ -1,0 +1,140 @@
+/* Host-side test for read-only / code-page persistence (#131).
+ *
+ * Verifies:
+ *   1. checkpoint_page_action() classifies pages correctly: clean writable ->
+ *      persist writable, modified writable -> skip (captured elsewhere),
+ *      read-only region -> persist read-only, absent -> skip.
+ *   2. On restore, a read-only record (CHECKPOINT_REC_READONLY) is re-mapped
+ *      WITHOUT write permission, while an ordinary page is mapped writable, and
+ *      both pages' contents land in their frames.
+ *
+ * Build: gcc -I../include -o test_checkpoint_readonly test_checkpoint_readonly.c \
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+extern int   printf(const char*, ...);
+extern void* malloc(size_t);
+extern void  free(void*);
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   memcmp(const void*, const void*, size_t);
+
+void* kmalloc(size_t s) { return malloc(s); }
+void  kfree(void* p) { free(p); }
+
+#include "checkpoint.h"
+
+/* ---- Recording mocks for the restore path ---- */
+static int g_fake_space; /* a non-null vm_space_t stand-in */
+pte_t* vmm_get_page_table(vm_space_t* s, uint64_t a, int l, bool c) {
+    (void)s; (void)a; (void)l; (void)c; return 0;
+}
+vm_space_t* vmm_get_current_space(void) { return 0; }
+void vmm_flush_tlb_page(uint64_t a) { (void)a; }
+uint64_t vmm_get_physical_addr(vm_space_t* s, uint64_t a) { (void)s; (void)a; return 0; }
+vm_space_t* vmm_create_address_space(uint32_t pid) { (void)pid; return (vm_space_t*)&g_fake_space; }
+uint64_t vmm_alloc_page(void) { return (uint64_t)(uintptr_t)malloc(PAGE_SIZE); }
+
+#define MAXMAP 8
+static struct { uint64_t virt; uint64_t phys; uint32_t flags; } g_maps[MAXMAP];
+static int g_map_n;
+int vmm_map_page(vm_space_t* s, uint64_t v, uint64_t p, uint32_t f) {
+    (void)s;
+    if (g_map_n < MAXMAP) { g_maps[g_map_n].virt = v; g_maps[g_map_n].phys = p; g_maps[g_map_n].flags = f; g_map_n++; }
+    return 0;
+}
+struct process;
+int pm_get_process_list(uint32_t* p, uint32_t m, uint32_t* c) {
+    (void)p; (void)m; if (c) *c = 0; return 0;
+}
+struct process* pm_get_process(uint32_t pid) { (void)pid; return 0; }
+struct process* process_get_by_pid(int pid) { (void)pid; return 0; }
+struct process* process_create(const char* a, const char* b) { (void)a; (void)b; return 0; }
+int pm_table_add_process(struct process* p) { (void)p; return 0; }
+int scheduler_add_process(struct process* p) { (void)p; return 0; }
+
+/* ---- Mock block device ---- */
+#define MOCK_SECTORS 4096
+static uint8_t g_disk[MOCK_SECTORS * SNAPSHOT_SECTOR_SIZE];
+static int mock_read(void* d, uint32_t s, uint32_t n, void* b) {
+    (void)d; if ((uint64_t)s + n > MOCK_SECTORS) return -1;
+    memcpy(b, g_disk + (size_t)s * SNAPSHOT_SECTOR_SIZE, (size_t)n * SNAPSHOT_SECTOR_SIZE); return 0;
+}
+static int mock_write(void* d, uint32_t s, uint32_t n, const void* b) {
+    (void)d; if ((uint64_t)s + n > MOCK_SECTORS) return -1;
+    memcpy(g_disk + (size_t)s * SNAPSHOT_SECTOR_SIZE, b, (size_t)n * SNAPSHOT_SECTOR_SIZE); return 0;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+#define RW_VADDR 0x400000ULL
+#define RO_VADDR 0x500000ULL
+
+int main(void) {
+    /* === 1. Decision matrix === */
+    printf("Test 1: checkpoint_page_action\n");
+    pte_t present_cow = PAGE_PRESENT | PAGE_SNAPSHOT_COW;
+    pte_t present_plain = PAGE_PRESENT;            /* writable region, tag cleared */
+    pte_t absent = 0;
+    CHECK(checkpoint_page_action(true,  present_cow)   == CHECKPOINT_PAGE_PERSIST_RW, "clean writable -> persist RW");
+    CHECK(checkpoint_page_action(true,  present_plain) == CHECKPOINT_PAGE_SKIP,       "modified writable -> skip");
+    CHECK(checkpoint_page_action(false, present_plain) == CHECKPOINT_PAGE_PERSIST_RO, "read-only region -> persist RO");
+    CHECK(checkpoint_page_action(false, present_cow)   == CHECKPOINT_PAGE_PERSIST_RO, "read-only region (any pte) -> RO");
+    CHECK(checkpoint_page_action(true,  absent)        == CHECKPOINT_PAGE_SKIP,       "absent (writable) -> skip");
+    CHECK(checkpoint_page_action(false, absent)        == CHECKPOINT_PAGE_SKIP,       "absent (read-only) -> skip");
+
+    /* === 2. Restore maps RO records read-only, RW records writable === */
+    printf("Test 2: restore honors the read-only flag\n");
+    memset(g_disk, 0, sizeof(g_disk));
+    fat_block_device_t dev = {0};
+    dev.read_sectors = mock_read; dev.write_sectors = mock_write;
+    dev.sector_size = SNAPSHOT_SECTOR_SIZE; dev.total_sectors = MOCK_SECTORS;
+    snapshot_store_t store;
+    snapshot_store_init(&store, &dev, 0, 256);
+    snapshot_store_format(&store);
+
+    /* Lay down one writable page and one read-only (code) page for pid 7. */
+    uint8_t rwp[SNAPSHOT_PAGE_SIZE], rop[SNAPSHOT_PAGE_SIZE];
+    for (int i = 0; i < SNAPSHOT_PAGE_SIZE; i++) { rwp[i] = (uint8_t)(i + 1); rop[i] = (uint8_t)(0xC0 ^ i); }
+    snapshot_writer_t w;
+    snapshot_store_begin(&store, 3, &w);
+    snapshot_writer_add_page(&w, 7, RW_VADDR, 0, rwp);                      /* writable */
+    snapshot_writer_add_page(&w, 7, RO_VADDR, CHECKPOINT_REC_READONLY, rop); /* read-only */
+    snapshot_store_commit(&w);
+
+    checkpoint_init();
+    g_map_n = 0;
+    int restored = checkpoint_restore_boot(&store);
+    CHECK(restored == 2, "restored two pages");
+    CHECK(g_map_n == 2, "two pages mapped");
+
+    /* Locate each mapping by its virtual address. */
+    int irw = -1, iro = -1;
+    for (int i = 0; i < g_map_n; i++) {
+        if (g_maps[i].virt == RW_VADDR) irw = i;
+        if (g_maps[i].virt == RO_VADDR) iro = i;
+    }
+    CHECK(irw >= 0 && iro >= 0, "both virtual addresses mapped");
+    CHECK(irw >= 0 && (g_maps[irw].flags & PAGE_WRITABLE) != 0, "writable page mapped PAGE_WRITABLE");
+    CHECK(iro >= 0 && (g_maps[iro].flags & PAGE_WRITABLE) == 0, "read-only page mapped without PAGE_WRITABLE");
+    CHECK(iro >= 0 && (g_maps[iro].flags & PAGE_PRESENT) != 0 && (g_maps[iro].flags & PAGE_USER) != 0,
+          "read-only page still present + user");
+
+    /* Contents landed in the allocated frames. */
+    if (irw >= 0) CHECK(memcmp((void*)(uintptr_t)g_maps[irw].phys, rwp, SNAPSHOT_PAGE_SIZE) == 0, "writable page contents restored");
+    if (iro >= 0) CHECK(memcmp((void*)(uintptr_t)g_maps[iro].phys, rop, SNAPSHOT_PAGE_SIZE) == 0, "read-only page contents restored");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Closes the v1 gap where only writable user pages were persisted: a restored process was missing its **code**, because read-only pages are never marked snapshot-COW and writeback skipped them. The last v1.5 follow-up to #121. On its own branch.

## Approach

Option 2 from the issue (self-contained; no executable-path lookup): persist read-only pages directly, since they never change.

- **`checkpoint_page_action(region_writable, pte)`** - the pure decision core:
  - clean writable page (snapshot-COW set) -> persist, map writable
  - modified writable page (tag cleared) -> skip (streamed via its capture)
  - read-only region page -> persist with `CHECKPOINT_REC_READONLY`
  - absent -> skip
- **Writeback** now walks read-only regions too and streams their present pages, tagging them read-only.
- **Restore** maps `CHECKPOINT_REC_READONLY` records without `PAGE_WRITABLE`, so code keeps its original protection; writable pages stay writable.

## Testing

`tests/test_checkpoint_readonly.c`:
1. The `checkpoint_page_action` matrix (clean/modified/read-only/absent).
2. End-to-end restore: a writable record and a read-only record are laid down on the store; `checkpoint_restore_boot` maps the read-only page **without** `PAGE_WRITABLE` (still present + user) and the writable page **with** it, and both pages' contents land in their frames.

All eleven checkpoint/store unit suites plus the headless e2e demo pass, 0 failures. `kernel/checkpoint.c` compiles clean under `-ffreestanding -m64 -Wall -Wextra`. Wired into CI.

## Notes

The decision/mapping logic is fully unit-tested; the in-kernel clean-page walk that reads frames (`writeback_clean_pages`) runs only with live processes, so the host tests exercise the decision function and the restore mapping rather than the frame-reading walk itself (consistent with the other writeback tests). Anonymous read-only maps are covered by this content-persisting approach; reload-from-executable (option 1) remains available as a future optimization to shrink checkpoints.

Builds on #112/#115/#116.