### PR TITLE
Extend external-state severing to DMA and IPC endpoints (#146)

### DIFF
--- a/include/checkpoint_extstate.h
+++ b/include/checkpoint_extstate.h
@@ -30,8 +30,9 @@ typedef enum {
 } extstate_kind_t;
 
 /* Handle state flags. */
-#define EXTSTATE_FLAG_OPEN     0x1   /* the handle is currently open/in use */
-#define EXTSTATE_FLAG_SEVERED  0x2   /* severed across a checkpoint restore */
+#define EXTSTATE_FLAG_OPEN        0x1   /* the handle is currently open/in use */
+#define EXTSTATE_FLAG_SEVERED     0x2   /* severed across a checkpoint restore */
+#define EXTSTATE_FLAG_RECONNECTED 0x4   /* owner re-established it after a sever */
 
 /* Status codes an app/syscall observes when touching a handle. */
 #define EXTSTATE_OK        0
@@ -84,5 +85,54 @@ bool extstate_sever_fd(uint32_t* flags);
 /* Has this descriptor been severed across a restore? Syscalls consult this to
  * return a clean error so the app re-establishes the resource. */
 bool extstate_fd_is_severed(uint32_t flags);
+
+/* ----- DMA / IPC endpoints and the reconnection contract (v2, #146) -----
+ *
+ * Not every non-persistable resource is a file descriptor. An in-flight DMA
+ * mapping or a non-drainable IPC/network endpoint is its own kernel object, so
+ * v2 pushes the severing policy inward to those resources directly (v2 design
+ * section 6). The kernel tracks each such resource as an extstate_endpoint_t;
+ * at the checkpoint barrier the non-persistable ones are dropped from the
+ * persisted set, and on restore they are severed so their next use returns a
+ * defined error.
+ *
+ * Reconnection contract: an owner that observes EXTSTATE_SEVERED (via
+ * extstate_endpoint_status, mirroring the socket reconnect path of #128)
+ * re-establishes the resource out of band, then calls extstate_endpoint_reconnect
+ * to clear the severed state. The generation counter bumps on every reconnect so
+ * stale references held elsewhere can detect that the endpoint was rebuilt. */
+typedef struct {
+    extstate_kind_t kind;        /* DMA_BUFFER, DEVICE, SOCKET, PIPE, ... */
+    uint32_t        flags;       /* EXTSTATE_FLAG_OPEN / _SEVERED / _RECONNECTED */
+    uint32_t        owner;       /* owning pid (for the restore registrar) */
+    uint32_t        generation;  /* bumped each time the owner re-establishes it */
+} extstate_endpoint_t;
+
+/* Does this endpoint's connection ride through a checkpoint, or must it be
+ * severed? A thin wrapper over the kind classification (DMA/device/socket/pipe
+ * do not survive; a regular-file-backed mapping would). */
+bool extstate_endpoint_persistable(const extstate_endpoint_t* ep);
+
+/* Restore-time transition for one endpoint: if it is open, non-persistable, and
+ * not already severed, mark it severed and return true. Idempotent. */
+bool extstate_endpoint_sever(extstate_endpoint_t* ep);
+
+/* Sever every endpoint in an array; returns the number that transitioned. Use
+ * when reconstructing a process's DMA mappings / IPC endpoints on restore. */
+int  extstate_endpoint_sever_all(extstate_endpoint_t* eps, int count);
+
+/* Status the owner observes: EXTSTATE_SEVERED while the endpoint is severed and
+ * not yet reconnected, else EXTSTATE_OK. */
+int  extstate_endpoint_status(const extstate_endpoint_t* ep);
+
+/* Does this endpoint still need the owner to re-establish it? (Severed and not
+ * yet reconnected.) */
+bool extstate_endpoint_needs_reconnect(const extstate_endpoint_t* ep);
+
+/* The reconnection contract. Call after the owner has re-established the
+ * underlying resource: clears the severed state, marks it reconnected + open,
+ * bumps the generation, and returns true. Returns false (no-op) if the endpoint
+ * was not severed, so a double reconnect is safe. */
+bool extstate_endpoint_reconnect(extstate_endpoint_t* ep);
 
 #endif /* CHECKPOINT_EXTSTATE_H */

--- a/kernel/checkpoint_extstate.c
+++ b/kernel/checkpoint_extstate.c
@@ -93,3 +93,67 @@ bool extstate_sever_fd(uint32_t* flags) {
 bool extstate_fd_is_severed(uint32_t flags) {
     return (flags & EXTSTATE_FD_SEVERED) != 0;
 }
+
+/* ----- DMA / IPC endpoints and the reconnection contract (v2, #146) ----- */
+
+bool extstate_endpoint_persistable(const extstate_endpoint_t* ep) {
+    if (!ep) {
+        return false; /* fail safe: nothing to vouch for */
+    }
+    return extstate_survives_checkpoint(ep->kind);
+}
+
+bool extstate_endpoint_sever(extstate_endpoint_t* ep) {
+    if (!ep) {
+        return false;
+    }
+    if (!(ep->flags & EXTSTATE_FLAG_OPEN)) {
+        return false; /* not in use */
+    }
+    if (ep->flags & EXTSTATE_FLAG_SEVERED) {
+        return false; /* already severed: idempotent */
+    }
+    if (extstate_survives_checkpoint(ep->kind)) {
+        return false; /* persistable: leave intact */
+    }
+    ep->flags |= EXTSTATE_FLAG_SEVERED;
+    ep->flags &= ~EXTSTATE_FLAG_RECONNECTED; /* a fresh sever supersedes any prior reconnect */
+    return true;
+}
+
+int extstate_endpoint_sever_all(extstate_endpoint_t* eps, int count) {
+    if (!eps || count <= 0) {
+        return 0;
+    }
+    int severed = 0;
+    for (int i = 0; i < count; i++) {
+        if (extstate_endpoint_sever(&eps[i])) {
+            severed++;
+        }
+    }
+    return severed;
+}
+
+int extstate_endpoint_status(const extstate_endpoint_t* ep) {
+    if (ep && (ep->flags & EXTSTATE_FLAG_SEVERED)) {
+        return EXTSTATE_SEVERED;
+    }
+    return EXTSTATE_OK;
+}
+
+bool extstate_endpoint_needs_reconnect(const extstate_endpoint_t* ep) {
+    return ep && (ep->flags & EXTSTATE_FLAG_SEVERED) != 0;
+}
+
+bool extstate_endpoint_reconnect(extstate_endpoint_t* ep) {
+    if (!ep) {
+        return false;
+    }
+    if (!(ep->flags & EXTSTATE_FLAG_SEVERED)) {
+        return false; /* nothing to re-establish: safe no-op */
+    }
+    ep->flags &= ~EXTSTATE_FLAG_SEVERED;
+    ep->flags |= EXTSTATE_FLAG_OPEN | EXTSTATE_FLAG_RECONNECTED;
+    ep->generation++;
+    return true;
+}

--- a/tests/test_checkpoint_extstate.c
+++ b/tests/test_checkpoint_extstate.c
@@ -114,6 +114,59 @@ int main(void) {
         CHECK(extstate_sever_fd(0) == false, "NULL flags safe");
     }
 
+    /* === 5. DMA / IPC endpoints + reconnection contract (#146) === */
+    printf("Test 5: DMA / IPC endpoint severing\n");
+    {
+        /* A process holding an in-flight DMA mapping, a device handle, an IPC
+         * socket endpoint, and a regular-file-backed mapping. */
+        extstate_endpoint_t eps[4];
+        eps[0].kind = EXTSTATE_DMA_BUFFER; eps[0].flags = EXTSTATE_FLAG_OPEN; eps[0].owner = 7; eps[0].generation = 0;
+        eps[1].kind = EXTSTATE_DEVICE;     eps[1].flags = EXTSTATE_FLAG_OPEN; eps[1].owner = 7; eps[1].generation = 0;
+        eps[2].kind = EXTSTATE_SOCKET;     eps[2].flags = EXTSTATE_FLAG_OPEN; eps[2].owner = 7; eps[2].generation = 0;
+        eps[3].kind = EXTSTATE_REGULAR_FILE; eps[3].flags = EXTSTATE_FLAG_OPEN; eps[3].owner = 7; eps[3].generation = 0;
+
+        CHECK(extstate_endpoint_persistable(&eps[0]) == false, "DMA endpoint non-persistable");
+        CHECK(extstate_endpoint_persistable(&eps[3]) == true,  "file-backed endpoint persistable");
+
+        int n = extstate_endpoint_sever_all(eps, 4);
+        CHECK(n == 3, "the DMA, device, and socket endpoints are severed");
+        CHECK(extstate_endpoint_status(&eps[0]) == EXTSTATE_SEVERED, "DMA reports severed");
+        CHECK(extstate_endpoint_status(&eps[3]) == EXTSTATE_OK,      "file-backed endpoint untouched");
+        CHECK(extstate_endpoint_needs_reconnect(&eps[2]) == true,    "socket needs reconnect");
+
+        /* Idempotent: a second restore pass severs nothing new. */
+        CHECK(extstate_endpoint_sever_all(eps, 4) == 0, "second sever pass is a no-op");
+        CHECK(extstate_endpoint_sever(0) == false, "NULL endpoint safe");
+        CHECK(extstate_endpoint_sever_all(0, 4) == 0, "NULL array safe");
+    }
+
+    printf("Test 6: reconnection contract\n");
+    {
+        extstate_endpoint_t dma;
+        dma.kind = EXTSTATE_DMA_BUFFER; dma.flags = EXTSTATE_FLAG_OPEN; dma.owner = 9; dma.generation = 0;
+
+        /* Restore severs it; the owner observes the defined error. */
+        CHECK(extstate_endpoint_sever(&dma) == true, "DMA severed on restore");
+        CHECK(extstate_endpoint_status(&dma) == EXTSTATE_SEVERED, "owner sees EXTSTATE_SEVERED");
+
+        /* Owner re-establishes the mapping, then calls reconnect. */
+        CHECK(extstate_endpoint_reconnect(&dma) == true, "reconnect transitions from severed");
+        CHECK(extstate_endpoint_status(&dma) == EXTSTATE_OK, "endpoint usable again");
+        CHECK(extstate_endpoint_needs_reconnect(&dma) == false, "no longer needs reconnect");
+        CHECK((dma.flags & EXTSTATE_FLAG_RECONNECTED) != 0, "reconnected flag set");
+        CHECK(dma.generation == 1, "generation bumped so stale refs can tell");
+
+        /* A second reconnect is a safe no-op. */
+        CHECK(extstate_endpoint_reconnect(&dma) == false, "double reconnect is a no-op");
+        CHECK(dma.generation == 1, "generation not bumped twice");
+
+        /* A fresh checkpoint can sever the reconnected endpoint again. */
+        CHECK(extstate_endpoint_sever(&dma) == true, "reconnected endpoint can be re-severed");
+        CHECK((dma.flags & EXTSTATE_FLAG_RECONNECTED) == 0, "re-sever clears the reconnected flag");
+
+        CHECK(extstate_endpoint_reconnect(0) == false, "NULL reconnect safe");
+    }
+
     printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
            failures, failures == 1 ? "" : "s");
     return failures ? 1 : 0;


### PR DESCRIPTION
## What

Pushes the v1.5 external-state policy inward per `docs/architecture/orthogonal-persistence-v2.md` section 6. In-flight DMA buffers and non-drainable IPC/network endpoints cannot be replayed across a power cut, so they are severed on restore with a defined error and the owner re-establishes them.

Closes #146.

## Why an endpoint layer

Not every non-persistable resource is a file descriptor. An in-flight DMA mapping or an IPC/network endpoint is its own kernel object. v1.5 severed the fd-flags layer (#128); v2 adds an endpoint layer that severs those resources directly, plus the reconnection contract the design calls for.

## What is added

New `extstate_endpoint_t` (kind, flags, owner pid, generation) and its ops:

- **persistable**: thin wrapper over the kind classification (DMA / device / socket / pipe do not survive; a file-backed mapping would).
- **sever / sever_all**: restore-time transition. Severs open non-persistable endpoints, idempotent, so a process's DMA mappings and IPC endpoints are reported severed and their next use returns a clean `EXTSTATE_SEVERED`.
- **status / needs_reconnect**: what the owner observes, mirroring the socket reconnect path of #128.
- **reconnect** (the reconnection contract): after the owner re-establishes the resource out of band it calls `reconnect`, which clears the severed state, marks it reconnected + open, and bumps a generation counter so stale references elsewhere can detect the endpoint was rebuilt. A re-sever on a later checkpoint clears the reconnected flag; a double reconnect is a safe no-op.

This lands in the dependency-free policy core, so it stays host-testable and builds unchanged in the freestanding kernel.

## Testing

The existing extstate unit test gains a DMA/IPC endpoint section and a reconnection-contract section: a checkpoint taken with an in-flight DMA mapping restores with the mapping severed (the acceptance criterion), then reconnects cleanly and can be re-severed by a later checkpoint. All checks pass. The module compiles clean freestanding and the end-to-end persistence demo still passes.

No new build wiring, since the module and its CI test invocation are already in place.

Depends on #118/#128 (external-state policy) and #143 (re-attach framework, merged).