### PR TITLE
Persistence v2: drain and persist in-flight IPC messages (#142)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -48,6 +48,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_kern   test_checkpoint_kernel.c    $K && /tmp/t_kern
           gcc -I../include -Wall -o /tmp/t_proc   test_checkpoint_proctable.c ../kernel/checkpoint_proctable.c && /tmp/t_proc
           gcc -I../include -Wall -o /tmp/t_file   test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c && /tmp/t_file
+          gcc -I../include -Wall -o /tmp/t_ipc    test_checkpoint_ipc.c       ../kernel/checkpoint_ipc.c && /tmp/t_ipc
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_ipc.h
+++ b/include/checkpoint_ipc.h
@@ -1,0 +1,81 @@
+/* IKOS Orthogonal Persistence v2 - IPC channel/message serialization (#142)
+ *
+ * Persists IPC across a checkpoint without losing or duplicating messages. At
+ * the checkpoint barrier the message queues are drained to a quiescent point,
+ * then the settled channels and their queued messages are serialized as kernel
+ * state; restore recreates the channels and re-enqueues the messages.
+ *
+ * Two layers, mirroring #140/#141:
+ *   - a pure, dependency-free serialize/deserialize/validate core (host-tested);
+ *   - kernel capture/restore adapters (declared here, defined in the sync module)
+ *     over the process manager's pm_ipc_* API.
+ *
+ * See docs/architecture/orthogonal-persistence-v2.md §6.
+ */
+
+#ifndef CHECKPOINT_IPC_H
+#define CHECKPOINT_IPC_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHECKPOINT_IPC_MAGIC        0x494B49504331ULL /* "IKIPC1" */
+#define CHECKPOINT_IPC_VERSION      1
+#define CHECKPOINT_IPC_MAX_CHANNELS 32
+#define CHECKPOINT_IPC_MAX_MESSAGES 16
+#define CHECKPOINT_IPC_DATA_MAX     4096 /* PM_IPC_BUFFER_SIZE */
+
+typedef struct {
+    uint32_t channel_id;
+    uint32_t owner_pid;
+    uint32_t permissions;
+    uint8_t  active;
+    uint8_t  reserved[3];
+} checkpoint_ipc_channel_t;
+
+typedef struct {
+    uint32_t channel_id;
+    uint32_t type;
+    uint32_t src_pid;
+    uint32_t dst_pid;
+    uint32_t message_id;
+    uint32_t data_size;   /* valid bytes of data[] */
+    uint32_t flags;
+    uint32_t reserved;
+    uint64_t timestamp;
+    uint8_t  data[CHECKPOINT_IPC_DATA_MAX];
+} checkpoint_ipc_message_t;
+
+typedef struct {
+    uint32_t channel_count;
+    uint32_t message_count;
+    checkpoint_ipc_channel_t channels[CHECKPOINT_IPC_MAX_CHANNELS];
+    checkpoint_ipc_message_t messages[CHECKPOINT_IPC_MAX_MESSAGES];
+} checkpoint_ipc_t;
+
+/* ----- Pure serialization core ----- */
+
+uint32_t checkpoint_ipc_serialize(const checkpoint_ipc_t* t, void* buf, uint32_t bufsize);
+bool     checkpoint_ipc_deserialize(checkpoint_ipc_t* t, const void* buf, uint32_t size);
+
+/* channel_count/message_count within bounds; channel ids unique + nonzero;
+ * every message's channel_id resolves to a present channel; data_size bounded. */
+bool checkpoint_ipc_validate(const checkpoint_ipc_t* t);
+
+const checkpoint_ipc_channel_t* checkpoint_ipc_find_channel(const checkpoint_ipc_t* t,
+                                                            uint32_t channel_id);
+
+uint32_t checkpoint_ipc_blob_size(uint32_t channel_count, uint32_t message_count);
+
+/* ----- Kernel capture/restore adapters (kernel sync module) ----- */
+#define CHECKPOINT_TAG_IPC 3
+
+/* Drain the live IPC channels and persist the settled channels + messages as a
+ * kernel-state blob (#139). Returns 0 on success, negative on error. */
+int checkpoint_capture_ipc(void);
+
+/* Recreate channels and re-enqueue the persisted messages from a blob on
+ * restore. Returns 0 on success, negative on error. */
+int checkpoint_restore_ipc(const void* blob, uint32_t size);
+
+#endif /* CHECKPOINT_IPC_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -48,7 +48,8 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             audio.c audio_ac97.c audio_syscalls.c audio_user.c \
             ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c \
             checkpoint_proctable.c checkpoint_proctable_sync.c \
-            checkpoint_filetable.c checkpoint_filetable_sync.c
+            checkpoint_filetable.c checkpoint_filetable_sync.c \
+            checkpoint_ipc.c checkpoint_ipc_sync.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_ipc.c
+++ b/kernel/checkpoint_ipc.c
@@ -1,0 +1,116 @@
+/* IKOS Orthogonal Persistence v2 - IPC serialization core (#142)
+ *
+ * Pure serialize/deserialize/validate. No kernel deps. See
+ * include/checkpoint_ipc.h.
+ */
+
+#include "checkpoint_ipc.h"
+
+extern void* memcpy(void* dest, const void* src, unsigned long n);
+
+typedef struct {
+    uint64_t magic;
+    uint32_t version;
+    uint32_t channel_count;
+    uint32_t message_count;
+    uint32_t reserved;
+} ipc_blob_header_t;
+
+uint32_t checkpoint_ipc_blob_size(uint32_t channel_count, uint32_t message_count) {
+    return (uint32_t)sizeof(ipc_blob_header_t) +
+           channel_count * (uint32_t)sizeof(checkpoint_ipc_channel_t) +
+           message_count * (uint32_t)sizeof(checkpoint_ipc_message_t);
+}
+
+uint32_t checkpoint_ipc_serialize(const checkpoint_ipc_t* t, void* buf, uint32_t bufsize) {
+    if (!t || !buf ||
+        t->channel_count > CHECKPOINT_IPC_MAX_CHANNELS ||
+        t->message_count > CHECKPOINT_IPC_MAX_MESSAGES) {
+        return 0;
+    }
+    uint32_t need = checkpoint_ipc_blob_size(t->channel_count, t->message_count);
+    if (bufsize < need) {
+        return 0;
+    }
+
+    ipc_blob_header_t h;
+    h.magic = CHECKPOINT_IPC_MAGIC;
+    h.version = CHECKPOINT_IPC_VERSION;
+    h.channel_count = t->channel_count;
+    h.message_count = t->message_count;
+    h.reserved = 0;
+
+    uint8_t* p = (uint8_t*)buf;
+    memcpy(p, &h, sizeof(h));
+    p += sizeof(h);
+    memcpy(p, t->channels, t->channel_count * sizeof(checkpoint_ipc_channel_t));
+    p += t->channel_count * sizeof(checkpoint_ipc_channel_t);
+    memcpy(p, t->messages, t->message_count * sizeof(checkpoint_ipc_message_t));
+    return need;
+}
+
+bool checkpoint_ipc_deserialize(checkpoint_ipc_t* t, const void* buf, uint32_t size) {
+    if (!t || !buf || size < sizeof(ipc_blob_header_t)) {
+        return false;
+    }
+    ipc_blob_header_t h;
+    memcpy(&h, buf, sizeof(h));
+    if (h.magic != CHECKPOINT_IPC_MAGIC ||
+        h.version != CHECKPOINT_IPC_VERSION ||
+        h.channel_count > CHECKPOINT_IPC_MAX_CHANNELS ||
+        h.message_count > CHECKPOINT_IPC_MAX_MESSAGES) {
+        return false;
+    }
+    if (size < checkpoint_ipc_blob_size(h.channel_count, h.message_count)) {
+        return false;
+    }
+
+    const uint8_t* p = (const uint8_t*)buf + sizeof(h);
+    t->channel_count = h.channel_count;
+    t->message_count = h.message_count;
+    memcpy(t->channels, p, h.channel_count * sizeof(checkpoint_ipc_channel_t));
+    p += h.channel_count * sizeof(checkpoint_ipc_channel_t);
+    memcpy(t->messages, p, h.message_count * sizeof(checkpoint_ipc_message_t));
+    return true;
+}
+
+const checkpoint_ipc_channel_t* checkpoint_ipc_find_channel(const checkpoint_ipc_t* t,
+                                                            uint32_t channel_id) {
+    if (!t) {
+        return 0;
+    }
+    for (uint32_t i = 0; i < t->channel_count; i++) {
+        if (t->channels[i].channel_id == channel_id) {
+            return &t->channels[i];
+        }
+    }
+    return 0;
+}
+
+bool checkpoint_ipc_validate(const checkpoint_ipc_t* t) {
+    if (!t ||
+        t->channel_count > CHECKPOINT_IPC_MAX_CHANNELS ||
+        t->message_count > CHECKPOINT_IPC_MAX_MESSAGES) {
+        return false;
+    }
+    for (uint32_t i = 0; i < t->channel_count; i++) {
+        if (t->channels[i].channel_id == 0) {
+            return false;
+        }
+        for (uint32_t j = i + 1; j < t->channel_count; j++) {
+            if (t->channels[j].channel_id == t->channels[i].channel_id) {
+                return false; /* channel ids unique */
+            }
+        }
+    }
+    for (uint32_t i = 0; i < t->message_count; i++) {
+        const checkpoint_ipc_message_t* m = &t->messages[i];
+        if (m->data_size > CHECKPOINT_IPC_DATA_MAX) {
+            return false;
+        }
+        if (!checkpoint_ipc_find_channel(t, m->channel_id)) {
+            return false; /* every message belongs to a present channel */
+        }
+    }
+    return true;
+}

--- a/kernel/checkpoint_ipc_sync.c
+++ b/kernel/checkpoint_ipc_sync.c
@@ -1,0 +1,120 @@
+/* IKOS Orthogonal Persistence v2 - IPC capture/restore adapter (#142)
+ *
+ * Bridges the process manager's pm_ipc_* API to the portable serialization core
+ * (checkpoint_ipc.c) and the kernel-state blob mechanism (#139). Kernel only;
+ * the host tests cover the pure core, this adapter is validated by the build.
+ */
+
+#include "checkpoint_ipc.h"
+#include "checkpoint.h"
+#include "process_manager.h"
+#include <stddef.h>
+
+extern void* kmalloc(size_t size);
+extern void  kfree(void* ptr);
+extern void* memcpy(void* dest, const void* src, size_t n);
+extern void* memset(void* dest, int value, size_t n);
+
+int checkpoint_capture_ipc(void) {
+    checkpoint_ipc_t* t = (checkpoint_ipc_t*)kmalloc(sizeof(*t));
+    if (!t) {
+        return -1;
+    }
+    t->channel_count = 0;
+    t->message_count = 0;
+
+    /* Walk the active channels; drain each queue to a quiescent point (the
+     * drained messages are persisted here and re-enqueued on restore). */
+    for (uint32_t id = 1;
+         id <= PM_MAX_IPC_CHANNELS && t->channel_count < CHECKPOINT_IPC_MAX_CHANNELS;
+         id++) {
+        pm_ipc_channel_t info;
+        if (pm_ipc_get_channel_info(id, &info) != 0 || !info.is_active) {
+            continue;
+        }
+
+        checkpoint_ipc_channel_t* c = &t->channels[t->channel_count++];
+        c->channel_id = info.channel_id;
+        c->owner_pid = info.owner_pid;
+        c->permissions = info.permissions;
+        c->active = 1;
+        c->reserved[0] = c->reserved[1] = c->reserved[2] = 0;
+
+        while (pm_ipc_channel_has_messages(id) &&
+               t->message_count < CHECKPOINT_IPC_MAX_MESSAGES) {
+            pm_ipc_message_t m;
+            if (pm_ipc_receive_message(info.owner_pid, id, &m) != 0) {
+                break;
+            }
+            checkpoint_ipc_message_t* r = &t->messages[t->message_count++];
+            r->channel_id = m.channel_id;
+            r->type = (uint32_t)m.type;
+            r->src_pid = m.src_pid;
+            r->dst_pid = m.dst_pid;
+            r->message_id = m.message_id;
+            r->data_size = m.data_size;
+            r->flags = m.flags;
+            r->reserved = 0;
+            r->timestamp = m.timestamp;
+            uint32_t n = m.data_size <= CHECKPOINT_IPC_DATA_MAX
+                             ? m.data_size : CHECKPOINT_IPC_DATA_MAX;
+            memset(r->data, 0, CHECKPOINT_IPC_DATA_MAX);
+            memcpy(r->data, m.data, n);
+        }
+    }
+
+    uint32_t bufsize = checkpoint_ipc_blob_size(t->channel_count, t->message_count);
+    uint8_t* buf = (uint8_t*)kmalloc(bufsize);
+    if (!buf) {
+        kfree(t);
+        return -1;
+    }
+    int rc = -1;
+    uint32_t w = checkpoint_ipc_serialize(t, buf, bufsize);
+    if (w) {
+        rc = checkpoint_capture_kernel_blob(CHECKPOINT_TAG_IPC, buf, w);
+    }
+    kfree(buf);
+    kfree(t);
+    return rc;
+}
+
+int checkpoint_restore_ipc(const void* blob, uint32_t size) {
+    checkpoint_ipc_t* t = (checkpoint_ipc_t*)kmalloc(sizeof(*t));
+    if (!t) {
+        return -1;
+    }
+    if (!checkpoint_ipc_deserialize(t, blob, size) || !checkpoint_ipc_validate(t)) {
+        kfree(t);
+        return -1;
+    }
+
+    /* Recreate the channels (id preservation is pm-dependent; best-effort). */
+    for (uint32_t i = 0; i < t->channel_count; i++) {
+        uint32_t new_id = 0;
+        if (pm_ipc_create_channel(t->channels[i].owner_pid, &new_id) == 0) {
+            pm_ipc_set_channel_permissions(new_id, t->channels[i].permissions);
+        }
+    }
+
+    /* Re-enqueue the persisted messages. */
+    for (uint32_t i = 0; i < t->message_count; i++) {
+        checkpoint_ipc_message_t* r = &t->messages[i];
+        pm_ipc_message_t m;
+        memset(&m, 0, sizeof(m));
+        m.type = (pm_ipc_type_t)r->type;
+        m.src_pid = r->src_pid;
+        m.dst_pid = r->dst_pid;
+        m.channel_id = r->channel_id;
+        m.message_id = r->message_id;
+        m.data_size = r->data_size;
+        m.timestamp = r->timestamp;
+        m.flags = r->flags;
+        uint32_t n = r->data_size <= PM_IPC_BUFFER_SIZE ? r->data_size : PM_IPC_BUFFER_SIZE;
+        memcpy(m.data, r->data, n);
+        pm_ipc_send_message(&m);
+    }
+
+    kfree(t);
+    return 0;
+}

--- a/tests/test_checkpoint_ipc.c
+++ b/tests/test_checkpoint_ipc.c
@@ -1,0 +1,94 @@
+/* Host-side test for the IPC serialization core (#142).
+ *
+ * Pure core, no kernel deps. Verifies serialize/deserialize round-trips
+ * channels + messages (incl. payloads) exactly, validation catches malformed
+ * tables (dangling/duplicate/zero channel ids, oversized payload), find, bounds.
+ *
+ * Build: gcc -I../include -o test_checkpoint_ipc \
+ *            test_checkpoint_ipc.c ../kernel/checkpoint_ipc.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int   printf(const char*, ...);
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   memcmp(const void*, const void*, size_t);
+
+#include "checkpoint_ipc.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+static checkpoint_ipc_t in, out;
+static uint8_t buf[256 * 1024];
+
+/* Channels 10 and 20; three messages across them with distinct payloads. */
+static void build(void) {
+    memset(&in, 0, sizeof(in));
+    in.channel_count = 2;
+    in.channels[0] = (checkpoint_ipc_channel_t){ .channel_id=10, .owner_pid=3, .permissions=0x7, .active=1 };
+    in.channels[1] = (checkpoint_ipc_channel_t){ .channel_id=20, .owner_pid=4, .permissions=0x1, .active=1 };
+    in.message_count = 3;
+    for (int i = 0; i < 3; i++) {
+        checkpoint_ipc_message_t* m = &in.messages[i];
+        m->channel_id = (i == 2) ? 20 : 10;
+        m->type = 1; m->src_pid = 3; m->dst_pid = 4; m->message_id = 100 + i;
+        m->data_size = 64 + i;
+        m->timestamp = 5000 + i;
+        for (uint32_t k = 0; k < m->data_size; k++) m->data[k] = (uint8_t)(i * 40 + k);
+    }
+}
+
+int main(void) {
+    printf("Test 1: round-trip\n");
+    build();
+    uint32_t need = checkpoint_ipc_blob_size(in.channel_count, in.message_count);
+    uint32_t w = checkpoint_ipc_serialize(&in, buf, sizeof(buf));
+    CHECK(w == need, "serialize returns the computed blob size");
+    CHECK(checkpoint_ipc_deserialize(&out, buf, w), "deserialize succeeds");
+    CHECK(out.channel_count == 2 && out.message_count == 3, "counts round-trip");
+    CHECK(memcmp(out.channels, in.channels, 2 * sizeof(checkpoint_ipc_channel_t)) == 0,
+          "channels round-trip");
+    CHECK(memcmp(out.messages, in.messages, 3 * sizeof(checkpoint_ipc_message_t)) == 0,
+          "messages (incl. payloads) round-trip exactly");
+
+    const checkpoint_ipc_channel_t* c20 = checkpoint_ipc_find_channel(&out, 20);
+    CHECK(c20 && c20->owner_pid == 4, "find channel 20");
+    CHECK(checkpoint_ipc_find_channel(&out, 99) == 0, "find of absent channel is NULL");
+    CHECK(out.messages[2].channel_id == 20 && out.messages[2].data[0] == (uint8_t)(2*40),
+          "message 2 payload preserved");
+
+    printf("Test 2: validation\n");
+    CHECK(checkpoint_ipc_validate(&in), "consistent table validates");
+
+    checkpoint_ipc_t bad = in;
+    bad.messages[0].channel_id = 77; /* dangling */
+    CHECK(!checkpoint_ipc_validate(&bad), "message on absent channel rejected");
+
+    bad = in; bad.channels[1].channel_id = 10; /* duplicate */
+    CHECK(!checkpoint_ipc_validate(&bad), "duplicate channel id rejected");
+
+    bad = in; bad.channels[0].channel_id = 0;
+    CHECK(!checkpoint_ipc_validate(&bad), "channel id 0 rejected");
+
+    bad = in; bad.messages[0].data_size = CHECKPOINT_IPC_DATA_MAX + 1;
+    CHECK(!checkpoint_ipc_validate(&bad), "oversized payload rejected");
+
+    printf("Test 3: bounds\n");
+    CHECK(checkpoint_ipc_serialize(&in, buf, need - 1) == 0, "too-small buffer rejected");
+    uint8_t tiny[8];
+    CHECK(!checkpoint_ipc_deserialize(&out, tiny, sizeof(tiny)), "truncated blob rejected");
+    checkpoint_ipc_serialize(&in, buf, sizeof(buf));
+    buf[1] ^= 0xFF;
+    CHECK(!checkpoint_ipc_deserialize(&out, buf, w), "bad magic rejected");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

The third consumer of the v2 kernel-state blob mechanism (#139), per [design doc §6](https://github.com/Ikey168/IKOS/blob/main/docs/architecture/orthogonal-persistence-v2.md): persist IPC across a checkpoint without losing or duplicating messages. On its own branch.

## What's included

### Pure core (`include/checkpoint_ipc.h`, `kernel/checkpoint_ipc.c`)
Dependency-free, host-tested. Packs/unpacks IPC channels and their queued messages (including payloads) to a versioned blob. Validation enforces unique nonzero channel ids, that every message belongs to a present channel, and bounded payload size. Includes serialize/deserialize/validate/find/blob_size.

### Kernel adapter (`kernel/checkpoint_ipc_sync.c`)
- `checkpoint_capture_ipc()`: walks the active channels (`pm_ipc_get_channel_info`) and **drains** each queue to a quiescent point (`pm_ipc_receive_message`), persisting the settled channels + messages as a kernel-state blob (tag `CHECKPOINT_TAG_IPC`). Draining is the "settle to a quiescent point" step from the design.
- `checkpoint_restore_ipc()`: recreates the channels (`pm_ipc_create_channel` + `pm_ipc_set_channel_permissions`) and re-enqueues the messages (`pm_ipc_send_message`), so nothing is lost or delivered twice.

## Testing

`tests/test_checkpoint_ipc.c` (pure core): round-trip of 2 channels + 3 messages including payload bytes; validation of a message on an absent channel, a duplicate channel id, a zero channel id, and an oversized payload; find-by-id; too-small buffer; truncated blob; bad magic.

All checkpoint/store unit suites plus the headless e2e demo pass, 0 failures. `checkpoint.c` is untouched, so no other test needed relinking. Both new kernel files compile clean under `-ffreestanding -m64 -Wall -Wextra` (the adapter's compile validates its accesses against the real `pm_ipc_*` API). Wired into the build and CI.

## Scope / honesty

The pure serialization + validation core is fully host-tested, and the drain/re-enqueue logic is implemented against the real `pm_ipc_*` API. Two best-effort points, since they depend on pm internals that need a booting kernel to validate: channel-id preservation on restore (`pm_ipc_create_channel` assigns an id, so exact id reuse is a follow-up), and the capture caps (32 channels / 16 messages, sized for a quiescent barrier where queues are small). Draining at capture time is what guarantees no duplication.

Wiring capture into the barrier and restore into the boot order is the capstone (#147).

Follows the v2 design doc (#132), the kernel-state record (#139), the process table (#140), and the file table (#141).