### PR TITLE
Persistence v2: persist + restore the VFS open-file tables (#141)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -47,6 +47,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_bar    test_checkpoint_barrier.c   ../kernel/checkpoint_barrier.c && /tmp/t_bar
           gcc -I../include -Wall -o /tmp/t_kern   test_checkpoint_kernel.c    $K && /tmp/t_kern
           gcc -I../include -Wall -o /tmp/t_proc   test_checkpoint_proctable.c ../kernel/checkpoint_proctable.c && /tmp/t_proc
+          gcc -I../include -Wall -o /tmp/t_file   test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c && /tmp/t_file
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_filetable.h
+++ b/include/checkpoint_filetable.h
@@ -1,0 +1,73 @@
+/* IKOS Orthogonal Persistence v2 - Open-file table serialization (#141)
+ *
+ * Serializes a process's open files into a portable blob and rebuilds them on
+ * restore. Files are the easy case for persistence: their bytes live in the
+ * persistent filesystem, so we persist the descriptor (number, offset, flags,
+ * kind, path) and on restore reopen the backing file by path and seek to the
+ * saved offset. Non-persistable kinds (sockets, DMA, devices) are not reopened;
+ * they are severed via the external-state policy (#118/#128).
+ *
+ * Two layers, mirroring the process-table work (#140):
+ *   - a pure, dependency-free serialize/deserialize/validate core (host-tested);
+ *   - kernel capture/restore adapters (declared here, defined in the kernel sync
+ *     module) that snapshot proc->fds[] and reopen via the VFS.
+ *
+ * See docs/architecture/orthogonal-persistence-v2.md §5.
+ */
+
+#ifndef CHECKPOINT_FILETABLE_H
+#define CHECKPOINT_FILETABLE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHECKPOINT_FILETABLE_MAGIC   0x494B46494C455431ULL /* "IKFILET1" */
+#define CHECKPOINT_FILETABLE_VERSION 1
+#define CHECKPOINT_FILETABLE_MAX     64  /* MAX_OPEN_FILES */
+#define CHECKPOINT_FILE_PATH_MAX     128 /* per-descriptor backing path */
+
+/* Portable record for one open descriptor. */
+typedef struct {
+    uint32_t fd;
+    uint32_t flags;
+    uint64_t offset;
+    uint32_t kind;     /* extstate_kind_t: regular file persistable, others severed */
+    uint32_t reserved;
+    char     path[CHECKPOINT_FILE_PATH_MAX]; /* NUL-terminated; empty if unknown */
+} checkpoint_file_record_t;
+
+typedef struct {
+    uint32_t pid;
+    uint32_t count;
+    checkpoint_file_record_t records[CHECKPOINT_FILETABLE_MAX];
+} checkpoint_filetable_t;
+
+/* ----- Pure serialization core ----- */
+
+uint32_t checkpoint_filetable_serialize(const checkpoint_filetable_t* t,
+                                        void* buf, uint32_t bufsize);
+bool     checkpoint_filetable_deserialize(checkpoint_filetable_t* t,
+                                          const void* buf, uint32_t size);
+
+/* Referential / shape check: count <= MAX, fds unique, and every record's path
+ * is NUL-terminated within CHECKPOINT_FILE_PATH_MAX. */
+bool checkpoint_filetable_validate(const checkpoint_filetable_t* t);
+
+const checkpoint_file_record_t* checkpoint_filetable_find(const checkpoint_filetable_t* t,
+                                                          uint32_t fd);
+
+uint32_t checkpoint_filetable_blob_size(uint32_t count);
+
+/* ----- Kernel capture/restore adapters (kernel sync module) ----- */
+#define CHECKPOINT_TAG_FILETABLE 2
+
+/* Snapshot one process's open-file table into a kernel-state blob (#139).
+ * Returns 0 on success, negative on error. */
+int checkpoint_capture_filetable(uint32_t pid);
+
+/* Rebuild a process's open files from a serialized blob: reopen persistable
+ * files by path and seek to the saved offset; sever non-persistable handles.
+ * Returns 0 on success, negative on error. */
+int checkpoint_restore_filetable(const void* blob, uint32_t size);
+
+#endif /* CHECKPOINT_FILETABLE_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -47,7 +47,8 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             usb.c usb_hid.c usb_uhci.c usb_control.c usb_syscalls.c usb_test.c usb_integration.c \
             audio.c audio_ac97.c audio_syscalls.c audio_user.c \
             ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c \
-            checkpoint_proctable.c checkpoint_proctable_sync.c
+            checkpoint_proctable.c checkpoint_proctable_sync.c \
+            checkpoint_filetable.c checkpoint_filetable_sync.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_filetable.c
+++ b/kernel/checkpoint_filetable.c
@@ -1,0 +1,108 @@
+/* IKOS Orthogonal Persistence v2 - Open-file table serialization core (#141)
+ *
+ * Pure serialize/deserialize/validate. No kernel deps. See
+ * include/checkpoint_filetable.h.
+ */
+
+#include "checkpoint_filetable.h"
+
+extern void* memcpy(void* dest, const void* src, unsigned long n);
+
+typedef struct {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t pid;
+    uint32_t count;
+    uint32_t reserved;
+} filetable_blob_header_t;
+
+uint32_t checkpoint_filetable_blob_size(uint32_t count) {
+    return (uint32_t)sizeof(filetable_blob_header_t) +
+           count * (uint32_t)sizeof(checkpoint_file_record_t);
+}
+
+uint32_t checkpoint_filetable_serialize(const checkpoint_filetable_t* t,
+                                        void* buf, uint32_t bufsize) {
+    if (!t || !buf || t->count > CHECKPOINT_FILETABLE_MAX) {
+        return 0;
+    }
+    uint32_t need = checkpoint_filetable_blob_size(t->count);
+    if (bufsize < need) {
+        return 0;
+    }
+
+    filetable_blob_header_t h;
+    h.magic = CHECKPOINT_FILETABLE_MAGIC;
+    h.version = CHECKPOINT_FILETABLE_VERSION;
+    h.pid = t->pid;
+    h.count = t->count;
+    h.reserved = 0;
+
+    uint8_t* p = (uint8_t*)buf;
+    memcpy(p, &h, sizeof(h));
+    memcpy(p + sizeof(h), t->records, t->count * sizeof(checkpoint_file_record_t));
+    return need;
+}
+
+bool checkpoint_filetable_deserialize(checkpoint_filetable_t* t,
+                                      const void* buf, uint32_t size) {
+    if (!t || !buf || size < sizeof(filetable_blob_header_t)) {
+        return false;
+    }
+    filetable_blob_header_t h;
+    memcpy(&h, buf, sizeof(h));
+    if (h.magic != CHECKPOINT_FILETABLE_MAGIC ||
+        h.version != CHECKPOINT_FILETABLE_VERSION ||
+        h.count > CHECKPOINT_FILETABLE_MAX) {
+        return false;
+    }
+    if (size < checkpoint_filetable_blob_size(h.count)) {
+        return false;
+    }
+
+    const uint8_t* p = (const uint8_t*)buf;
+    t->pid = h.pid;
+    t->count = h.count;
+    memcpy(t->records, p + sizeof(h), h.count * sizeof(checkpoint_file_record_t));
+    return true;
+}
+
+const checkpoint_file_record_t* checkpoint_filetable_find(const checkpoint_filetable_t* t,
+                                                          uint32_t fd) {
+    if (!t) {
+        return 0;
+    }
+    for (uint32_t i = 0; i < t->count; i++) {
+        if (t->records[i].fd == fd) {
+            return &t->records[i];
+        }
+    }
+    return 0;
+}
+
+static bool path_is_terminated(const char* path) {
+    for (uint32_t i = 0; i < CHECKPOINT_FILE_PATH_MAX; i++) {
+        if (path[i] == '\0') {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool checkpoint_filetable_validate(const checkpoint_filetable_t* t) {
+    if (!t || t->count > CHECKPOINT_FILETABLE_MAX) {
+        return false;
+    }
+    for (uint32_t i = 0; i < t->count; i++) {
+        const checkpoint_file_record_t* r = &t->records[i];
+        if (!path_is_terminated(r->path)) {
+            return false; /* path must be a valid C string */
+        }
+        for (uint32_t j = i + 1; j < t->count; j++) {
+            if (t->records[j].fd == r->fd) {
+                return false; /* fds unique within a process */
+            }
+        }
+    }
+    return true;
+}

--- a/kernel/checkpoint_filetable_sync.c
+++ b/kernel/checkpoint_filetable_sync.c
@@ -1,0 +1,126 @@
+/* IKOS Orthogonal Persistence v2 - Open-file table capture/restore adapter (#141)
+ *
+ * Bridges a process's proc->fds[] to the portable serialization core
+ * (checkpoint_filetable.c), the external-state policy (#128), and the VFS.
+ * Kernel only; the host tests cover the pure core, this adapter is validated by
+ * the build.
+ */
+
+#include "checkpoint_filetable.h"
+#include "checkpoint.h"
+#include "checkpoint_extstate.h"
+#include "process_manager.h"   /* process_t, file_descriptor_t, MAX_OPEN_FILES, pm */
+#include "vfs.h"               /* vfs_open, vfs_lseek */
+#include <stddef.h>
+
+extern void* kmalloc(size_t size);
+extern void  kfree(void* ptr);
+
+#define SEEK_SET_ 0
+
+int checkpoint_capture_filetable(uint32_t pid) {
+    process_t* proc = process_get_by_pid((pid_t)pid);
+    if (!proc) {
+        return -1;
+    }
+
+    checkpoint_filetable_t* t = (checkpoint_filetable_t*)kmalloc(sizeof(*t));
+    if (!t) {
+        return -1;
+    }
+    t->pid = pid;
+    t->count = 0;
+
+    for (int i = 0; i < MAX_OPEN_FILES && t->count < CHECKPOINT_FILETABLE_MAX; i++) {
+        file_descriptor_t* fd = &proc->fds[i];
+        if (fd->fd < 0) {
+            continue; /* slot not in use */
+        }
+        checkpoint_file_record_t* r = &t->records[t->count++];
+        r->fd = (uint32_t)fd->fd;
+        r->flags = fd->flags;
+        r->offset = fd->offset;
+        r->kind = (uint32_t)extstate_kind_from_fd_flags(fd->flags);
+        r->reserved = 0;
+        /* The descriptor does not currently store its backing path; leave it
+         * empty until the VFS exposes it (records still carry offset/flags/kind
+         * so non-persistable handles are severed and metadata is restored). */
+        for (int k = 0; k < CHECKPOINT_FILE_PATH_MAX; k++) {
+            r->path[k] = '\0';
+        }
+    }
+
+    uint32_t bufsize = checkpoint_filetable_blob_size(t->count);
+    uint8_t* buf = (uint8_t*)kmalloc(bufsize);
+    if (!buf) {
+        kfree(t);
+        return -1;
+    }
+
+    int rc = -1;
+    uint32_t written = checkpoint_filetable_serialize(t, buf, bufsize);
+    if (written) {
+        rc = checkpoint_capture_kernel_blob(CHECKPOINT_TAG_FILETABLE, buf, written);
+    }
+    kfree(buf);
+    kfree(t);
+    return rc;
+}
+
+int checkpoint_restore_filetable(const void* blob, uint32_t size) {
+    checkpoint_filetable_t* t = (checkpoint_filetable_t*)kmalloc(sizeof(*t));
+    if (!t) {
+        return -1;
+    }
+    if (!checkpoint_filetable_deserialize(t, blob, size) ||
+        !checkpoint_filetable_validate(t)) {
+        kfree(t);
+        return -1;
+    }
+
+    process_t* proc = process_get_by_pid((pid_t)t->pid);
+    if (!proc) {
+        kfree(t);
+        return -1;
+    }
+
+    for (uint32_t i = 0; i < t->count; i++) {
+        checkpoint_file_record_t* r = &t->records[i];
+
+        /* Find the matching descriptor slot, or the first free one. */
+        file_descriptor_t* slot = NULL;
+        for (int j = 0; j < MAX_OPEN_FILES; j++) {
+            if (proc->fds[j].fd == (int)r->fd) { slot = &proc->fds[j]; break; }
+        }
+        if (!slot) {
+            for (int j = 0; j < MAX_OPEN_FILES; j++) {
+                if (proc->fds[j].fd < 0) { slot = &proc->fds[j]; break; }
+            }
+        }
+        if (!slot) {
+            continue;
+        }
+
+        slot->fd = (int)r->fd;
+        slot->offset = r->offset;
+        slot->flags = r->flags;
+        slot->file_data = NULL;
+
+        if (extstate_survives_checkpoint((extstate_kind_t)r->kind) && r->path[0] != '\0') {
+            /* Regular file: reopen by path and seek to the saved offset. (The
+             * VFS-level fd is reconciled with r->fd by a later VFS change.) */
+            int vfd = vfs_open(r->path, r->flags, 0);
+            if (vfd >= 0) {
+                vfs_lseek(vfd, r->offset, SEEK_SET_);
+            }
+        } else {
+            /* Non-persistable handle (socket/DMA/device), or a file whose path
+             * we could not capture: sever it so the app re-establishes it. */
+            extstate_fd_set_kind(&slot->flags, (extstate_kind_t)r->kind);
+            extstate_sever_fd(&slot->flags);
+        }
+    }
+
+    kfree(t);
+    return 0;
+}

--- a/tests/test_checkpoint_filetable.c
+++ b/tests/test_checkpoint_filetable.c
@@ -1,0 +1,102 @@
+/* Host-side test for the open-file table serialization core (#141).
+ *
+ * Pure core, no kernel deps. Verifies serialize/deserialize round-trips
+ * descriptors (fd, offset, flags, kind, path) exactly, validation catches
+ * malformed tables (unterminated path, duplicate fd), find-by-fd, and bounds.
+ *
+ * Build: gcc -I../include -o test_checkpoint_filetable \
+ *            test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int    printf(const char*, ...);
+extern void*  memcpy(void*, const void*, size_t);
+extern void*  memset(void*, int, size_t);
+extern int    memcmp(const void*, const void*, size_t);
+extern size_t strlen(const char*);
+
+#include "checkpoint_filetable.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Set a record's NUL-terminated path. */
+static void set_path(checkpoint_file_record_t* r, const char* s) {
+    memset(r->path, 0, CHECKPOINT_FILE_PATH_MAX);
+    size_t n = strlen(s);
+    if (n >= CHECKPOINT_FILE_PATH_MAX) n = CHECKPOINT_FILE_PATH_MAX - 1;
+    memcpy(r->path, s, n);
+}
+
+/* fd 3: a regular file with a path; fd 5: a socket (no path). */
+static void build(checkpoint_filetable_t* t) {
+    memset(t, 0, sizeof(*t));
+    t->pid = 7;
+    t->count = 2;
+    t->records[0].fd = 3; t->records[0].flags = 0x2; t->records[0].offset = 4096;
+    t->records[0].kind = 0 /* EXTSTATE_REGULAR_FILE */;
+    set_path(&t->records[0], "/etc/motd");
+    t->records[1].fd = 5; t->records[1].flags = 0x1; t->records[1].offset = 0;
+    t->records[1].kind = 1 /* EXTSTATE_SOCKET */;
+    set_path(&t->records[1], "");
+}
+
+int main(void) {
+    printf("Test 1: round-trip\n");
+    checkpoint_filetable_t in, out;
+    build(&in);
+
+    static uint8_t buf[64 * 1024];
+    uint32_t need = checkpoint_filetable_blob_size(in.count);
+    uint32_t w = checkpoint_filetable_serialize(&in, buf, sizeof(buf));
+    CHECK(w == need, "serialize returns the computed blob size");
+    CHECK(checkpoint_filetable_deserialize(&out, buf, w), "deserialize succeeds");
+    CHECK(out.pid == 7 && out.count == 2, "pid + count round-trip");
+    CHECK(memcmp(out.records, in.records, in.count * sizeof(checkpoint_file_record_t)) == 0,
+          "records round-trip exactly");
+
+    const checkpoint_file_record_t* f3 = checkpoint_filetable_find(&out, 3);
+    CHECK(f3 && f3->offset == 4096 && strlen(f3->path) > 0, "find(3): offset + path preserved");
+    const checkpoint_file_record_t* f5 = checkpoint_filetable_find(&out, 5);
+    CHECK(f5 && f5->kind == 1 && f5->path[0] == '\0', "find(5): socket, no path");
+    CHECK(checkpoint_filetable_find(&out, 9) == 0, "find of absent fd is NULL");
+
+    printf("Test 2: validation\n");
+    CHECK(checkpoint_filetable_validate(&in), "consistent table validates");
+
+    checkpoint_filetable_t bad = in;
+    memset(bad.records[0].path, 'A', CHECKPOINT_FILE_PATH_MAX); /* no NUL */
+    CHECK(!checkpoint_filetable_validate(&bad), "unterminated path rejected");
+
+    bad = in; bad.records[1].fd = 3; /* duplicate fd */
+    CHECK(!checkpoint_filetable_validate(&bad), "duplicate fd rejected");
+
+    printf("Test 3: bounds\n");
+    CHECK(checkpoint_filetable_serialize(&in, buf, need - 1) == 0, "too-small buffer rejected");
+    uint8_t tiny[8];
+    CHECK(!checkpoint_filetable_deserialize(&out, tiny, sizeof(tiny)), "truncated blob rejected");
+    checkpoint_filetable_serialize(&in, buf, sizeof(buf));
+    buf[2] ^= 0xFF;
+    CHECK(!checkpoint_filetable_deserialize(&out, buf, w), "bad magic rejected");
+
+    printf("Test 4: full table spans multiple pages\n");
+    checkpoint_filetable_t big;
+    memset(&big, 0, sizeof(big));
+    big.pid = 1; big.count = CHECKPOINT_FILETABLE_MAX;
+    for (uint32_t i = 0; i < big.count; i++) { big.records[i].fd = i; }
+    uint32_t bw = checkpoint_filetable_serialize(&big, buf, sizeof(buf));
+    CHECK(bw == checkpoint_filetable_blob_size(big.count), "full-table blob size");
+    CHECK(bw > 4096, "full table exceeds one page (exercises blob chunking)");
+    CHECK(checkpoint_filetable_deserialize(&out, buf, bw) && out.count == big.count,
+          "full table round-trips");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Another consumer of the v2 kernel-state blob mechanism (#139), per [design doc §5](https://github.com/Ikey168/IKOS/blob/main/docs/architecture/orthogonal-persistence-v2.md): serialize a process's open files and rebuild them on restore. Files are the easy case (their bytes live in the persistent filesystem), so we persist the descriptor and reopen the backing file by path. On its own branch.

## What's included

### Pure core (`include/checkpoint_filetable.h`, `kernel/checkpoint_filetable.c`)
Dependency-free, host-tested. Packs/unpacks a per-process file table to a versioned blob, each record carrying `{ fd, offset, flags, kind, path }`. Validation enforces unique fds and NUL-terminated paths. Includes serialize/deserialize/validate/find/blob_size.

### Kernel adapter (`kernel/checkpoint_filetable_sync.c`)
- `checkpoint_capture_filetable(pid)`: snapshots `proc->fds[]`, classifying each descriptor's kind via the external-state policy (`extstate_kind_from_fd_flags`, #128), into a kernel-state blob (tag `CHECKPOINT_TAG_FILETABLE`).
- `checkpoint_restore_filetable(blob, size)`: deserializes + validates, then for each record reopens persistable files by path (`vfs_open` + `vfs_lseek` to the saved offset) and severs non-persistable handles (sockets / DMA / devices) via `extstate_sever_fd`, so the app re-establishes them.

## Testing

`tests/test_checkpoint_filetable.c` (pure core): round-trip of a mixed table (a regular file with a path + a socket without), validation of unterminated path and duplicate fd, find-by-fd, too-small buffer, truncated blob, bad magic, and a full 64-entry table that spans multiple pages (so #139's blob chunker splits it).

All checkpoint/store unit suites plus the headless e2e demo pass, 0 failures. `checkpoint.c` is untouched, so no other test needed relinking. Both new kernel files compile clean under `-ffreestanding -m64 -Wall -Wextra` (the adapter's compile validates its accesses against `file_descriptor_t`, the VFS, and the extstate APIs). Wired into the build and CI.

## Scope / honesty

The pure serialization + validation core is fully host-tested, and the reopen-by-path + sever logic is implemented against the real `vfs_open` / `vfs_lseek` / extstate APIs. One real limitation: `file_descriptor_t` does not currently store its backing path, so capture leaves the path empty for now (offset / flags / kind are still captured, and non-persistable handles are still severed on restore). Reopen-by-path activates once the VFS exposes the descriptor's path; the core and the restore path are already wired for it. Reconciling the VFS-level fd returned by `vfs_open` with the saved fd number, and the pipe/unlinked-file edge cases noted in the issue, are follow-ups.

Wiring capture into the barrier and restore into the boot order is the capstone (#147).

Follows the v2 design doc (#132), the kernel-state record (#139), and the process table (#140).