### PR TITLE
Persistence v2: persist + restore the process table and scheduler links (#140)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -46,6 +46,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_store  test_snapshot_store.c            && /tmp/t_store
           gcc -I../include -Wall -o /tmp/t_bar    test_checkpoint_barrier.c   ../kernel/checkpoint_barrier.c && /tmp/t_bar
           gcc -I../include -Wall -o /tmp/t_kern   test_checkpoint_kernel.c    $K && /tmp/t_kern
+          gcc -I../include -Wall -o /tmp/t_proc   test_checkpoint_proctable.c ../kernel/checkpoint_proctable.c && /tmp/t_proc
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_proctable.h
+++ b/include/checkpoint_proctable.h
@@ -1,0 +1,84 @@
+/* IKOS Orthogonal Persistence v2 - Process-table serialization (#140)
+ *
+ * Serializes the process table and per-process scheduler state into a portable
+ * blob (and back), so a whole-machine checkpoint can resume the exact set of
+ * processes and their relationships. Pointers are never persisted: parent /
+ * child / sibling links and scheduler membership are stored by pid and rebuilt
+ * on restore.
+ *
+ * This header has two layers:
+ *   - a pure, dependency-free serialize/deserialize/validate core (host-tested);
+ *   - kernel capture/restore adapters that snapshot the live process manager
+ *     into the portable form and apply it back (declared here, defined in the
+ *     kernel-only sync module).
+ *
+ * See docs/architecture/orthogonal-persistence-v2.md §3.
+ */
+
+#ifndef CHECKPOINT_PROCTABLE_H
+#define CHECKPOINT_PROCTABLE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHECKPOINT_PROCTABLE_MAGIC   0x494B50524F435431ULL /* "IKPROCT1" */
+#define CHECKPOINT_PROCTABLE_VERSION 1
+#define CHECKPOINT_PROCTABLE_MAX     256 /* PM_MAX_PROCESSES */
+
+/* Portable, pointer-free record for one process. Relationships and scheduler
+ * membership are by pid (0 = none). */
+typedef struct {
+    uint32_t pid;
+    uint32_t ppid;
+    uint32_t state;            /* process_state_t */
+    uint32_t priority;         /* process_priority_t */
+    uint64_t alarm_time;
+    uint32_t first_child_pid;  /* 0 = none */
+    uint32_t next_sibling_pid; /* 0 = none */
+    uint8_t  on_ready_queue;   /* 1 if in the scheduler ready queue */
+    uint8_t  reserved[3];
+    uint32_t ready_order;      /* position in the ready queue */
+} checkpoint_proc_record_t;
+
+typedef struct {
+    checkpoint_proc_record_t procs[CHECKPOINT_PROCTABLE_MAX];
+    uint32_t count;
+} checkpoint_proctable_t;
+
+/* ----- Pure serialization core ----- */
+
+/* Serialize `t` into `buf`. Returns the number of bytes written, or 0 if the
+ * buffer is too small / inputs are invalid. */
+uint32_t checkpoint_proctable_serialize(const checkpoint_proctable_t* t,
+                                        void* buf, uint32_t bufsize);
+
+/* Deserialize `buf` into `t`. Returns true on a valid magic/version and a
+ * self-consistent length; false otherwise. */
+bool checkpoint_proctable_deserialize(checkpoint_proctable_t* t,
+                                      const void* buf, uint32_t size);
+
+/* Referential-integrity check: every nonzero ppid / first_child_pid /
+ * next_sibling_pid refers to a pid present in the table, and pids are unique
+ * and nonzero. Returns true if consistent. */
+bool checkpoint_proctable_validate(const checkpoint_proctable_t* t);
+
+/* Find a record by pid, or NULL. */
+const checkpoint_proc_record_t* checkpoint_proctable_find(const checkpoint_proctable_t* t,
+                                                          uint32_t pid);
+
+/* Serialized size of a table with `count` records. */
+uint32_t checkpoint_proctable_blob_size(uint32_t count);
+
+/* ----- Kernel capture/restore adapters (defined in the kernel sync module) -----
+ * Kernel-state blob tag for the process table. */
+#define CHECKPOINT_TAG_PROCTABLE 1
+
+/* Snapshot the live process table into a kernel-state blob (#139) at checkpoint
+ * time. Returns 0 on success, negative on error. */
+int checkpoint_capture_proctable(void);
+
+/* Rebuild the live process table + scheduler links from a serialized blob on
+ * restore. Returns 0 on success, negative on error. */
+int checkpoint_restore_proctable(const void* blob, uint32_t size);
+
+#endif /* CHECKPOINT_PROCTABLE_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -46,7 +46,8 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             ext2.c ext2_syscalls.c \
             usb.c usb_hid.c usb_uhci.c usb_control.c usb_syscalls.c usb_test.c usb_integration.c \
             audio.c audio_ac97.c audio_syscalls.c audio_user.c \
-            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c
+            ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c \
+            checkpoint_proctable.c checkpoint_proctable_sync.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_proctable.c
+++ b/kernel/checkpoint_proctable.c
@@ -1,0 +1,109 @@
+/* IKOS Orthogonal Persistence v2 - Process-table serialization core (#140)
+ *
+ * Pure serialize/deserialize/validate. No kernel deps. See
+ * include/checkpoint_proctable.h.
+ */
+
+#include "checkpoint_proctable.h"
+
+extern void* memcpy(void* dest, const void* src, unsigned long n);
+
+/* On-disk blob header: magic + version + record count, followed by `count`
+ * checkpoint_proc_record_t. Both serialize and deserialize use the same struct
+ * layout (IKOS is x86_64-only; the superblock kernel-version stamp guards format
+ * changes). */
+typedef struct {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t count;
+} proctable_blob_header_t;
+
+uint32_t checkpoint_proctable_blob_size(uint32_t count) {
+    return (uint32_t)sizeof(proctable_blob_header_t) +
+           count * (uint32_t)sizeof(checkpoint_proc_record_t);
+}
+
+uint32_t checkpoint_proctable_serialize(const checkpoint_proctable_t* t,
+                                        void* buf, uint32_t bufsize) {
+    if (!t || !buf || t->count > CHECKPOINT_PROCTABLE_MAX) {
+        return 0;
+    }
+    uint32_t need = checkpoint_proctable_blob_size(t->count);
+    if (bufsize < need) {
+        return 0;
+    }
+
+    proctable_blob_header_t h;
+    h.magic = CHECKPOINT_PROCTABLE_MAGIC;
+    h.version = CHECKPOINT_PROCTABLE_VERSION;
+    h.count = t->count;
+
+    uint8_t* p = (uint8_t*)buf;
+    memcpy(p, &h, sizeof(h));
+    memcpy(p + sizeof(h), t->procs, t->count * sizeof(checkpoint_proc_record_t));
+    return need;
+}
+
+bool checkpoint_proctable_deserialize(checkpoint_proctable_t* t,
+                                      const void* buf, uint32_t size) {
+    if (!t || !buf || size < sizeof(proctable_blob_header_t)) {
+        return false;
+    }
+    proctable_blob_header_t h;
+    memcpy(&h, buf, sizeof(h));
+    if (h.magic != CHECKPOINT_PROCTABLE_MAGIC ||
+        h.version != CHECKPOINT_PROCTABLE_VERSION ||
+        h.count > CHECKPOINT_PROCTABLE_MAX) {
+        return false;
+    }
+    if (size < checkpoint_proctable_blob_size(h.count)) {
+        return false;
+    }
+
+    const uint8_t* p = (const uint8_t*)buf;
+    memcpy(t->procs, p + sizeof(h), h.count * sizeof(checkpoint_proc_record_t));
+    t->count = h.count;
+    return true;
+}
+
+const checkpoint_proc_record_t* checkpoint_proctable_find(const checkpoint_proctable_t* t,
+                                                          uint32_t pid) {
+    if (!t) {
+        return 0;
+    }
+    for (uint32_t i = 0; i < t->count; i++) {
+        if (t->procs[i].pid == pid) {
+            return &t->procs[i];
+        }
+    }
+    return 0;
+}
+
+bool checkpoint_proctable_validate(const checkpoint_proctable_t* t) {
+    if (!t || t->count > CHECKPOINT_PROCTABLE_MAX) {
+        return false;
+    }
+    for (uint32_t i = 0; i < t->count; i++) {
+        const checkpoint_proc_record_t* r = &t->procs[i];
+        if (r->pid == 0) {
+            return false; /* pids are nonzero */
+        }
+        /* unique pids */
+        for (uint32_t j = i + 1; j < t->count; j++) {
+            if (t->procs[j].pid == r->pid) {
+                return false;
+            }
+        }
+        /* every nonzero relationship resolves to a present pid */
+        if (r->ppid && !checkpoint_proctable_find(t, r->ppid)) {
+            return false;
+        }
+        if (r->first_child_pid && !checkpoint_proctable_find(t, r->first_child_pid)) {
+            return false;
+        }
+        if (r->next_sibling_pid && !checkpoint_proctable_find(t, r->next_sibling_pid)) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/kernel/checkpoint_proctable_sync.c
+++ b/kernel/checkpoint_proctable_sync.c
@@ -1,0 +1,115 @@
+/* IKOS Orthogonal Persistence v2 - Process-table capture/restore adapter (#140)
+ *
+ * Bridges the live process manager to the portable serialization core
+ * (checkpoint_proctable.c) and the kernel-state blob mechanism (#139). Kernel
+ * only: references process_manager/process/scheduler. Compiled freestanding;
+ * the host tests cover the pure core, this adapter is validated by the build.
+ */
+
+#include "checkpoint_proctable.h"
+#include "checkpoint.h"
+#include "process_manager.h"
+#include <stddef.h>
+
+extern void* kmalloc(size_t size);
+extern void  kfree(void* ptr);
+extern int   scheduler_add_process(process_t* proc);
+
+int checkpoint_capture_proctable(void) {
+    checkpoint_proctable_t* t = (checkpoint_proctable_t*)kmalloc(sizeof(*t));
+    if (!t) {
+        return -1;
+    }
+    t->count = 0;
+
+    uint32_t pids[PM_MAX_PROCESSES];
+    uint32_t n = 0;
+    if (pm_get_process_list(pids, PM_MAX_PROCESSES, &n) != 0) {
+        kfree(t);
+        return -1;
+    }
+
+    for (uint32_t i = 0; i < n && t->count < CHECKPOINT_PROCTABLE_MAX; i++) {
+        process_t* p = pm_get_process(pids[i]);
+        if (!p) {
+            continue;
+        }
+        checkpoint_proc_record_t* r = &t->procs[t->count++];
+        r->pid = (uint32_t)p->pid;
+        r->ppid = (uint32_t)p->ppid;
+        r->state = (uint32_t)p->state;
+        r->priority = (uint32_t)p->priority;
+        r->alarm_time = p->alarm_time;
+        r->first_child_pid = p->first_child ? (uint32_t)p->first_child->pid : 0;
+        r->next_sibling_pid = p->next_sibling ? (uint32_t)p->next_sibling->pid : 0;
+        r->on_ready_queue = (p->state == PROCESS_STATE_READY) ? 1 : 0;
+        r->reserved[0] = r->reserved[1] = r->reserved[2] = 0;
+        r->ready_order = 0;
+    }
+
+    uint32_t bufsize = checkpoint_proctable_blob_size(t->count);
+    uint8_t* buf = (uint8_t*)kmalloc(bufsize);
+    if (!buf) {
+        kfree(t);
+        return -1;
+    }
+
+    int rc = -1;
+    uint32_t written = checkpoint_proctable_serialize(t, buf, bufsize);
+    if (written) {
+        rc = checkpoint_capture_kernel_blob(CHECKPOINT_TAG_PROCTABLE, buf, written);
+    }
+    kfree(buf);
+    kfree(t);
+    return rc;
+}
+
+int checkpoint_restore_proctable(const void* blob, uint32_t size) {
+    checkpoint_proctable_t* t = (checkpoint_proctable_t*)kmalloc(sizeof(*t));
+    if (!t) {
+        return -1;
+    }
+    if (!checkpoint_proctable_deserialize(t, blob, size) ||
+        !checkpoint_proctable_validate(t)) {
+        kfree(t);
+        return -1;
+    }
+
+    /* Pass 1: ensure a process_t exists per pid with its scalar fields. */
+    for (uint32_t i = 0; i < t->count; i++) {
+        checkpoint_proc_record_t* r = &t->procs[i];
+        process_t* p = process_get_by_pid((pid_t)r->pid);
+        if (!p) {
+            p = process_create("restored", "");
+            if (!p) {
+                continue;
+            }
+            p->pid = (pid_t)r->pid;
+            pm_table_add_process(p);
+        }
+        p->ppid = (pid_t)r->ppid;
+        p->state = (process_state_t)r->state;
+        p->priority = (process_priority_t)r->priority;
+        p->alarm_time = r->alarm_time;
+    }
+
+    /* Pass 2: rebuild pointer links by pid, and re-add to the scheduler. */
+    for (uint32_t i = 0; i < t->count; i++) {
+        checkpoint_proc_record_t* r = &t->procs[i];
+        process_t* p = process_get_by_pid((pid_t)r->pid);
+        if (!p) {
+            continue;
+        }
+        p->parent = r->ppid ? process_get_by_pid((pid_t)r->ppid) : NULL;
+        p->first_child = r->first_child_pid
+                             ? process_get_by_pid((pid_t)r->first_child_pid) : NULL;
+        p->next_sibling = r->next_sibling_pid
+                              ? process_get_by_pid((pid_t)r->next_sibling_pid) : NULL;
+        if (r->on_ready_queue) {
+            scheduler_add_process(p);
+        }
+    }
+
+    kfree(t);
+    return 0;
+}

--- a/tests/test_checkpoint_proctable.c
+++ b/tests/test_checkpoint_proctable.c
@@ -1,0 +1,107 @@
+/* Host-side test for the process-table serialization core (#140).
+ *
+ * Pure core, no kernel deps. Verifies serialize/deserialize round-trips the
+ * table (pids, relationships, scheduler membership) exactly, that referential
+ * integrity validation catches broken tables, find-by-pid, and buffer bounds.
+ *
+ * Build: gcc -I../include -o test_checkpoint_proctable \
+ *            test_checkpoint_proctable.c ../kernel/checkpoint_proctable.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int   printf(const char*, ...);
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   memcmp(const void*, const void*, size_t);
+
+#include "checkpoint_proctable.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Build a small, consistent table: pid 1 (init) has child 2; 2 and 3 are
+ * siblings; 3's parent is 1. */
+static void build(checkpoint_proctable_t* t) {
+    memset(t, 0, sizeof(*t));
+    t->count = 3;
+    t->procs[0] = (checkpoint_proc_record_t){ .pid=1, .ppid=0, .state=2, .priority=1,
+        .alarm_time=0, .first_child_pid=2, .next_sibling_pid=0, .on_ready_queue=1, .ready_order=0 };
+    t->procs[1] = (checkpoint_proc_record_t){ .pid=2, .ppid=1, .state=2, .priority=2,
+        .alarm_time=500, .first_child_pid=0, .next_sibling_pid=3, .on_ready_queue=1, .ready_order=1 };
+    t->procs[2] = (checkpoint_proc_record_t){ .pid=3, .ppid=1, .state=3, .priority=0,
+        .alarm_time=0, .first_child_pid=0, .next_sibling_pid=0, .on_ready_queue=0, .ready_order=0 };
+}
+
+int main(void) {
+    /* === 1. round-trip === */
+    printf("Test 1: serialize/deserialize round-trip\n");
+    checkpoint_proctable_t in, out;
+    build(&in);
+
+    uint32_t need = checkpoint_proctable_blob_size(in.count);
+    static uint8_t buf[64 * 1024];
+    uint32_t w = checkpoint_proctable_serialize(&in, buf, sizeof(buf));
+    CHECK(w == need, "serialize returns the computed blob size");
+
+    CHECK(checkpoint_proctable_deserialize(&out, buf, w), "deserialize succeeds");
+    CHECK(out.count == in.count, "count round-trips");
+    CHECK(memcmp(out.procs, in.procs, in.count * sizeof(checkpoint_proc_record_t)) == 0,
+          "all records round-trip exactly");
+
+    /* spot-check a couple of fields */
+    const checkpoint_proc_record_t* p2 = checkpoint_proctable_find(&out, 2);
+    CHECK(p2 && p2->ppid == 1 && p2->next_sibling_pid == 3 && p2->alarm_time == 500,
+          "find(2): parent/sibling/alarm preserved");
+    CHECK(checkpoint_proctable_find(&out, 1)->first_child_pid == 2, "find(1): child preserved");
+    CHECK(checkpoint_proctable_find(&out, 99) == 0, "find of absent pid is NULL");
+
+    /* === 2. validation === */
+    printf("Test 2: validation\n");
+    CHECK(checkpoint_proctable_validate(&in), "consistent table validates");
+
+    checkpoint_proctable_t bad = in;
+    bad.procs[1].ppid = 77; /* references an absent pid */
+    CHECK(!checkpoint_proctable_validate(&bad), "dangling ppid rejected");
+
+    bad = in; bad.procs[2].pid = 1; /* duplicate pid */
+    CHECK(!checkpoint_proctable_validate(&bad), "duplicate pid rejected");
+
+    bad = in; bad.procs[0].pid = 0; /* pid 0 */
+    CHECK(!checkpoint_proctable_validate(&bad), "pid 0 rejected");
+
+    bad = in; bad.procs[0].first_child_pid = 42; /* dangling child */
+    CHECK(!checkpoint_proctable_validate(&bad), "dangling first_child rejected");
+
+    /* === 3. bounds === */
+    printf("Test 3: bounds\n");
+    CHECK(checkpoint_proctable_serialize(&in, buf, need - 1) == 0, "too-small buffer rejected");
+    uint8_t tiny[4];
+    CHECK(!checkpoint_proctable_deserialize(&out, tiny, sizeof(tiny)), "truncated blob rejected");
+
+    /* corrupt magic */
+    checkpoint_proctable_serialize(&in, buf, sizeof(buf));
+    buf[0] ^= 0xFF;
+    CHECK(!checkpoint_proctable_deserialize(&out, buf, w), "bad magic rejected");
+
+    /* === 4. a full table spans multiple pages (kernel blob will chunk it) === */
+    printf("Test 4: large table\n");
+    checkpoint_proctable_t big;
+    memset(&big, 0, sizeof(big));
+    big.count = CHECKPOINT_PROCTABLE_MAX;
+    for (uint32_t i = 0; i < big.count; i++) big.procs[i].pid = i + 1;
+    uint32_t bw = checkpoint_proctable_serialize(&big, buf, sizeof(buf));
+    CHECK(bw == checkpoint_proctable_blob_size(big.count), "full-table blob size");
+    CHECK(bw > 4096, "full table exceeds one page (exercises blob chunking)");
+    CHECK(checkpoint_proctable_deserialize(&out, buf, bw) && out.count == big.count,
+          "full table round-trips");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

First consumer of the v2 kernel-state blob mechanism (#139), per [design doc §3](https://github.com/Ikey168/IKOS/blob/main/docs/architecture/orthogonal-persistence-v2.md): serialize the process table into a portable, pointer-free blob and rebuild it (with scheduler membership) on restore. On its own branch.

## What's included

### Pure core (`include/checkpoint_proctable.h`, `kernel/checkpoint_proctable.c`)
Dependency-free, host-tested. Packs/unpacks the table to a versioned blob (magic + version + count + records). Relationships (parent / child / sibling) and ready-queue membership are stored **by pid**, never as pointers, so they survive a reboot. Includes:
- `serialize` / `deserialize` with magic/version/length checks.
- `validate`: referential integrity (unique nonzero pids; every nonzero ppid / first_child / next_sibling resolves to a present pid).
- `find` by pid, and `blob_size`.

### Kernel adapter (`kernel/checkpoint_proctable_sync.c`)
- `checkpoint_capture_proctable()`: snapshots the live process manager (`pm_get_process_list` / `pm_get_process`) into the portable form and emits it as a kernel-state blob (tag `CHECKPOINT_TAG_PROCTABLE`).
- `checkpoint_restore_proctable(blob, size)`: deserializes + validates, recreates a `process_t` per pid with its scalar fields (ppid, state, priority, alarm), then in a second pass rebuilds parent/child/sibling pointers by pid lookup and re-adds ready processes to the scheduler.

## Testing

`tests/test_checkpoint_proctable.c` (pure core): round-trip of a small table (parent/child/sibling, alarm, ready membership) and a full 256-entry table that spans multiple pages (so the kernel blob chunker from #139 will split it); validation of dangling ppid, dangling first_child, duplicate pid, and pid 0; find-by-pid; too-small buffer; truncated blob; bad magic.

All checkpoint/store unit suites plus the headless e2e demo pass, 0 failures. `checkpoint.c` is untouched, so no other test needed relinking. Both new kernel files compile clean under `-ffreestanding -m64 -Wall -Wextra` (the adapter's compile validates its field accesses against the real `process_t` / pm / scheduler APIs). Wired into the build and CI.

## Scope / honesty

The pure serialization + validation core is fully host-tested. The kernel adapter (live-table snapshot and pointer rebuild) can only be compile-validated here, since exercising it needs a booting kernel with a populated process manager; "the scheduler actually runs the restored processes" is observed in QEMU. Wiring `checkpoint_capture_proctable()` into the checkpoint barrier and `checkpoint_restore_proctable()` into the boot ordering is the capstone (#147).

Follows the v2 design doc (#132), the barrier (#138), and the kernel-state record (#139).