### PR TITLE
Persistence v2: checkpoint barrier / quiescent-point state machine (#138)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -41,9 +41,10 @@ jobs:
         run: |
           set -e
           cd tests
-          K="../kernel/checkpoint.c ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c"
+          K="../kernel/checkpoint.c ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c"
           KR="$K ../kernel/ramdisk.c"
           gcc -I../include -Wall -o /tmp/t_store  test_snapshot_store.c            && /tmp/t_store
+          gcc -I../include -Wall -o /tmp/t_bar    test_checkpoint_barrier.c   ../kernel/checkpoint_barrier.c && /tmp/t_bar
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_barrier.h
+++ b/include/checkpoint_barrier.h
@@ -1,0 +1,70 @@
+/* IKOS Orthogonal Persistence v2 - Checkpoint barrier (quiescent point)
+ *
+ * A whole-machine checkpoint can only be taken when the kernel is
+ * self-consistent: no CPU holds a lock and no syscall is mid-flight. This is
+ * the quiescent-point state machine from
+ * docs/architecture/orthogonal-persistence-v2.md (#138).
+ *
+ * Lifecycle:  IDLE --arm--> ARMED --(all CPUs park)--> QUIESCENT --release--> IDLE
+ *
+ * The periodic trigger ARMS the barrier (it does not take a checkpoint inline).
+ * Each CPU, on reaching a safe boundary (about to return to user mode, or in
+ * the idle loop) with no lock held, parks. When every CPU is parked the system
+ * is QUIESCENT and the checkpoint may be taken; release() then resumes the CPUs.
+ *
+ * On single-CPU IKOS this collapses to "arm, park the one CPU, take, release"
+ * within a single tick, but the state machine is written for SMP.
+ *
+ * Pure and dependency-free: host-testable with no kernel stubs.
+ */
+
+#ifndef CHECKPOINT_BARRIER_H
+#define CHECKPOINT_BARRIER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHECKPOINT_BARRIER_MAX_CPUS 8
+
+typedef enum {
+    CHECKPOINT_BARRIER_IDLE = 0,  /* no checkpoint pending */
+    CHECKPOINT_BARRIER_ARMED,     /* requested; CPUs converging on the barrier */
+    CHECKPOINT_BARRIER_QUIESCENT, /* all CPUs parked, no lock held; safe to take */
+} checkpoint_barrier_state_t;
+
+typedef struct {
+    checkpoint_barrier_state_t state;
+    uint32_t ncpus;        /* participating CPUs (1 on single-CPU IKOS) */
+    uint32_t parked;       /* how many are currently parked */
+    bool     is_parked[CHECKPOINT_BARRIER_MAX_CPUS];
+} checkpoint_barrier_t;
+
+/* Initialize for `ncpus` CPUs (clamped to [1, MAX_CPUS]); state IDLE. */
+void checkpoint_barrier_init(checkpoint_barrier_t* b, uint32_t ncpus);
+
+/* Request a checkpoint. IDLE -> ARMED, returns true (newly armed). If a
+ * checkpoint is already in progress (ARMED/QUIESCENT) this is a no-op and
+ * returns false. */
+bool checkpoint_barrier_arm(checkpoint_barrier_t* b);
+
+/* A CPU reports it has reached a safe boundary. `can_park` is false if the CPU
+ * still holds a lock / is mid-syscall and cannot park yet. Only meaningful while
+ * ARMED. Returns true if THIS call made the system QUIESCENT (the last CPU
+ * parked) - the caller should then take the checkpoint and release(). Parking
+ * the same CPU twice is idempotent. */
+bool checkpoint_barrier_park(checkpoint_barrier_t* b, uint32_t cpu, bool can_park);
+
+/* A parked CPU has to back out (e.g. it must take a lock): unpark it, dropping
+ * back from QUIESCENT to ARMED if necessary. */
+void checkpoint_barrier_unpark(checkpoint_barrier_t* b, uint32_t cpu);
+
+/* True once every CPU is parked and it is safe to take the checkpoint. */
+bool checkpoint_barrier_is_quiescent(const checkpoint_barrier_t* b);
+
+/* Current state. */
+checkpoint_barrier_state_t checkpoint_barrier_state(const checkpoint_barrier_t* b);
+
+/* Checkpoint taken: resume all CPUs. Returns to IDLE, ready to be armed again. */
+void checkpoint_barrier_release(checkpoint_barrier_t* b);
+
+#endif /* CHECKPOINT_BARRIER_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -46,7 +46,7 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             ext2.c ext2_syscalls.c \
             usb.c usb_hid.c usb_uhci.c usb_control.c usb_syscalls.c usb_test.c usb_integration.c \
             audio.c audio_ac97.c audio_syscalls.c audio_user.c \
-            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c
+            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint.c
+++ b/kernel/checkpoint.c
@@ -6,6 +6,7 @@
 
 #include "checkpoint.h"
 #include "checkpoint_extstate.h"
+#include "checkpoint_barrier.h"
 #include "process_manager.h"
 #include <stddef.h>
 
@@ -27,6 +28,10 @@ static bool     g_timer_enabled = false;
 static uint64_t g_timer_interval = CHECKPOINT_DEFAULT_INTERVAL_TICKS;
 static uint64_t g_timer_ticks = 0;
 
+/* Quiescent-point barrier (#138). The trigger arms it; the checkpoint is taken
+ * when every CPU has parked. Single CPU until SMP lands. */
+static checkpoint_barrier_t g_barrier;
+
 void checkpoint_init(void) {
     g_checkpoint.current_epoch = 0;
     g_checkpoint.spaces_marked = 0;
@@ -34,6 +39,7 @@ void checkpoint_init(void) {
     g_checkpoint.total_takes = 0;
     g_checkpoint.epoch_open = false;
     g_timer_ticks = 0;
+    checkpoint_barrier_init(&g_barrier, 1); /* single-CPU for now */
     checkpoint_clear_captures();
 }
 
@@ -635,5 +641,18 @@ bool checkpoint_tick(void) {
     }
 
     g_timer_ticks = 0;
-    return checkpoint_take() != 0;
+
+    /* Arm the quiescent-point barrier rather than taking the checkpoint inline
+     * (#138). A timer tick fires at a safe boundary (about to resume the
+     * interrupted context) with no checkpoint lock held, so this CPU can park
+     * immediately. On single-CPU IKOS that one park makes the system quiescent
+     * and the checkpoint is taken here; under SMP the other CPUs park on their
+     * own ticks and the last one to park takes it. */
+    checkpoint_barrier_arm(&g_barrier);
+    if (checkpoint_barrier_park(&g_barrier, 0 /* cpu */, true /* no lock held */)) {
+        uint64_t epoch = checkpoint_take();
+        checkpoint_barrier_release(&g_barrier);
+        return epoch != 0;
+    }
+    return false;
 }

--- a/kernel/checkpoint_barrier.c
+++ b/kernel/checkpoint_barrier.c
@@ -1,0 +1,94 @@
+/* IKOS Orthogonal Persistence v2 - Checkpoint barrier (quiescent point)
+ *
+ * See include/checkpoint_barrier.h. Pure state machine, no kernel deps.
+ * Issue #138.
+ */
+
+#include "checkpoint_barrier.h"
+
+void checkpoint_barrier_init(checkpoint_barrier_t* b, uint32_t ncpus) {
+    if (!b) {
+        return;
+    }
+    if (ncpus < 1) {
+        ncpus = 1;
+    }
+    if (ncpus > CHECKPOINT_BARRIER_MAX_CPUS) {
+        ncpus = CHECKPOINT_BARRIER_MAX_CPUS;
+    }
+    b->state = CHECKPOINT_BARRIER_IDLE;
+    b->ncpus = ncpus;
+    b->parked = 0;
+    for (uint32_t i = 0; i < CHECKPOINT_BARRIER_MAX_CPUS; i++) {
+        b->is_parked[i] = false;
+    }
+}
+
+bool checkpoint_barrier_arm(checkpoint_barrier_t* b) {
+    if (!b || b->state != CHECKPOINT_BARRIER_IDLE) {
+        return false; /* already in progress */
+    }
+    b->state = CHECKPOINT_BARRIER_ARMED;
+    b->parked = 0;
+    for (uint32_t i = 0; i < CHECKPOINT_BARRIER_MAX_CPUS; i++) {
+        b->is_parked[i] = false;
+    }
+    return true;
+}
+
+bool checkpoint_barrier_park(checkpoint_barrier_t* b, uint32_t cpu, bool can_park) {
+    if (!b || cpu >= b->ncpus || b->state != CHECKPOINT_BARRIER_ARMED) {
+        return false;
+    }
+    if (!can_park) {
+        return false; /* CPU still holds a lock / is mid-syscall */
+    }
+    if (b->is_parked[cpu]) {
+        return false; /* idempotent: already counted */
+    }
+
+    b->is_parked[cpu] = true;
+    b->parked++;
+
+    if (b->parked >= b->ncpus) {
+        b->state = CHECKPOINT_BARRIER_QUIESCENT;
+        return true; /* this call achieved quiescence */
+    }
+    return false;
+}
+
+void checkpoint_barrier_unpark(checkpoint_barrier_t* b, uint32_t cpu) {
+    if (!b || cpu >= b->ncpus) {
+        return;
+    }
+    if (b->state == CHECKPOINT_BARRIER_IDLE || !b->is_parked[cpu]) {
+        return;
+    }
+    b->is_parked[cpu] = false;
+    if (b->parked > 0) {
+        b->parked--;
+    }
+    /* Lost quiescence: a CPU is running again, so fall back to ARMED. */
+    if (b->state == CHECKPOINT_BARRIER_QUIESCENT) {
+        b->state = CHECKPOINT_BARRIER_ARMED;
+    }
+}
+
+bool checkpoint_barrier_is_quiescent(const checkpoint_barrier_t* b) {
+    return b && b->state == CHECKPOINT_BARRIER_QUIESCENT;
+}
+
+checkpoint_barrier_state_t checkpoint_barrier_state(const checkpoint_barrier_t* b) {
+    return b ? b->state : CHECKPOINT_BARRIER_IDLE;
+}
+
+void checkpoint_barrier_release(checkpoint_barrier_t* b) {
+    if (!b) {
+        return;
+    }
+    b->state = CHECKPOINT_BARRIER_IDLE;
+    b->parked = 0;
+    for (uint32_t i = 0; i < CHECKPOINT_BARRIER_MAX_CPUS; i++) {
+        b->is_parked[i] = false;
+    }
+}

--- a/scripts/test/persistence_demo.sh
+++ b/scripts/test/persistence_demo.sh
@@ -29,7 +29,8 @@ echo "==> building end-to-end harness"
     "$ROOT/tests/test_persistence_e2e.c" \
     "$ROOT/kernel/checkpoint.c" \
     "$ROOT/kernel/snapshot_store.c" \
-    "$ROOT/kernel/checkpoint_extstate.c"
+    "$ROOT/kernel/checkpoint_extstate.c" \
+    "$ROOT/kernel/checkpoint_barrier.c"
 
 echo
 echo "==> power cycle 1: boot fresh, count to 5"

--- a/tests/test_checkpoint.c
+++ b/tests/test_checkpoint.c
@@ -16,7 +16,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint test_checkpoint.c \
  *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
- *            ../kernel/checkpoint_extstate.c
+ *            ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  * (checkpoint.c + snapshot_store.c are linked; this file mocks the VMM/PM
  * symbols they call.)
  */

--- a/tests/test_checkpoint_barrier.c
+++ b/tests/test_checkpoint_barrier.c
@@ -1,0 +1,85 @@
+/* Host-side unit test for the checkpoint barrier state machine (#138).
+ *
+ * Pure state machine, no kernel deps. Verifies the lifecycle
+ * IDLE -> ARMED -> QUIESCENT -> IDLE across single- and multi-CPU
+ * configurations, plus park/unpark edge cases.
+ *
+ * Build: gcc -I../include -o test_checkpoint_barrier test_checkpoint_barrier.c \
+ *            ../kernel/checkpoint_barrier.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "checkpoint_barrier.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+int main(void) {
+    checkpoint_barrier_t b;
+
+    /* === init + clamping === */
+    printf("Test 1: init\n");
+    checkpoint_barrier_init(&b, 0); /* clamps to 1 */
+    CHECK(checkpoint_barrier_state(&b) == CHECKPOINT_BARRIER_IDLE, "starts IDLE");
+    CHECK(b.ncpus == 1, "ncpus 0 clamps to 1");
+    checkpoint_barrier_init(&b, 999); /* clamps to MAX */
+    CHECK(b.ncpus == CHECKPOINT_BARRIER_MAX_CPUS, "ncpus clamps to MAX");
+
+    /* === single-CPU collapse === */
+    printf("Test 2: single CPU\n");
+    checkpoint_barrier_init(&b, 1);
+    CHECK(checkpoint_barrier_arm(&b) == true, "arm IDLE -> true");
+    CHECK(checkpoint_barrier_state(&b) == CHECKPOINT_BARRIER_ARMED, "now ARMED");
+    CHECK(checkpoint_barrier_arm(&b) == false, "re-arm is a no-op");
+    CHECK(checkpoint_barrier_park(&b, 0, true) == true, "the one CPU parks -> quiescent");
+    CHECK(checkpoint_barrier_is_quiescent(&b), "is quiescent");
+    checkpoint_barrier_release(&b);
+    CHECK(checkpoint_barrier_state(&b) == CHECKPOINT_BARRIER_IDLE, "release -> IDLE");
+    CHECK(checkpoint_barrier_arm(&b) == true, "can re-arm after release");
+
+    /* === multi-CPU: quiescent only when the LAST CPU parks === */
+    printf("Test 3: multi CPU\n");
+    checkpoint_barrier_init(&b, 3);
+    checkpoint_barrier_arm(&b);
+    CHECK(checkpoint_barrier_park(&b, 0, true) == false, "cpu0 parks, not yet quiescent");
+    CHECK(checkpoint_barrier_park(&b, 2, true) == false, "cpu2 parks, not yet quiescent");
+    CHECK(!checkpoint_barrier_is_quiescent(&b), "still ARMED with one CPU running");
+    CHECK(checkpoint_barrier_park(&b, 1, true) == true, "last CPU parks -> quiescent");
+    CHECK(checkpoint_barrier_is_quiescent(&b), "quiescent once all parked");
+
+    /* === edge cases === */
+    printf("Test 4: edges\n");
+    checkpoint_barrier_init(&b, 2);
+    checkpoint_barrier_arm(&b);
+    CHECK(checkpoint_barrier_park(&b, 0, false) == false, "can_park=false does not park");
+    CHECK(checkpoint_barrier_park(&b, 0, true) == false, "cpu0 parks (1 of 2)");
+    CHECK(checkpoint_barrier_park(&b, 0, true) == false, "parking cpu0 again is idempotent");
+    CHECK(checkpoint_barrier_park(&b, 5, true) == false, "cpu >= ncpus rejected");
+    CHECK(checkpoint_barrier_park(&b, 1, true) == true, "cpu1 parks -> quiescent");
+
+    /* park when not armed */
+    checkpoint_barrier_init(&b, 1);
+    CHECK(checkpoint_barrier_park(&b, 0, true) == false, "park while IDLE rejected");
+
+    /* === unpark drops quiescence === */
+    printf("Test 5: unpark\n");
+    checkpoint_barrier_init(&b, 2);
+    checkpoint_barrier_arm(&b);
+    checkpoint_barrier_park(&b, 0, true);
+    checkpoint_barrier_park(&b, 1, true);
+    CHECK(checkpoint_barrier_is_quiescent(&b), "both parked -> quiescent");
+    checkpoint_barrier_unpark(&b, 1);
+    CHECK(checkpoint_barrier_state(&b) == CHECKPOINT_BARRIER_ARMED, "unpark drops back to ARMED");
+    CHECK(!checkpoint_barrier_is_quiescent(&b), "no longer quiescent");
+    CHECK(checkpoint_barrier_park(&b, 1, true) == true, "re-park -> quiescent again");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}

--- a/tests/test_checkpoint_context.c
+++ b/tests/test_checkpoint_context.c
@@ -7,7 +7,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_context test_checkpoint_context.c \
  *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
- *            ../kernel/checkpoint_extstate.c
+ *            ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_readonly.c
+++ b/tests/test_checkpoint_readonly.c
@@ -10,7 +10,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_readonly test_checkpoint_readonly.c \
  *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
- *            ../kernel/checkpoint_extstate.c
+ *            ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_reconstruct.c
+++ b/tests/test_checkpoint_reconstruct.c
@@ -9,7 +9,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_reconstruct \
  *            test_checkpoint_reconstruct.c ../kernel/checkpoint.c \
- *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c
+ *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_restore.c
+++ b/tests/test_checkpoint_restore.c
@@ -12,7 +12,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_restore \
  *            test_checkpoint_restore.c ../kernel/checkpoint.c \
- *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c
+ *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_timer.c
+++ b/tests/test_checkpoint_timer.c
@@ -10,7 +10,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_timer test_checkpoint_timer.c \
  *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
- *            ../kernel/checkpoint_extstate.c
+ *            ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_checkpoint_writeback.c
+++ b/tests/test_checkpoint_writeback.c
@@ -11,7 +11,7 @@
  *
  * Build: gcc -I../include -o test_checkpoint_writeback \
  *            test_checkpoint_writeback.c ../kernel/checkpoint.c \
- *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c
+ *            ../kernel/snapshot_store.c ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_persistence_e2e.c
+++ b/tests/test_persistence_e2e.c
@@ -21,7 +21,7 @@
  *
  * Build: gcc -I../include -o test_persistence_e2e test_persistence_e2e.c \
  *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
- *            ../kernel/checkpoint_extstate.c
+ *            ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>

--- a/tests/test_persistence_init.c
+++ b/tests/test_persistence_init.c
@@ -10,7 +10,7 @@
  *
  * Build: gcc -I../include -o test_persistence_init test_persistence_init.c \
  *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
- *            ../kernel/checkpoint_extstate.c ../kernel/ramdisk.c
+ *            ../kernel/checkpoint_extstate.c ../kernel/ramdisk.c ../kernel/checkpoint_barrier.c
  */
 
 #include <stdint.h>


### PR DESCRIPTION
## Summary

The first v2 piece (per [design doc §2.1](https://github.com/Ikey168/IKOS/blob/main/docs/architecture/orthogonal-persistence-v2.md), #132): a defined point where the kernel is self-consistent (no lock held, no syscall in flight) at which a whole-machine checkpoint can safely be taken. On its own branch.

## What's included

- **`checkpoint_barrier`** (`include/checkpoint_barrier.h`, `kernel/checkpoint_barrier.c`): a pure, dependency-free state machine with the lifecycle `IDLE -> ARMED -> QUIESCENT -> IDLE`:
  - `arm()` requests a checkpoint (IDLE to ARMED; a no-op if one is already in progress).
  - `park(cpu, can_park)` is how each CPU reports it reached a safe boundary; `can_park` is false if it still holds a lock. When the last CPU parks the system is QUIESCENT and the caller takes the checkpoint. Idempotent per CPU; rejects out-of-range CPUs and parking while not armed.
  - `unpark(cpu)` backs a CPU out and drops QUIESCENT back to ARMED.
  - `release()` resumes the CPUs and returns to IDLE.
  - Written for SMP (`MAX_CPUS` parked-mask); collapses to a single park on single-CPU IKOS.
- **`checkpoint_tick()`** now ARMS the barrier and parks CPU 0 instead of taking the checkpoint inline. On single-CPU that one park reaches quiescence and the checkpoint is taken there, so the existing periodic-trigger behavior is preserved.

## Testing

`tests/test_checkpoint_barrier.c` covers the state machine: init/clamping, single-CPU collapse, multi-CPU (quiescent only when the last CPU parks), `can_park=false`, idempotent re-park, out-of-range CPU, park-while-idle, and unpark dropping quiescence. The existing timer test passes unchanged (the barrier integration preserves "takes a checkpoint on the Nth tick").

All twelve checkpoint/store unit suites plus the headless e2e demo pass, 0 failures. `kernel/checkpoint_barrier.c` and `kernel/checkpoint.c` compile clean under `-ffreestanding -m64 -Wall -Wextra`. Wired into the build, the e2e script, and CI; build comments updated.

## Scope / next

This lands the barrier and routes the existing single-CPU trigger through it. The full multi-CPU quiesce (parking other CPUs at their own safe boundaries) and taking a whole-machine (kernel + driver) checkpoint at the barrier come with the later v2 issues (#139 onward). The pure state machine here is the host-testable core they build on.

Follows the v2 design doc (#132).