### PR TITLE
Framebuffer re-attach and repaint for orthogonal persistence (#145)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -51,6 +51,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_ipc    test_checkpoint_ipc.c       ../kernel/checkpoint_ipc.c && /tmp/t_ipc
           gcc -I../include -Wall -o /tmp/t_drv    test_checkpoint_driver.c    ../kernel/checkpoint_driver.c && /tmp/t_drv
           gcc -I../include -Wall -o /tmp/t_disk   test_checkpoint_disk.c      ../kernel/checkpoint_disk.c && /tmp/t_disk
+          gcc -I../include -Wall -o /tmp/t_fb     test_checkpoint_fb.c        ../kernel/checkpoint_fb.c && /tmp/t_fb
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint_fb.h
+++ b/include/checkpoint_fb.h
@@ -1,0 +1,91 @@
+/* IKOS Orthogonal Persistence v2 - Framebuffer re-attach + repaint (#145)
+ *
+ * The headline whole-machine moment: on restore, re-initialize the video mode
+ * and repaint the screen from the persisted pixel buffer, so the desktop comes
+ * back exactly as it was before the power cut (orthogonal-persistence-v2.md
+ * section 4).
+ *
+ * Video memory (the MMIO aperture at fb_info.buffer) is a hardware region and is
+ * NOT persisted. Instead a plain-RAM shadow of the pixels is captured into the
+ * checkpoint as kernel state (#139/#140) alongside the framebuffer geometry.
+ * On restore this core re-programs the mode from the saved geometry and blits
+ * the persisted shadow back into the freshly re-initialized video memory.
+ *
+ * The mode-set and blit are injected through a vtable so the reconcile logic is
+ * a pure, host-testable core. The kernel adapter (checkpoint_fb_sync.c) wires
+ * the real framebuffer.c calls in, captures the shadow, and registers the
+ * display into the global driver registry (#143).
+ */
+
+#ifndef CHECKPOINT_FB_H
+#define CHECKPOINT_FB_H
+
+#include <stdint.h>
+
+/* Kernel-blob tags (see checkpoint_capture_kernel_blob, #139). 1..3 are taken
+ * by the proc/file/ipc tables; the framebuffer uses 4 (geometry) and 5 (pixels). */
+#define CHECKPOINT_TAG_FRAMEBUFFER        4
+#define CHECKPOINT_TAG_FRAMEBUFFER_PIXELS 5
+
+#define CHECKPOINT_FB_OK          0
+#define CHECKPOINT_FB_ERR_PARAM  -1
+#define CHECKPOINT_FB_ERR_STATE  -2   /* saved geometry is inconsistent */
+#define CHECKPOINT_FB_ERR_MODE   -3   /* re-init of the video mode failed */
+#define CHECKPOINT_FB_ERR_BLIT   -4   /* repaint into video memory failed */
+
+/* Portable framebuffer geometry captured at checkpoint time and persisted as a
+ * kernel-state blob. `size` must equal pitch * height and bounds the shadow. */
+typedef struct {
+    uint32_t width;
+    uint32_t height;
+    uint32_t bpp;
+    uint32_t pitch;    /* bytes per scanline */
+    uint32_t size;     /* total pixel bytes = pitch * height */
+    uint32_t mode;     /* fb_mode_t value to restore */
+    uint32_t valid;    /* nonzero once a checkpoint captured a framebuffer */
+    uint32_t reserved;
+} checkpoint_fb_state_t;
+
+/* Hardware operations, injected so the reconcile logic is host-testable.
+ * Each returns 0 on success. */
+typedef struct {
+    int (*set_mode)(void* ctx, uint32_t mode,
+                    uint32_t width, uint32_t height, uint32_t bpp);
+    int (*blit)(void* ctx, const void* pixels, uint32_t bytes); /* shadow -> video */
+    void* ctx;
+} checkpoint_fb_ops_t;
+
+/* Fill *st from framebuffer geometry, marking it valid. Returns
+ * CHECKPOINT_FB_OK, or CHECKPOINT_FB_ERR_PARAM / _STATE on bad geometry. */
+int checkpoint_fb_capture_state(checkpoint_fb_state_t* st,
+                                uint32_t mode, uint32_t width, uint32_t height,
+                                uint32_t bpp, uint32_t pitch, uint32_t size);
+
+/* Validate a (deserialized) geometry blob: size == pitch*height, all nonzero. */
+int checkpoint_fb_validate(const checkpoint_fb_state_t* st);
+
+/* quiesce: the pixel buffer is plain memory persisted with kernel state, so
+ * there is nothing in flight to stop. Always succeeds (kept for symmetry). */
+int checkpoint_fb_quiesce(void);
+
+/* reattach: re-init the video mode from *st, then blit the persisted `shadow`
+ * (st->size bytes) into video memory via ops. An invalid/absent capture is a
+ * no-op success (nothing was persisted to repaint). */
+int checkpoint_fb_reattach(const checkpoint_fb_state_t* st,
+                           const void* shadow,
+                           const checkpoint_fb_ops_t* ops);
+
+/* Kernel adapter (checkpoint_fb_sync.c): capture the current framebuffer
+ * geometry + pixel shadow into the checkpoint, and register the display's
+ * persist_ops (#143) into the global driver registry. Return 0, or negative. */
+int checkpoint_fb_capture(void);
+int checkpoint_fb_register(void);
+
+/* Restore path (driven by #147): hand the reassembled kernel blobs back to the
+ * adapter so the registered reattach can repaint. checkpoint_fb_restore_state
+ * deserializes the geometry blob; checkpoint_fb_restore_pixels caches the
+ * persisted pixel shadow the reattach will blit. Return 0, or negative. */
+int checkpoint_fb_restore_state(const void* blob, uint32_t size);
+int checkpoint_fb_restore_pixels(const void* pixels, uint32_t size);
+
+#endif /* CHECKPOINT_FB_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -50,7 +50,8 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             checkpoint_proctable.c checkpoint_proctable_sync.c \
             checkpoint_filetable.c checkpoint_filetable_sync.c \
             checkpoint_ipc.c checkpoint_ipc_sync.c checkpoint_driver.c \
-            checkpoint_disk.c checkpoint_disk_sync.c
+            checkpoint_disk.c checkpoint_disk_sync.c \
+            checkpoint_fb.c checkpoint_fb_sync.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_fb.c
+++ b/kernel/checkpoint_fb.c
@@ -1,0 +1,76 @@
+/* IKOS Orthogonal Persistence v2 - Framebuffer re-attach + repaint (#145)
+ *
+ * Pure reconcile core. No kernel deps. See include/checkpoint_fb.h.
+ */
+
+#include "checkpoint_fb.h"
+
+int checkpoint_fb_validate(const checkpoint_fb_state_t* st) {
+    if (!st) {
+        return CHECKPOINT_FB_ERR_PARAM;
+    }
+    if (!st->valid) {
+        /* No framebuffer was captured; not an error, just nothing to repaint. */
+        return CHECKPOINT_FB_OK;
+    }
+    if (st->width == 0 || st->height == 0 || st->bpp == 0 ||
+        st->pitch == 0 || st->size == 0) {
+        return CHECKPOINT_FB_ERR_STATE;
+    }
+    if (st->size != st->pitch * st->height) {
+        return CHECKPOINT_FB_ERR_STATE;
+    }
+    return CHECKPOINT_FB_OK;
+}
+
+int checkpoint_fb_capture_state(checkpoint_fb_state_t* st,
+                                uint32_t mode, uint32_t width, uint32_t height,
+                                uint32_t bpp, uint32_t pitch, uint32_t size) {
+    if (!st) {
+        return CHECKPOINT_FB_ERR_PARAM;
+    }
+    st->width    = width;
+    st->height   = height;
+    st->bpp      = bpp;
+    st->pitch    = pitch;
+    st->size     = size;
+    st->mode     = mode;
+    st->valid    = 1;
+    st->reserved = 0;
+    return checkpoint_fb_validate(st);
+}
+
+int checkpoint_fb_quiesce(void) {
+    /* The pixel buffer is plain RAM captured with kernel state; nothing to stop. */
+    return CHECKPOINT_FB_OK;
+}
+
+int checkpoint_fb_reattach(const checkpoint_fb_state_t* st,
+                           const void* shadow,
+                           const checkpoint_fb_ops_t* ops) {
+    if (!st || !ops || !ops->set_mode || !ops->blit) {
+        return CHECKPOINT_FB_ERR_PARAM;
+    }
+    if (!st->valid) {
+        return CHECKPOINT_FB_OK; /* nothing was persisted to repaint */
+    }
+
+    int vc = checkpoint_fb_validate(st);
+    if (vc != CHECKPOINT_FB_OK) {
+        return vc;
+    }
+    if (!shadow) {
+        return CHECKPOINT_FB_ERR_PARAM; /* valid geometry but no pixels to blit */
+    }
+
+    /* Re-program the video mode the display had at checkpoint time. The MMIO
+     * aperture and controller registers are meaningless after a power cut. */
+    if (ops->set_mode(ops->ctx, st->mode, st->width, st->height, st->bpp) != 0) {
+        return CHECKPOINT_FB_ERR_MODE;
+    }
+    /* Repaint: blit the persisted pixel shadow back into fresh video memory. */
+    if (ops->blit(ops->ctx, shadow, st->size) != 0) {
+        return CHECKPOINT_FB_ERR_BLIT;
+    }
+    return CHECKPOINT_FB_OK;
+}

--- a/kernel/checkpoint_fb_sync.c
+++ b/kernel/checkpoint_fb_sync.c
@@ -1,0 +1,121 @@
+/* IKOS Orthogonal Persistence v2 - Framebuffer re-attach adapter (#145)
+ *
+ * Wires the pure repaint core (checkpoint_fb.c) to the real framebuffer driver:
+ * captures the geometry + a plain-RAM shadow of the pixels into the checkpoint
+ * (#139 kernel blobs), and registers the display's persist_ops (#143) so that on
+ * restore the mode is re-programmed and the persisted pixels are blitted back
+ * into fresh video memory. Compile-checked freestanding; the visible repaint is
+ * validated in QEMU (the demo GIF).
+ */
+
+#include "checkpoint_fb.h"
+#include "checkpoint_driver.h"
+#include "checkpoint.h"        /* checkpoint_capture_kernel_blob */
+#include "framebuffer.h"       /* fb_info_t, fb_get_info, fb_set_mode */
+
+/* Saved geometry and the restored pixel shadow used by the reattach thunk. The
+ * capture path fills g_fb_state in-run; the restore path (#147) repopulates both
+ * from the reassembled kernel blobs before the registry drives reattach. */
+static checkpoint_fb_state_t g_fb_state;
+static const void*           g_fb_shadow;
+
+/* Byte copy; the freestanding build has no libc. Screen-sized but only ever runs
+ * once per restore. */
+static void fb_bytecopy(void* dst, const void* src, uint32_t n) {
+    unsigned char* d = (unsigned char*)dst;
+    const unsigned char* s = (const unsigned char*)src;
+    for (uint32_t i = 0; i < n; i++) {
+        d[i] = s[i];
+    }
+}
+
+/* ----- hardware ops for the pure core ----- */
+
+static int fb_do_set_mode(void* ctx, uint32_t mode,
+                          uint32_t width, uint32_t height, uint32_t bpp) {
+    (void)ctx;
+    return fb_set_mode((fb_mode_t)mode, width, height, bpp);
+}
+
+static int fb_do_blit(void* ctx, const void* pixels, uint32_t bytes) {
+    (void)ctx;
+    fb_info_t* info = fb_get_info();
+    if (!info || !info->buffer) {
+        return -1;
+    }
+    fb_bytecopy(info->buffer, pixels, bytes);
+    return 0;
+}
+
+/* ----- persist_ops (#143) thunks ----- */
+
+static int fb_persist_quiesce(void* dev) {
+    (void)dev;
+    return checkpoint_fb_quiesce();
+}
+
+static int fb_persist_reattach(void* dev) {
+    (void)dev;
+    checkpoint_fb_ops_t ops;
+    ops.set_mode = fb_do_set_mode;
+    ops.blit     = fb_do_blit;
+    ops.ctx      = 0;
+    return checkpoint_fb_reattach(&g_fb_state, g_fb_shadow, &ops);
+}
+
+/* ----- capture ----- */
+
+int checkpoint_fb_capture(void) {
+    fb_info_t* info = fb_get_info();
+    if (!info || !info->initialized) {
+        return -1;
+    }
+
+    int rc = checkpoint_fb_capture_state(&g_fb_state, (uint32_t)info->mode,
+                                         info->width, info->height, info->bpp,
+                                         info->pitch, info->size);
+    if (rc != CHECKPOINT_FB_OK) {
+        return rc;
+    }
+
+    /* The persisted pixel source is the plain-RAM back buffer when double
+     * buffered; otherwise read straight from the (readable) video aperture. */
+    const void* pixels = info->double_buffered && info->back_buffer
+                       ? info->back_buffer : info->buffer;
+    if (!pixels) {
+        return -1;
+    }
+
+    rc = checkpoint_capture_kernel_blob(CHECKPOINT_TAG_FRAMEBUFFER,
+                                        &g_fb_state, (uint32_t)sizeof(g_fb_state));
+    if (rc != 0) {
+        return rc;
+    }
+    return checkpoint_capture_kernel_blob(CHECKPOINT_TAG_FRAMEBUFFER_PIXELS,
+                                          pixels, g_fb_state.size);
+}
+
+int checkpoint_fb_register(void) {
+    static const checkpoint_persist_ops_t ops = {
+        fb_persist_quiesce, fb_persist_reattach, true
+    };
+    return checkpoint_driver_register(checkpoint_driver_global(), &g_fb_state, &ops);
+}
+
+/* ----- restore (driven by #147) ----- */
+
+int checkpoint_fb_restore_state(const void* blob, uint32_t size) {
+    if (!blob || size != sizeof(g_fb_state)) {
+        return -1;
+    }
+    fb_bytecopy(&g_fb_state, blob, (uint32_t)sizeof(g_fb_state));
+    return checkpoint_fb_validate(&g_fb_state);
+}
+
+int checkpoint_fb_restore_pixels(const void* pixels, uint32_t size) {
+    if (!pixels || size < g_fb_state.size) {
+        return -1;
+    }
+    g_fb_shadow = pixels;
+    return 0;
+}

--- a/tests/test_checkpoint_fb.c
+++ b/tests/test_checkpoint_fb.c
@@ -1,0 +1,120 @@
+/* Host-side test for the framebuffer repaint reconcile core (#145).
+ *
+ * Pure logic, no kernel deps. Verifies geometry capture/validation, the
+ * quiesce no-op, and that reattach re-programs the mode then blits the persisted
+ * pixel shadow into a mock "video memory" so it ends up byte-identical, plus
+ * the failure modes (bad geometry, mode-set failure, blit failure, no capture).
+ *
+ * Build: gcc -I../include -o test_checkpoint_fb test_checkpoint_fb.c \
+ *            ../kernel/checkpoint_fb.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "checkpoint_fb.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock display. video[] models the MMIO aperture the blit repaints into. */
+#define VMEM 4096
+static unsigned char g_video[VMEM];
+static int g_setmode_calls, g_blit_calls;
+static uint32_t g_last_mode, g_last_w, g_last_h, g_last_bpp, g_last_blit_bytes;
+static int g_setmode_fail, g_blit_fail;
+
+static void mock_reset(void) {
+    g_setmode_calls = g_blit_calls = 0;
+    g_last_mode = g_last_w = g_last_h = g_last_bpp = g_last_blit_bytes = 0;
+    g_setmode_fail = g_blit_fail = 0;
+    for (int i = 0; i < VMEM; i++) g_video[i] = 0;
+}
+
+static int mock_set_mode(void* ctx, uint32_t mode, uint32_t w, uint32_t h, uint32_t bpp) {
+    (void)ctx;
+    g_setmode_calls++;
+    g_last_mode = mode; g_last_w = w; g_last_h = h; g_last_bpp = bpp;
+    return g_setmode_fail ? -1 : 0;
+}
+static int mock_blit(void* ctx, const void* pixels, uint32_t bytes) {
+    (void)ctx;
+    g_blit_calls++; g_last_blit_bytes = bytes;
+    if (g_blit_fail) return -1;
+    const unsigned char* s = (const unsigned char*)pixels;
+    for (uint32_t i = 0; i < bytes && i < VMEM; i++) g_video[i] = s[i];
+    return 0;
+}
+
+static checkpoint_fb_ops_t make_ops(void) {
+    checkpoint_fb_ops_t o;
+    o.set_mode = mock_set_mode; o.blit = mock_blit; o.ctx = 0;
+    return o;
+}
+
+int main(void) {
+    /* A small persisted framebuffer: 16 x 8 x 32bpp, pitch 64, size 512. */
+    unsigned char shadow[512];
+    for (int i = 0; i < 512; i++) shadow[i] = (unsigned char)(i * 7 + 3);
+
+    checkpoint_fb_state_t st;
+    checkpoint_fb_ops_t o;
+
+    printf("Test 1: capture + validate geometry\n");
+    CHECK(checkpoint_fb_capture_state(&st, 1, 16, 8, 32, 64, 512) == CHECKPOINT_FB_OK,
+          "capture ok");
+    CHECK(st.valid && st.size == 512 && st.pitch == 64, "fields recorded");
+    CHECK(checkpoint_fb_validate(&st) == CHECKPOINT_FB_OK, "validate ok");
+
+    printf("Test 2: inconsistent geometry rejected\n");
+    checkpoint_fb_state_t bad = st; bad.size = 500; /* != pitch*height */
+    CHECK(checkpoint_fb_validate(&bad) == CHECKPOINT_FB_ERR_STATE, "size mismatch rejected");
+    bad = st; bad.bpp = 0;
+    CHECK(checkpoint_fb_validate(&bad) == CHECKPOINT_FB_ERR_STATE, "zero bpp rejected");
+
+    printf("Test 3: quiesce is a no-op success\n");
+    CHECK(checkpoint_fb_quiesce() == CHECKPOINT_FB_OK, "quiesce ok");
+
+    printf("Test 4: reattach re-programs mode then repaints\n");
+    mock_reset(); o = make_ops();
+    CHECK(checkpoint_fb_reattach(&st, shadow, &o) == CHECKPOINT_FB_OK, "reattach ok");
+    CHECK(g_setmode_calls == 1 && g_blit_calls == 1, "mode set then blit, once each");
+    CHECK(g_last_mode == 1 && g_last_w == 16 && g_last_h == 8 && g_last_bpp == 32,
+          "mode re-programmed from saved geometry");
+    CHECK(g_last_blit_bytes == 512, "blitted the full pixel buffer");
+    int identical = 1;
+    for (int i = 0; i < 512; i++) if (g_video[i] != shadow[i]) identical = 0;
+    CHECK(identical, "video memory now byte-identical to the persisted shadow");
+
+    printf("Test 5: mode-set failure stops before blit\n");
+    mock_reset(); g_setmode_fail = 1; o = make_ops();
+    CHECK(checkpoint_fb_reattach(&st, shadow, &o) == CHECKPOINT_FB_ERR_MODE, "mode failure reported");
+    CHECK(g_blit_calls == 0, "no repaint after a failed mode set");
+
+    printf("Test 6: blit failure reported\n");
+    mock_reset(); g_blit_fail = 1; o = make_ops();
+    CHECK(checkpoint_fb_reattach(&st, shadow, &o) == CHECKPOINT_FB_ERR_BLIT, "blit failure reported");
+
+    printf("Test 7: no capture is a no-op success\n");
+    mock_reset(); o = make_ops();
+    checkpoint_fb_state_t none; none.valid = 0;
+    CHECK(checkpoint_fb_reattach(&none, 0, &o) == CHECKPOINT_FB_OK, "absent capture skipped");
+    CHECK(g_setmode_calls == 0 && g_blit_calls == 0, "nothing touched when nothing persisted");
+
+    printf("Test 8: valid geometry but missing pixels rejected\n");
+    o = make_ops();
+    CHECK(checkpoint_fb_reattach(&st, 0, &o) == CHECKPOINT_FB_ERR_PARAM, "null shadow rejected");
+
+    printf("Test 9: NULL args\n");
+    o = make_ops();
+    CHECK(checkpoint_fb_reattach(0, shadow, &o) == CHECKPOINT_FB_ERR_PARAM, "null state rejected");
+    CHECK(checkpoint_fb_reattach(&st, shadow, 0) == CHECKPOINT_FB_ERR_PARAM, "null ops rejected");
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

The headline whole-machine moment: on restore, re-initialize the video mode and repaint the screen from the persisted pixel buffer, so the desktop comes back exactly as it was before the power cut. Implements the re-attach contract (#143) for the framebuffer per `docs/architecture/orthogonal-persistence-v2.md` section 4.

Closes #145.

## How

Video memory (the MMIO aperture at `fb_info.buffer`) is a hardware region and is not persisted. Instead a plain-RAM shadow of the pixels is captured into the checkpoint as kernel state (#139) alongside the framebuffer geometry. On restore the mode is re-programmed from the saved geometry and the shadow is blitted back into the freshly re-initialized video memory.

- **quiesce**: the pixel buffer is plain memory persisted with kernel state, so there is nothing in flight to stop (no-op success).
- **reattach**: re-init the video mode, then repaint by blitting the persisted shadow into video memory.

## Structure

The usual pure-core plus kernel-adapter pair:

- `kernel/checkpoint_fb.c` is a dependency-free reconcile core. The mode-set and blit are injected through a vtable, so the host test drives a mock display and asserts video memory ends up byte-identical to the persisted shadow, plus every failure mode.
- `kernel/checkpoint_fb_sync.c` wires the real `framebuffer.c` calls in, captures the geometry and pixel shadow as kernel blobs (tags 4 and 5), registers the display's `persist_ops` into the global registry (#143), and exposes the restore-side setters the boot-ordering capstone (#147) will drive.

## Testing

`tests/test_checkpoint_fb.c` covers geometry capture/validation, the quiesce no-op, the re-program-then-repaint path (asserting the mock video memory ends byte-identical to the persisted shadow), and each failure mode (bad geometry, mode-set, blit, absent capture, NULL args). All 20 checks pass. Both modules compile clean freestanding and the end-to-end persistence demo still passes.

Wired into `kernel/Makefile` and the persistence CI workflow (freestanding compile plus the host test).

Depends on #143 (re-attach framework, merged) and #140 (kernel-state persistence). The visible repaint after a QEMU power cut is the README demo candidate and is validated in QEMU under the boot-ordering capstone (#147).