### PR TITLE
Driver re-attach framework for orthogonal persistence (#143)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -49,6 +49,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_proc   test_checkpoint_proctable.c ../kernel/checkpoint_proctable.c && /tmp/t_proc
           gcc -I../include -Wall -o /tmp/t_file   test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c && /tmp/t_file
           gcc -I../include -Wall -o /tmp/t_ipc    test_checkpoint_ipc.c       ../kernel/checkpoint_ipc.c && /tmp/t_ipc
+          gcc -I../include -Wall -o /tmp/t_drv    test_checkpoint_driver.c    ../kernel/checkpoint_driver.c && /tmp/t_drv
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_driver.h
+++ b/include/checkpoint_driver.h
@@ -1,0 +1,80 @@
+/* IKOS Orthogonal Persistence v2 - Driver re-attach framework (#143)
+ *
+ * Device-register state is meaningless after a power cut, so each driver
+ * declares how to quiesce its hardware before a checkpoint and re-initialize +
+ * reconcile it on restore. This is the contract and the ordering engine from
+ * docs/architecture/orthogonal-persistence-v2.md §4.
+ *
+ * Flow:
+ *   - at the checkpoint barrier (#138): quiesce every registered device;
+ *   - on restore, after cold-init and before user restore: reattach every one.
+ *
+ * The device is an opaque void* so this stays decoupled from device_manager and
+ * is a pure, host-testable ordering core (like the barrier). Real drivers
+ * register their ops in #144 (disk) and #145 (framebuffer).
+ */
+
+#ifndef CHECKPOINT_DRIVER_H
+#define CHECKPOINT_DRIVER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHECKPOINT_DRIVER_MAX 32
+
+/* Per-driver persistence contract. */
+typedef struct {
+    int  (*quiesce)(void* dev);   /* reach a safe boundary before checkpoint; 0 = ok */
+    int  (*reattach)(void* dev);  /* re-init hardware on restore, reconcile; 0 = ok */
+    bool persistable;             /* false: the device's connections are severed */
+} checkpoint_persist_ops_t;
+
+typedef struct {
+    void* dev;
+    checkpoint_persist_ops_t ops;
+    bool  severed;                /* set if reattach failed under CONTINUE mode */
+} checkpoint_driver_entry_t;
+
+typedef struct {
+    checkpoint_driver_entry_t entries[CHECKPOINT_DRIVER_MAX];
+    uint32_t count;
+} checkpoint_driver_registry_t;
+
+/* Failure policy for reattach. */
+typedef enum {
+    CHECKPOINT_REATTACH_ABORT = 0,   /* first failed reattach aborts (cold boot) */
+    CHECKPOINT_REATTACH_CONTINUE,    /* a failed reattach severs that device, keep going */
+} checkpoint_reattach_mode_t;
+
+#define CHECKPOINT_DRIVER_ABORTED (-1)
+
+/* ----- Registry ----- */
+
+void     checkpoint_driver_registry_init(checkpoint_driver_registry_t* r);
+/* Register a device + ops. Returns 0, or -1 if the registry is full or args are
+ * bad. quiesce/reattach may be NULL (treated as a no-op success). */
+int      checkpoint_driver_register(checkpoint_driver_registry_t* r,
+                                    void* dev, const checkpoint_persist_ops_t* ops);
+uint32_t checkpoint_driver_count(const checkpoint_driver_registry_t* r);
+
+/* Quiesce every registered device, in registration order. Returns the number
+ * that quiesced successfully; a driver whose quiesce returns nonzero is counted
+ * as failed but does not stop the others (best effort to reach a safe boundary). */
+int      checkpoint_driver_quiesce_all(checkpoint_driver_registry_t* r);
+
+/* Reattach every registered device, in registration order.
+ *  - CONTINUE: attempt all; a failed reattach marks that entry severed; returns
+ *    the number reattached successfully.
+ *  - ABORT: stop at the first failure and return CHECKPOINT_DRIVER_ABORTED
+ *    (the caller cold-boots); otherwise returns the number reattached. */
+int      checkpoint_driver_reattach_all(checkpoint_driver_registry_t* r,
+                                        checkpoint_reattach_mode_t mode);
+
+/* Was this entry severed by a failed reattach? */
+bool     checkpoint_driver_is_severed(const checkpoint_driver_registry_t* r, uint32_t index);
+
+/* Process-wide registry that real drivers register into at boot; the barrier
+ * and restore path drive it in #147. */
+checkpoint_driver_registry_t* checkpoint_driver_global(void);
+
+#endif /* CHECKPOINT_DRIVER_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -49,7 +49,7 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c \
             checkpoint_proctable.c checkpoint_proctable_sync.c \
             checkpoint_filetable.c checkpoint_filetable_sync.c \
-            checkpoint_ipc.c checkpoint_ipc_sync.c
+            checkpoint_ipc.c checkpoint_ipc_sync.c checkpoint_driver.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_driver.c
+++ b/kernel/checkpoint_driver.c
@@ -1,0 +1,100 @@
+/* IKOS Orthogonal Persistence v2 - Driver re-attach framework (#143)
+ *
+ * Pure ordering engine + registry. No kernel deps. See
+ * include/checkpoint_driver.h.
+ */
+
+#include "checkpoint_driver.h"
+
+void checkpoint_driver_registry_init(checkpoint_driver_registry_t* r) {
+    if (!r) {
+        return;
+    }
+    r->count = 0;
+    for (uint32_t i = 0; i < CHECKPOINT_DRIVER_MAX; i++) {
+        r->entries[i].dev = 0;
+        r->entries[i].ops.quiesce = 0;
+        r->entries[i].ops.reattach = 0;
+        r->entries[i].ops.persistable = false;
+        r->entries[i].severed = false;
+    }
+}
+
+int checkpoint_driver_register(checkpoint_driver_registry_t* r,
+                               void* dev, const checkpoint_persist_ops_t* ops) {
+    if (!r || !ops || r->count >= CHECKPOINT_DRIVER_MAX) {
+        return -1;
+    }
+    checkpoint_driver_entry_t* e = &r->entries[r->count++];
+    e->dev = dev;
+    e->ops = *ops;
+    e->severed = false;
+    return 0;
+}
+
+uint32_t checkpoint_driver_count(const checkpoint_driver_registry_t* r) {
+    return r ? r->count : 0;
+}
+
+int checkpoint_driver_quiesce_all(checkpoint_driver_registry_t* r) {
+    if (!r) {
+        return 0;
+    }
+    int ok = 0;
+    for (uint32_t i = 0; i < r->count; i++) {
+        checkpoint_persist_ops_t* o = &r->entries[i].ops;
+        if (!o->quiesce) {
+            ok++; /* nothing to do counts as success */
+            continue;
+        }
+        if (o->quiesce(r->entries[i].dev) == 0) {
+            ok++;
+        }
+        /* A failed quiesce does not stop the others: we still try to reach a
+         * safe boundary for the rest. */
+    }
+    return ok;
+}
+
+int checkpoint_driver_reattach_all(checkpoint_driver_registry_t* r,
+                                   checkpoint_reattach_mode_t mode) {
+    if (!r) {
+        return 0;
+    }
+    int reattached = 0;
+    for (uint32_t i = 0; i < r->count; i++) {
+        checkpoint_driver_entry_t* e = &r->entries[i];
+        e->severed = false;
+
+        int rc = e->ops.reattach ? e->ops.reattach(e->dev) : 0;
+        if (rc == 0) {
+            reattached++;
+            continue;
+        }
+
+        if (mode == CHECKPOINT_REATTACH_ABORT) {
+            return CHECKPOINT_DRIVER_ABORTED; /* remaining devices not attempted */
+        }
+        /* CONTINUE: sever this device and keep going. */
+        e->severed = true;
+        e->ops.persistable = false;
+    }
+    return reattached;
+}
+
+bool checkpoint_driver_is_severed(const checkpoint_driver_registry_t* r, uint32_t index) {
+    if (!r || index >= r->count) {
+        return false;
+    }
+    return r->entries[index].severed;
+}
+
+checkpoint_driver_registry_t* checkpoint_driver_global(void) {
+    static checkpoint_driver_registry_t g_registry;
+    static bool initialized = false;
+    if (!initialized) {
+        checkpoint_driver_registry_init(&g_registry);
+        initialized = true;
+    }
+    return &g_registry;
+}

--- a/tests/test_checkpoint_driver.c
+++ b/tests/test_checkpoint_driver.c
@@ -1,0 +1,115 @@
+/* Host-side test for the driver re-attach framework (#143).
+ *
+ * Pure ordering engine, no kernel deps. Verifies quiesce/reattach run in
+ * registration order, the ABORT vs CONTINUE failure policy, severing on a
+ * failed CONTINUE reattach, NULL-op handling, and registry bounds.
+ *
+ * Build: gcc -I../include -o test_checkpoint_driver test_checkpoint_driver.c \
+ *            ../kernel/checkpoint_driver.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "checkpoint_driver.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock driver instrumentation. dev points at an int id. */
+static int g_order[16];
+static int g_order_n;
+static int g_quiesce_calls;
+static int g_reattach_calls;
+static int g_fail_reattach_id = -1;
+
+static void reset(void) { g_order_n = 0; g_quiesce_calls = 0; g_reattach_calls = 0; }
+
+static int mock_quiesce(void* dev) {
+    g_order[g_order_n++] = *(int*)dev; g_quiesce_calls++; return 0;
+}
+static int mock_reattach(void* dev) {
+    int id = *(int*)dev;
+    g_order[g_order_n++] = id; g_reattach_calls++;
+    return (id == g_fail_reattach_id) ? -1 : 0;
+}
+
+int main(void) {
+    int ids[4] = {0, 1, 2, 3};
+    checkpoint_persist_ops_t ops = { mock_quiesce, mock_reattach, true };
+
+    /* === registration + order === */
+    printf("Test 1: register + quiesce order\n");
+    checkpoint_driver_registry_t r;
+    checkpoint_driver_registry_init(&r);
+    CHECK(checkpoint_driver_register(&r, &ids[0], &ops) == 0, "register 0");
+    CHECK(checkpoint_driver_register(&r, &ids[1], &ops) == 0, "register 1");
+    CHECK(checkpoint_driver_register(&r, &ids[2], &ops) == 0, "register 2");
+    CHECK(checkpoint_driver_count(&r) == 3, "count is 3");
+    CHECK(checkpoint_driver_register(&r, 0, 0) == -1, "NULL ops rejected");
+
+    reset();
+    CHECK(checkpoint_driver_quiesce_all(&r) == 3, "all 3 quiesced");
+    CHECK(g_order[0] == 0 && g_order[1] == 1 && g_order[2] == 2, "quiesced in registration order");
+
+    /* === reattach: all succeed === */
+    printf("Test 2: reattach all ok\n");
+    reset(); g_fail_reattach_id = -1;
+    CHECK(checkpoint_driver_reattach_all(&r, CHECKPOINT_REATTACH_CONTINUE) == 3, "3 reattached");
+    CHECK(g_reattach_calls == 3, "all attempted");
+    CHECK(!checkpoint_driver_is_severed(&r, 0) && !checkpoint_driver_is_severed(&r, 1)
+          && !checkpoint_driver_is_severed(&r, 2), "none severed");
+
+    /* === CONTINUE: a failure severs that device, others proceed === */
+    printf("Test 3: CONTINUE severs the failed one\n");
+    reset(); g_fail_reattach_id = 1;
+    int n = checkpoint_driver_reattach_all(&r, CHECKPOINT_REATTACH_CONTINUE);
+    CHECK(n == 2, "2 reattached, 1 severed");
+    CHECK(g_reattach_calls == 3, "all 3 attempted despite the failure");
+    CHECK(checkpoint_driver_is_severed(&r, 1), "device 1 severed");
+    CHECK(!checkpoint_driver_is_severed(&r, 0) && !checkpoint_driver_is_severed(&r, 2),
+          "devices 0 and 2 not severed");
+
+    /* === ABORT: first failure stops the rest === */
+    printf("Test 4: ABORT stops at the first failure\n");
+    checkpoint_driver_registry_init(&r);
+    checkpoint_driver_register(&r, &ids[0], &ops);
+    checkpoint_driver_register(&r, &ids[1], &ops);
+    checkpoint_driver_register(&r, &ids[2], &ops);
+    reset(); g_fail_reattach_id = 1;
+    CHECK(checkpoint_driver_reattach_all(&r, CHECKPOINT_REATTACH_ABORT) == CHECKPOINT_DRIVER_ABORTED,
+          "reattach aborts");
+    CHECK(g_reattach_calls == 2, "device 2 was not attempted after the abort");
+    CHECK(g_order[0] == 0 && g_order[1] == 1, "attempted 0 then 1, then stopped");
+
+    /* === NULL ops are no-op successes === */
+    printf("Test 5: NULL quiesce/reattach\n");
+    checkpoint_driver_registry_init(&r);
+    checkpoint_persist_ops_t noop = { 0, 0, true };
+    checkpoint_driver_register(&r, &ids[0], &noop);
+    reset();
+    CHECK(checkpoint_driver_quiesce_all(&r) == 1, "NULL quiesce counts as success");
+    CHECK(checkpoint_driver_reattach_all(&r, CHECKPOINT_REATTACH_ABORT) == 1,
+          "NULL reattach counts as reattached");
+
+    /* === bounds === */
+    printf("Test 6: registry full\n");
+    checkpoint_driver_registry_init(&r);
+    int full_ok = 1;
+    for (uint32_t i = 0; i < CHECKPOINT_DRIVER_MAX; i++) {
+        if (checkpoint_driver_register(&r, &ids[0], &ops) != 0) full_ok = 0;
+    }
+    CHECK(full_ok, "register up to MAX succeeds");
+    CHECK(checkpoint_driver_register(&r, &ids[0], &ops) == -1, "one past MAX rejected");
+
+    /* === global singleton exists === */
+    CHECK(checkpoint_driver_global() != 0, "global registry available");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Device-register state is meaningless after a power cut. Each driver must declare how to quiesce its hardware before a checkpoint and how to re-initialize and reconcile it on restore. This adds the contract and the pure ordering engine from `docs/architecture/orthogonal-persistence-v2.md` section 4.

Closes #143.

## Design

`include/checkpoint_driver.h` defines the per-driver persistence contract:

```c
typedef struct {
    int  (*quiesce)(void* dev);   /* reach a safe boundary before checkpoint */
    int  (*reattach)(void* dev);  /* re-init hardware on restore, reconcile */
    bool persistable;             /* false: connections are severed */
} checkpoint_persist_ops_t;
```

The device is an opaque `void*`, so the core stays decoupled from `device_manager` and remains a pure, host-testable ordering engine like the checkpoint barrier (#138). Real drivers register their ops in the follow-up issues (#144 disk, #145 framebuffer).

## Ordering engine (`kernel/checkpoint_driver.c`)

- `quiesce_all` runs every registered `quiesce` in registration order. A failing quiesce is counted as failed but does not stop the others, so the rest still reach a safe boundary.
- `reattach_all` runs in registration order under two policies:
  - `ABORT`: stop at the first failure and return `CHECKPOINT_DRIVER_ABORTED` so the caller cold-boots.
  - `CONTINUE`: attempt them all, sever any that fail (marking them non-persistable), and return the number reattached.
- `checkpoint_driver_global()` returns a lazily-initialized process-wide registry that real drivers register into at boot.

NULL `quiesce`/`reattach` are treated as no-op successes.

## Testing

`tests/test_checkpoint_driver.c` covers registration order, quiesce ordering, both reattach failure policies, severing under CONTINUE, the ABORT stop point, NULL ops, and registry bounds. All pass. The module compiles clean freestanding and the end-to-end persistence demo still passes.

Wired into `kernel/Makefile` and the persistence CI workflow (freestanding compile plus the host test).