### PR TITLE
IDE disk driver re-attach for orthogonal persistence (#144)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -50,6 +50,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_file   test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c && /tmp/t_file
           gcc -I../include -Wall -o /tmp/t_ipc    test_checkpoint_ipc.c       ../kernel/checkpoint_ipc.c && /tmp/t_ipc
           gcc -I../include -Wall -o /tmp/t_drv    test_checkpoint_driver.c    ../kernel/checkpoint_driver.c && /tmp/t_drv
+          gcc -I../include -Wall -o /tmp/t_disk   test_checkpoint_disk.c      ../kernel/checkpoint_disk.c && /tmp/t_disk
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_disk.h
+++ b/include/checkpoint_disk.h
@@ -1,0 +1,61 @@
+/* IKOS Orthogonal Persistence v2 - Disk (IDE) driver re-attach (#144)
+ *
+ * Implements the re-attach contract (#143) for the IDE disk that backs the
+ * checkpoint store, per orthogonal-persistence-v2.md section 4:
+ *   - quiesce: flush the drive's write cache so the store reaches a durable
+ *     boundary before a checkpoint is committed;
+ *   - reattach: after a restore, re-probe the drive, then confirm the
+ *     checkpoint-store region is readable and carries the store superblock
+ *     magic, so we know the disk that came back is the one we checkpointed on.
+ *
+ * The hardware operations are injected through a small vtable so the reconcile
+ * logic is a pure, host-testable core (like the barrier in #138 and the driver
+ * registry in #143). The kernel adapter (checkpoint_disk_sync.c) wires the real
+ * ide_driver.c calls in and registers the drive into the global registry.
+ */
+
+#ifndef CHECKPOINT_DISK_H
+#define CHECKPOINT_DISK_H
+
+#include <stdint.h>
+
+/* Magic at offset 0 of the checkpoint-store superblock sector. Mirrors
+ * SNAPSHOT_SB_MAGIC ("IKOSSNBP") in snapshot_store.h, duplicated here so this
+ * reconcile core stays dependency-free and host-testable. */
+#define CHECKPOINT_DISK_SB_MAGIC 0x494B4F53534E4250ULL
+
+#define CHECKPOINT_DISK_OK           0
+#define CHECKPOINT_DISK_ERR_PARAM   -1
+#define CHECKPOINT_DISK_ERR_FLUSH   -2   /* quiesce: cache flush failed */
+#define CHECKPOINT_DISK_ERR_REPROBE -3   /* reattach: drive re-probe failed */
+#define CHECKPOINT_DISK_ERR_READ    -4   /* reattach: store region unreadable */
+#define CHECKPOINT_DISK_ERR_MAGIC   -5   /* reattach: store superblock magic wrong */
+
+/* Hardware operations for one IDE drive, injected so the reconcile logic can be
+ * tested against a mock disk. Each returns 0 on success. read_sector fills a
+ * 512-byte buffer with the sector at the given LBA. */
+typedef struct {
+    int (*flush)(void* ctx);                             /* flush write cache */
+    int (*reprobe)(void* ctx);                           /* re-identify drive(s) */
+    int (*read_sector)(void* ctx, uint64_t lba, void* buf512);
+    void*    ctx;
+    uint64_t store_lba;   /* sector of the checkpoint-store superblock */
+} checkpoint_disk_ops_t;
+
+/* Reach a durable boundary before a checkpoint: flush the write cache. */
+int checkpoint_disk_quiesce(const checkpoint_disk_ops_t* ops);
+
+/* After a restore: re-probe the drive, then confirm the checkpoint-store region
+ * is readable and its superblock carries CHECKPOINT_DISK_SB_MAGIC. */
+int checkpoint_disk_reattach(const checkpoint_disk_ops_t* ops);
+
+/* Little-endian u64 read of the first 8 bytes of a sector buffer. */
+uint64_t checkpoint_disk_read_magic(const void* buf512);
+
+/* Kernel adapter (checkpoint_disk_sync.c): bind the boot IDE drive backing the
+ * checkpoint store and register its persist_ops (#143) into the global driver
+ * registry. ide is an ide_device_t* (opaque here). Returns 0, or -1 on bad
+ * arguments or a full registry. */
+int checkpoint_disk_register(void* ide, uint8_t drive, uint64_t store_lba);
+
+#endif /* CHECKPOINT_DISK_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -49,7 +49,8 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             ramdisk.c snapshot_store.c checkpoint.c checkpoint_extstate.c checkpoint_ide.c checkpoint_barrier.c \
             checkpoint_proctable.c checkpoint_proctable_sync.c \
             checkpoint_filetable.c checkpoint_filetable_sync.c \
-            checkpoint_ipc.c checkpoint_ipc_sync.c checkpoint_driver.c
+            checkpoint_ipc.c checkpoint_ipc_sync.c checkpoint_driver.c \
+            checkpoint_disk.c checkpoint_disk_sync.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_disk.c
+++ b/kernel/checkpoint_disk.c
@@ -1,0 +1,47 @@
+/* IKOS Orthogonal Persistence v2 - Disk (IDE) driver re-attach (#144)
+ *
+ * Pure reconcile core. No kernel deps. See include/checkpoint_disk.h.
+ */
+
+#include "checkpoint_disk.h"
+
+uint64_t checkpoint_disk_read_magic(const void* buf512) {
+    const unsigned char* b = (const unsigned char*)buf512;
+    uint64_t m = 0;
+    for (int i = 7; i >= 0; i--) {
+        m = (m << 8) | (uint64_t)b[i];
+    }
+    return m;
+}
+
+int checkpoint_disk_quiesce(const checkpoint_disk_ops_t* ops) {
+    if (!ops) {
+        return CHECKPOINT_DISK_ERR_PARAM;
+    }
+    /* Nothing to flush is fine; a real flush that fails is not. */
+    if (ops->flush && ops->flush(ops->ctx) != 0) {
+        return CHECKPOINT_DISK_ERR_FLUSH;
+    }
+    return CHECKPOINT_DISK_OK;
+}
+
+int checkpoint_disk_reattach(const checkpoint_disk_ops_t* ops) {
+    if (!ops || !ops->read_sector) {
+        return CHECKPOINT_DISK_ERR_PARAM;
+    }
+    /* Re-probe first: the controller and drive registers are meaningless after
+     * a power cut, so re-identify before trusting any read. */
+    if (ops->reprobe && ops->reprobe(ops->ctx) != 0) {
+        return CHECKPOINT_DISK_ERR_REPROBE;
+    }
+    unsigned char sector[512];
+    if (ops->read_sector(ops->ctx, ops->store_lba, sector) != 0) {
+        return CHECKPOINT_DISK_ERR_READ;
+    }
+    /* The store region is only trustworthy if the superblock magic is intact:
+     * confirms we re-attached the disk we actually checkpointed on. */
+    if (checkpoint_disk_read_magic(sector) != CHECKPOINT_DISK_SB_MAGIC) {
+        return CHECKPOINT_DISK_ERR_MAGIC;
+    }
+    return CHECKPOINT_DISK_OK;
+}

--- a/kernel/checkpoint_disk_sync.c
+++ b/kernel/checkpoint_disk_sync.c
@@ -1,0 +1,72 @@
+/* IKOS Orthogonal Persistence v2 - Disk (IDE) driver re-attach adapter (#144)
+ *
+ * Wires the pure reconcile core (checkpoint_disk.c) to the real IDE driver and
+ * registers the boot drive that backs the checkpoint store into the global
+ * driver registry (#143). Compile-checked freestanding; exercised in QEMU.
+ */
+
+#include "checkpoint_disk.h"
+#include "checkpoint_driver.h"
+#include "ide_driver.h"
+
+/* Binding for the one IDE drive that holds the checkpoint store. */
+typedef struct {
+    ide_device_t* ide;
+    uint8_t       drive;
+    uint64_t      store_lba;
+} checkpoint_disk_dev_t;
+
+static int disk_flush(void* ctx) {
+    checkpoint_disk_dev_t* d = (checkpoint_disk_dev_t*)ctx;
+    return ide_flush_cache(d->ide, d->drive);
+}
+
+static int disk_reprobe(void* ctx) {
+    checkpoint_disk_dev_t* d = (checkpoint_disk_dev_t*)ctx;
+    return ide_identify_drives(d->ide);
+}
+
+static int disk_read_sector(void* ctx, uint64_t lba, void* buf512) {
+    checkpoint_disk_dev_t* d = (checkpoint_disk_dev_t*)ctx;
+    return ide_read_sectors(d->ide, d->drive, lba, 1, buf512);
+}
+
+static checkpoint_disk_ops_t disk_ops_for(checkpoint_disk_dev_t* d) {
+    checkpoint_disk_ops_t o;
+    o.flush       = disk_flush;
+    o.reprobe     = disk_reprobe;
+    o.read_sector = disk_read_sector;
+    o.ctx         = d;
+    o.store_lba   = d->store_lba;
+    return o;
+}
+
+/* persist_ops (#143) thunks: rebuild the ops vtable and call the pure core. */
+static int disk_persist_quiesce(void* dev) {
+    checkpoint_disk_dev_t* d = (checkpoint_disk_dev_t*)dev;
+    checkpoint_disk_ops_t o = disk_ops_for(d);
+    return checkpoint_disk_quiesce(&o);
+}
+
+static int disk_persist_reattach(void* dev) {
+    checkpoint_disk_dev_t* d = (checkpoint_disk_dev_t*)dev;
+    checkpoint_disk_ops_t o = disk_ops_for(d);
+    return checkpoint_disk_reattach(&o);
+}
+
+/* One static binding: the checkpoint store lives on a single boot drive. */
+static checkpoint_disk_dev_t g_disk_dev;
+
+int checkpoint_disk_register(void* ide, uint8_t drive, uint64_t store_lba) {
+    if (!ide) {
+        return -1;
+    }
+    g_disk_dev.ide       = (ide_device_t*)ide;
+    g_disk_dev.drive     = drive;
+    g_disk_dev.store_lba = store_lba;
+
+    static const checkpoint_persist_ops_t ops = {
+        disk_persist_quiesce, disk_persist_reattach, true
+    };
+    return checkpoint_driver_register(checkpoint_driver_global(), &g_disk_dev, &ops);
+}

--- a/tests/test_checkpoint_disk.c
+++ b/tests/test_checkpoint_disk.c
@@ -1,0 +1,108 @@
+/* Host-side test for the disk (IDE) re-attach reconcile core (#144).
+ *
+ * Pure logic, no kernel deps. Drives checkpoint_disk_quiesce/reattach against a
+ * mock disk: verifies the flush-on-quiesce path, the reprobe-then-verify order
+ * on reattach, and each failure mode (flush, reprobe, read, bad magic).
+ *
+ * Build: gcc -I../include -o test_checkpoint_disk test_checkpoint_disk.c \
+ *            ../kernel/checkpoint_disk.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "checkpoint_disk.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock disk. sector[] models the store superblock sector; the *_fail flags
+ * force each op to error; counters record call order. */
+static unsigned char g_sector[512];
+static uint64_t      g_store_lba = 2048;
+static int g_flush_calls, g_reprobe_calls, g_read_calls;
+static uint64_t g_last_read_lba;
+static int g_flush_fail, g_reprobe_fail, g_read_fail;
+
+static void mock_reset(void) {
+    g_flush_calls = g_reprobe_calls = g_read_calls = 0;
+    g_last_read_lba = 0;
+    g_flush_fail = g_reprobe_fail = g_read_fail = 0;
+    /* Default: a valid store superblock (magic in the first 8 bytes, LE). */
+    for (int i = 0; i < 512; i++) g_sector[i] = 0;
+    for (int i = 0; i < 8; i++)
+        g_sector[i] = (unsigned char)((CHECKPOINT_DISK_SB_MAGIC >> (8 * i)) & 0xFF);
+}
+
+static int mock_flush(void* ctx) { (void)ctx; g_flush_calls++; return g_flush_fail ? -1 : 0; }
+static int mock_reprobe(void* ctx) { (void)ctx; g_reprobe_calls++; return g_reprobe_fail ? -1 : 0; }
+static int mock_read(void* ctx, uint64_t lba, void* buf) {
+    (void)ctx;
+    g_read_calls++; g_last_read_lba = lba;
+    if (g_read_fail) return -1;
+    unsigned char* b = (unsigned char*)buf;
+    for (int i = 0; i < 512; i++) b[i] = g_sector[i];
+    return 0;
+}
+
+static checkpoint_disk_ops_t make_ops(void) {
+    checkpoint_disk_ops_t o;
+    o.flush = mock_flush; o.reprobe = mock_reprobe; o.read_sector = mock_read;
+    o.ctx = 0; o.store_lba = g_store_lba;
+    return o;
+}
+
+int main(void) {
+    checkpoint_disk_ops_t o;
+
+    printf("Test 1: read_magic is little-endian\n");
+    mock_reset();
+    CHECK(checkpoint_disk_read_magic(g_sector) == CHECKPOINT_DISK_SB_MAGIC, "decodes store magic");
+
+    printf("Test 2: quiesce flushes\n");
+    mock_reset(); o = make_ops();
+    CHECK(checkpoint_disk_quiesce(&o) == CHECKPOINT_DISK_OK, "quiesce ok");
+    CHECK(g_flush_calls == 1, "flush called once");
+
+    printf("Test 3: quiesce flush failure\n");
+    mock_reset(); g_flush_fail = 1; o = make_ops();
+    CHECK(checkpoint_disk_quiesce(&o) == CHECKPOINT_DISK_ERR_FLUSH, "flush failure reported");
+
+    printf("Test 4: reattach re-probes then verifies the store\n");
+    mock_reset(); o = make_ops();
+    CHECK(checkpoint_disk_reattach(&o) == CHECKPOINT_DISK_OK, "reattach ok");
+    CHECK(g_reprobe_calls == 1, "reprobed once");
+    CHECK(g_read_calls == 1, "read the store sector once");
+    CHECK(g_last_read_lba == g_store_lba, "read at the store LBA");
+
+    printf("Test 5: reprobe failure stops before any read\n");
+    mock_reset(); g_reprobe_fail = 1; o = make_ops();
+    CHECK(checkpoint_disk_reattach(&o) == CHECKPOINT_DISK_ERR_REPROBE, "reprobe failure reported");
+    CHECK(g_read_calls == 0, "store not read after a failed reprobe");
+
+    printf("Test 6: unreadable store region\n");
+    mock_reset(); g_read_fail = 1; o = make_ops();
+    CHECK(checkpoint_disk_reattach(&o) == CHECKPOINT_DISK_ERR_READ, "read failure reported");
+
+    printf("Test 7: wrong superblock magic\n");
+    mock_reset(); g_sector[0] ^= 0xFF; o = make_ops();
+    CHECK(checkpoint_disk_reattach(&o) == CHECKPOINT_DISK_ERR_MAGIC, "bad magic rejected");
+
+    printf("Test 8: NULL args\n");
+    CHECK(checkpoint_disk_quiesce(0) == CHECKPOINT_DISK_ERR_PARAM, "NULL quiesce rejected");
+    CHECK(checkpoint_disk_reattach(0) == CHECKPOINT_DISK_ERR_PARAM, "NULL reattach rejected");
+    o = make_ops(); o.read_sector = 0;
+    CHECK(checkpoint_disk_reattach(&o) == CHECKPOINT_DISK_ERR_PARAM, "reattach needs read_sector");
+
+    printf("Test 9: NULL flush is a no-op success\n");
+    mock_reset(); o = make_ops(); o.flush = 0;
+    CHECK(checkpoint_disk_quiesce(&o) == CHECKPOINT_DISK_OK, "no flush op still ok");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Implements the re-attach contract (#143) for the IDE disk that backs the checkpoint store, per `docs/architecture/orthogonal-persistence-v2.md` section 4, so the store and any mounted filesystems come back consistently after a restore.

Closes #144.

## Why

The IDE controller and drive registers are meaningless after a power cut. The store itself is already crash-consistent (v1) and the `checkpoint_ide` adapter (#130) is the durable backing; this issue makes the hardware come back consistently around it.

- **quiesce**: flush the drive's write cache (`ide_flush_cache`) so the store reaches a durable boundary before a checkpoint is committed.
- **reattach**: re-probe the drive (`ide_identify_drives`), then confirm the checkpoint-store region is readable and its superblock still carries the store magic, proving we re-attached the disk we actually checkpointed on before trusting it.

## Structure

The usual pure-core plus kernel-adapter pair:

- `kernel/checkpoint_disk.c` is a dependency-free reconcile core driven by an injected hardware vtable (`flush` / `reprobe` / `read_sector`), so every path and failure mode is host-testable against a mock disk.
- `kernel/checkpoint_disk_sync.c` wires the real `ide_driver.c` calls into a `persist_ops` entry (#143) and registers the boot drive into the global driver registry. The QEMU reconcile itself is compile-checked freestanding here.

## Testing

`tests/test_checkpoint_disk.c` covers the flush-on-quiesce path, the reprobe-then-verify ordering on reattach, and each failure mode (flush, reprobe, read, bad magic), plus NULL-arg handling. All 18 checks pass. Both modules compile clean freestanding and the end-to-end persistence demo still passes.

Wired into `kernel/Makefile` and the persistence CI workflow (freestanding compile plus the host test).

Depends on #143 (re-attach framework, merged) and #130 (checkpoint_ide). In-QEMU validation of the live re-probe path is follow-up under the boot-ordering capstone (#147).