### PR TITLE
Persistence v2: kernel-state records + superblock version stamp (#139)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -45,6 +45,7 @@ jobs:
           KR="$K ../kernel/ramdisk.c"
           gcc -I../include -Wall -o /tmp/t_store  test_snapshot_store.c            && /tmp/t_store
           gcc -I../include -Wall -o /tmp/t_bar    test_checkpoint_barrier.c   ../kernel/checkpoint_barrier.c && /tmp/t_bar
+          gcc -I../include -Wall -o /tmp/t_kern   test_checkpoint_kernel.c    $K && /tmp/t_kern
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint.h
+++ b/include/checkpoint.h
@@ -92,6 +92,10 @@ int checkpoint_capture_page(uint32_t pid, uint64_t virt_addr,
 /* Record flag marking a page that was read-only at checkpoint time (e.g. code).
  * Restore maps it read-only (no PAGE_WRITABLE) so it keeps its permissions. */
 #define CHECKPOINT_REC_READONLY 0x2
+/* Record flag marking a serialized kernel-state blob chunk (v2, #139), not an
+ * address-space page. Restore hands these to the kernel-state reassembler
+ * (process table, VFS, IPC, ...; #140+) rather than mapping them as memory. */
+#define CHECKPOINT_REC_KERNEL   0x4
 
 /* What writeback should do with one page of an address space, given whether its
  * region is writable and its PTE. The decision core of #131, exposed for tests. */
@@ -119,6 +123,14 @@ checkpoint_page_action_t checkpoint_page_action(bool region_writable, pte_t pte)
  * the reconstructed process (the latter in #127). Returns CHECKPOINT_OK or a
  * negative code. */
 int checkpoint_capture_context(uint32_t pid, const void* ctx, uint32_t ctx_size);
+
+/* Persist an arbitrary-size kernel-state blob (v2, #139) as one or more
+ * CHECKPOINT_REC_KERNEL records, chunked into pages and tagged with `tag` (which
+ * kernel structure it is). Each record encodes the total size and chunk index in
+ * its virt_addr field ((size << 32) | index) so the restore side can reassemble
+ * it. The writeback pass streams the records like any other. Returns
+ * CHECKPOINT_OK, or a negative code on bad input / allocation failure. */
+int checkpoint_capture_kernel_blob(uint32_t tag, const void* data, uint32_t size);
 
 /* Page-fault hook entry point. If fault_addr in `space` is a present,
  * snapshot-COW page, capture its current contents, restore writability, flush

--- a/include/snapshot_store.h
+++ b/include/snapshot_store.h
@@ -44,6 +44,7 @@
 #define SNAPSHOT_ERR_NO_CHECKPOINT -5 /* no valid checkpoint on disk */
 #define SNAPSHOT_ERR_CRC         -6   /* CRC mismatch (corrupt slot/superblock) */
 #define SNAPSHOT_ERR_STATE       -7   /* called in the wrong order */
+#define SNAPSHOT_ERR_VERSION     -8   /* checkpoint's kernel-version stamp mismatches */
 
 /* ----- On-disk structures (each lives in its own 512-byte sector) ----- */
 
@@ -53,7 +54,7 @@ typedef struct {
     uint32_t active_slot;      /* 0, 1, or SNAPSHOT_NO_SLOT */
     uint64_t epoch;            /* epoch stored in the active slot */
     uint32_t slot_crc;         /* crc32 of the active slot's record sectors */
-    uint32_t reserved;
+    uint32_t kernel_version;   /* kernel build stamp; restore rejects a mismatch (#139) */
     uint32_t superblock_crc;   /* crc32 over all preceding bytes of this struct */
 } snapshot_superblock_t;
 
@@ -83,6 +84,7 @@ typedef struct {
     uint32_t base_sector;      /* sector of the superblock */
     uint32_t slot_sectors;     /* sectors reserved for each slot */
     uint32_t max_records;      /* derived: (slot_sectors - 1) / 9 */
+    uint32_t kernel_version;   /* expected kernel build stamp (#139); 0 by default */
     bool     initialized;
 } snapshot_store_t;
 
@@ -123,6 +125,13 @@ typedef struct {
  * one page record fits. Does not write anything. */
 int snapshot_store_init(snapshot_store_t* store, fat_block_device_t* dev,
                         uint32_t base_sector, uint32_t slot_sectors);
+
+/* Stamp the store with the running kernel's build version (#139). It is written
+ * into the superblock on format/commit, and snapshot_store_load() rejects a
+ * checkpoint whose stamp differs (SNAPSHOT_ERR_VERSION), so a kernel upgrade
+ * invalidates old checkpoints instead of restoring incompatible kernel state.
+ * Defaults to 0 if never called (matches an unstamped store). */
+void snapshot_store_set_version(snapshot_store_t* store, uint32_t kernel_version);
 
 /* Write a fresh, empty superblock marking "no valid checkpoint". Use once
  * when provisioning a brand-new store. */

--- a/kernel/checkpoint.c
+++ b/kernel/checkpoint.c
@@ -232,6 +232,42 @@ int checkpoint_capture_context(uint32_t pid, const void* ctx, uint32_t ctx_size)
     return CHECKPOINT_OK;
 }
 
+int checkpoint_capture_kernel_blob(uint32_t tag, const void* data, uint32_t size) {
+    if (!data || size == 0) {
+        return CHECKPOINT_ERR_PARAM;
+    }
+    const uint8_t* p = (const uint8_t*)data;
+    uint32_t chunks = (size + PAGE_SIZE - 1) / PAGE_SIZE;
+
+    for (uint32_t i = 0; i < chunks; i++) {
+        checkpoint_capture_t* rec =
+            (checkpoint_capture_t*)kmalloc(sizeof(checkpoint_capture_t));
+        if (!rec) {
+            return CHECKPOINT_ERR_PARAM;
+        }
+        rec->data = kmalloc(PAGE_SIZE);
+        if (!rec->data) {
+            kfree(rec);
+            return CHECKPOINT_ERR_PARAM;
+        }
+
+        uint32_t off = i * PAGE_SIZE;
+        uint32_t n = (size - off) < PAGE_SIZE ? (size - off) : PAGE_SIZE;
+        memset(rec->data, 0, PAGE_SIZE);
+        memcpy(rec->data, p + off, n);
+
+        rec->epoch = g_checkpoint.current_epoch;
+        rec->pid = tag;
+        rec->flags = CHECKPOINT_REC_KERNEL;
+        /* Self-describing: total size in the high 32 bits, chunk index in the low. */
+        rec->virt_addr = ((uint64_t)size << 32) | (uint64_t)i;
+        rec->next = g_captures;
+        g_captures = rec;
+        g_capture_count++;
+    }
+    return CHECKPOINT_OK;
+}
+
 bool checkpoint_handle_write_fault(vm_space_t* space, uint64_t fault_addr) {
     if (!space) {
         return false;
@@ -447,6 +483,12 @@ static int checkpoint_restore_apply_kernel(void* ctx, const snapshot_page_record
         memcpy(e->context, rec->page_data, CHECKPOINT_CONTEXT_MAX);
         e->context_size = CHECKPOINT_CONTEXT_MAX;
         e->has_context = true;
+        return CHECKPOINT_OK;
+    }
+
+    /* Kernel-state blob chunks are reassembled by the kernel-state restorers
+     * (#140+); the page-restore path skips them. */
+    if (rec->flags & CHECKPOINT_REC_KERNEL) {
         return CHECKPOINT_OK;
     }
 

--- a/kernel/snapshot_store.c
+++ b/kernel/snapshot_store.c
@@ -105,6 +105,12 @@ int snapshot_store_init(snapshot_store_t* store, fat_block_device_t* dev,
     return SNAPSHOT_OK;
 }
 
+void snapshot_store_set_version(snapshot_store_t* store, uint32_t kernel_version) {
+    if (store) {
+        store->kernel_version = kernel_version;
+    }
+}
+
 int snapshot_store_format(snapshot_store_t* store) {
     if (!store || !store->initialized) return SNAPSHOT_ERR_STATE;
 
@@ -115,6 +121,7 @@ int snapshot_store_format(snapshot_store_t* store) {
     sb.active_slot = SNAPSHOT_NO_SLOT;
     sb.epoch = 0;
     sb.slot_crc = 0;
+    sb.kernel_version = store->kernel_version;
     sb.superblock_crc = superblock_crc(&sb);
     return write_superblock(store, &sb);
 }
@@ -202,6 +209,7 @@ int snapshot_store_commit(snapshot_writer_t* writer) {
     sb.active_slot = writer->slot;
     sb.epoch = writer->epoch;
     sb.slot_crc = writer->crc;
+    sb.kernel_version = store->kernel_version;
     sb.superblock_crc = superblock_crc(&sb);
     rc = write_superblock(store, &sb);
     if (rc != SNAPSHOT_OK) return rc;
@@ -242,6 +250,9 @@ int snapshot_store_load(snapshot_store_t* store, snapshot_reader_t* reader) {
     int rc = read_superblock(store, &sb);
     if (rc != SNAPSHOT_OK) return rc;
     if (!superblock_valid(&sb)) return SNAPSHOT_ERR_NO_CHECKPOINT;
+    /* Reject a checkpoint written by a different kernel build (#139): its
+     * persisted kernel state would not match this kernel's layout. */
+    if (sb.kernel_version != store->kernel_version) return SNAPSHOT_ERR_VERSION;
     if (sb.active_slot > 1) return SNAPSHOT_ERR_NO_CHECKPOINT;
 
     uint32_t slot_base = slot_base_sector(store, sb.active_slot);

--- a/tests/test_checkpoint_kernel.c
+++ b/tests/test_checkpoint_kernel.c
@@ -1,0 +1,150 @@
+/* Host-side test for kernel-state records + superblock version stamp (#139).
+ *
+ * 1. A checkpoint whose superblock kernel-version stamp differs from the store's
+ *    expected version is rejected with SNAPSHOT_ERR_VERSION (cold boot).
+ * 2. An arbitrary-size kernel-state blob round-trips: checkpoint_capture_kernel_blob
+ *    chunks it into CHECKPOINT_REC_KERNEL records, writeback commits them, and a
+ *    fresh load reassembles the exact bytes (size + chunk index decoded from each
+ *    record's virt_addr).
+ *
+ * Build: gcc -I../include -o test_checkpoint_kernel test_checkpoint_kernel.c \
+ *            ../kernel/checkpoint.c ../kernel/snapshot_store.c \
+ *            ../kernel/checkpoint_extstate.c ../kernel/checkpoint_barrier.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int   printf(const char*, ...);
+extern void* malloc(size_t);
+extern void  free(void*);
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   memcmp(const void*, const void*, size_t);
+
+void* kmalloc(size_t s) { return malloc(s); }
+void  kfree(void* p) { free(p); }
+
+#include "checkpoint.h"
+
+/* Engine link stubs (empty process list). */
+pte_t* vmm_get_page_table(vm_space_t* s, uint64_t a, int l, bool c) { (void)s;(void)a;(void)l;(void)c; return 0; }
+vm_space_t* vmm_get_current_space(void) { return 0; }
+void vmm_flush_tlb_page(uint64_t a) { (void)a; }
+uint64_t vmm_get_physical_addr(vm_space_t* s, uint64_t a) { (void)s;(void)a; return 0; }
+vm_space_t* vmm_create_address_space(uint32_t pid) { (void)pid; return 0; }
+uint64_t vmm_alloc_page(void) { return 0; }
+int vmm_map_page(vm_space_t* s, uint64_t v, uint64_t p, uint32_t f) { (void)s;(void)v;(void)p;(void)f; return 0; }
+struct process;
+int pm_get_process_list(uint32_t* p, uint32_t m, uint32_t* c) { (void)p;(void)m; if (c) *c = 0; return 0; }
+struct process* pm_get_process(uint32_t pid) { (void)pid; return 0; }
+struct process* process_get_by_pid(int pid) { (void)pid; return 0; }
+struct process* process_create(const char* a, const char* b) { (void)a;(void)b; return 0; }
+int pm_table_add_process(struct process* p) { (void)p; return 0; }
+int scheduler_add_process(struct process* p) { (void)p; return 0; }
+
+/* Mock block device. */
+#define MOCK_SECTORS 4096
+static uint8_t g_disk[MOCK_SECTORS * SNAPSHOT_SECTOR_SIZE];
+static int mock_read(void* d, uint32_t s, uint32_t n, void* b) {
+    (void)d; if ((uint64_t)s + n > MOCK_SECTORS) return -1;
+    memcpy(b, g_disk + (size_t)s * SNAPSHOT_SECTOR_SIZE, (size_t)n * SNAPSHOT_SECTOR_SIZE); return 0;
+}
+static int mock_write(void* d, uint32_t s, uint32_t n, const void* b) {
+    (void)d; if ((uint64_t)s + n > MOCK_SECTORS) return -1;
+    memcpy(g_disk + (size_t)s * SNAPSHOT_SECTOR_SIZE, b, (size_t)n * SNAPSHOT_SECTOR_SIZE); return 0;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+static void mkdev(fat_block_device_t* dev) {
+    memset(g_disk, 0, sizeof(g_disk));
+    memset(dev, 0, sizeof(*dev));
+    dev->read_sectors = mock_read; dev->write_sectors = mock_write;
+    dev->sector_size = SNAPSHOT_SECTOR_SIZE; dev->total_sectors = MOCK_SECTORS;
+}
+
+int main(void) {
+    /* === 1. Version stamp rejects a mismatched kernel build === */
+    printf("Test 1: kernel-version stamp\n");
+    {
+        fat_block_device_t dev; mkdev(&dev);
+        snapshot_store_t store;
+        snapshot_store_init(&store, &dev, 0, 256);
+        snapshot_store_set_version(&store, 100);
+        snapshot_store_format(&store);
+
+        /* Write a real checkpoint (stamped version 100). */
+        snapshot_writer_t w;
+        snapshot_store_begin(&store, 1, &w);
+        uint8_t page[SNAPSHOT_PAGE_SIZE]; memset(page, 0xAB, sizeof(page));
+        snapshot_writer_add_page(&w, 1, 0x1000, 0, page);
+        snapshot_store_commit(&w);
+
+        snapshot_reader_t r;
+        CHECK(snapshot_store_load(&store, &r) == SNAPSHOT_OK, "matching version loads");
+
+        snapshot_store_set_version(&store, 200); /* pretend a kernel upgrade */
+        CHECK(snapshot_store_load(&store, &r) == SNAPSHOT_ERR_VERSION, "mismatched version rejected");
+
+        snapshot_store_set_version(&store, 100);
+        CHECK(snapshot_store_load(&store, &r) == SNAPSHOT_OK, "matching version loads again");
+    }
+
+    /* === 2. Kernel-state blob round-trips through the store === */
+    printf("Test 2: kernel-state blob\n");
+    {
+        fat_block_device_t dev; mkdev(&dev);
+        snapshot_store_t store;
+        snapshot_store_init(&store, &dev, 0, 256); /* default version 0 */
+        snapshot_store_format(&store);
+
+        checkpoint_init();
+
+        /* A 9000-byte blob spans 3 pages (4096 + 4096 + 808). */
+        const uint32_t SZ = 9000;
+        static uint8_t blob[9000];
+        for (uint32_t i = 0; i < SZ; i++) blob[i] = (uint8_t)(i * 37 + 11);
+
+        checkpoint_take(); /* advance epoch (pm empty) */
+        CHECK(checkpoint_capture_kernel_blob(0xBEEF, blob, SZ) == CHECKPOINT_OK, "capture blob");
+        CHECK(checkpoint_capture_count() == 3, "blob chunked into 3 records");
+        CHECK(checkpoint_capture_kernel_blob(0xBEEF, 0, SZ) == CHECKPOINT_ERR_PARAM, "NULL data rejected");
+
+        CHECK(checkpoint_writeback(&store) == CHECKPOINT_OK, "writeback commits");
+
+        /* Reload and reassemble from the kernel records. */
+        snapshot_reader_t r;
+        CHECK(snapshot_store_load(&store, &r) == SNAPSHOT_OK, "load");
+
+        static uint8_t reasm[16384];
+        memset(reasm, 0, sizeof(reasm));
+        uint8_t page[SNAPSHOT_PAGE_SIZE];
+        snapshot_page_record_t rec; rec.page_data = page;
+        uint32_t total = 0, chunks = 0, tag_ok = 1;
+        while (snapshot_reader_next(&r, &rec) == SNAPSHOT_OK) {
+            if (!(rec.flags & CHECKPOINT_REC_KERNEL)) continue;
+            if (rec.pid != 0xBEEF) tag_ok = 0;
+            uint32_t sz = (uint32_t)(rec.virt_addr >> 32);
+            uint32_t idx = (uint32_t)(rec.virt_addr & 0xFFFFFFFFu);
+            total = sz;
+            uint32_t off = idx * SNAPSHOT_PAGE_SIZE;
+            uint32_t n = (sz - off) < SNAPSHOT_PAGE_SIZE ? (sz - off) : SNAPSHOT_PAGE_SIZE;
+            memcpy(reasm + off, page, n);
+            chunks++;
+        }
+        CHECK(chunks == 3, "reassembled 3 chunks");
+        CHECK(tag_ok, "every chunk carries the tag");
+        CHECK(total == SZ, "decoded total size matches");
+        CHECK(memcmp(reasm, blob, SZ) == 0, "blob bytes round-trip exactly");
+    }
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Foundational v2 store support (per [design doc §7](https://github.com/Ikey168/IKOS/blob/main/docs/architecture/orthogonal-persistence-v2.md), #132) for persisting kernel-internal state: a kernel-state record kind, and a kernel build/version stamp so a checkpoint from a different kernel is rejected. On its own branch.

## What's included

### Snapshot store: kernel-version stamp
- The superblock carries a `kernel_version` stamp (replaces a `reserved` field, so the on-disk layout is unchanged and it stays inside the superblock CRC).
- `snapshot_store_set_version(store, v)` records the expected version; `format`/`commit` write it; `load` rejects a checkpoint whose stamp differs, returning the new `SNAPSHOT_ERR_VERSION`. A kernel upgrade therefore invalidates incompatible checkpoints (cold boot) instead of restoring mismatched kernel state. Default version 0 is backward compatible, so existing stores/tests are unaffected.

### Checkpoint engine: kernel-state record kind
- `CHECKPOINT_REC_KERNEL` flag and `checkpoint_capture_kernel_blob(tag, data, size)`: serialize an arbitrary-size kernel-state blob as one or more kernel-state records, chunked into pages. Each record is self-describing (total size in the high 32 bits of `virt_addr`, chunk index in the low 32), so the restore side reassembles it by tag. The writeback pass streams them like any other record; the page-restore path skips them (the kernel-state restorers in #140 onward reassemble them).

## Testing

`tests/test_checkpoint_kernel.c`:
1. Version stamp: a matching store version loads; after bumping the store version (simulating a kernel upgrade) the same checkpoint is rejected with `SNAPSHOT_ERR_VERSION`; restoring the version loads again.
2. Kernel blob: a 9000-byte blob chunks into 3 records, commits via writeback, and reassembles to the exact bytes on reload, with the decoded size, chunk count, and tag all correct.

All thirteen checkpoint/store unit suites plus the headless e2e demo pass, 0 failures (the version stamp defaults to 0, so no regression). `kernel/snapshot_store.c` and `kernel/checkpoint.c` compile clean under `-ffreestanding -m64 -Wall -Wextra`. Wired into CI.

## Scope / next

This lands the record kind and the version guard. Consuming them to serialize specific kernel structures is the next wave: process table + scheduler (#140), VFS (#141), IPC (#142), which call `checkpoint_capture_kernel_blob` and add the matching reassemblers.

Follows the v2 design doc (#132) and the barrier (#138).