### PR TITLE
Boot restore ordering capstone for orthogonal persistence (#147)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -52,6 +52,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_drv    test_checkpoint_driver.c    ../kernel/checkpoint_driver.c && /tmp/t_drv
           gcc -I../include -Wall -o /tmp/t_disk   test_checkpoint_disk.c      ../kernel/checkpoint_disk.c && /tmp/t_disk
           gcc -I../include -Wall -o /tmp/t_fb     test_checkpoint_fb.c        ../kernel/checkpoint_fb.c && /tmp/t_fb
+          gcc -I../include -Wall -o /tmp/t_seq    test_checkpoint_restore_seq.c ../kernel/checkpoint_restore_seq.c && /tmp/t_seq
           gcc -I../include -Wall -o /tmp/t_ckpt   test_checkpoint.c            $K && /tmp/t_ckpt
           gcc -I../include -Wall -o /tmp/t_wb     test_checkpoint_writeback.c  $K && /tmp/t_wb
           gcc -I../include -Wall -o /tmp/t_rs     test_checkpoint_restore.c    $K && /tmp/t_rs

--- a/include/checkpoint.h
+++ b/include/checkpoint.h
@@ -213,6 +213,13 @@ void checkpoint_set_boot_store(snapshot_store_t* store);
  * Returns pages restored (>= 0) or CHECKPOINT_ERR_NO_CHECKPOINT. */
 int checkpoint_boot(void);
 
+/* v2 whole-machine boot restore (#147): runs the ordered restore (kernel state,
+ * driver re-attach, user processes) with a cold-boot fallback via the pure
+ * sequencer in checkpoint_restore_seq.c. Returns CHECKPOINT_OK if the machine
+ * resumed, or CHECKPOINT_ERR_NO_CHECKPOINT to continue a cold boot. Defined in
+ * checkpoint_boot_v2.c. */
+int checkpoint_boot_v2(snapshot_store_t* store);
+
 /* ----- Periodic trigger (#117) ----- */
 
 /* Default checkpoint cadence, in timer ticks. The scheduler tick rate

--- a/include/checkpoint_restore_seq.h
+++ b/include/checkpoint_restore_seq.h
@@ -1,0 +1,96 @@
+/* IKOS Orthogonal Persistence v2 - Boot restore ordering (#147)
+ *
+ * The v2 integration capstone. On boot, when a valid checkpoint exists, the
+ * whole machine must come back in a defined order (orthogonal-persistence-v2.md
+ * section 7):
+ *   1. restore kernel state (process table + scheduler #140, VFS #141, IPC #142,
+ *      reassembled from the kernel-state records #139);
+ *   2. re-attach drivers (#143 framework; disk #144, framebuffer #145);
+ *   3. restore user address spaces and processes on top (the v1 path), now with
+ *      live kernel state, applying external-state severing (#146).
+ *
+ * If there is no checkpoint we cold-boot cleanly; if kernel-state restore or a
+ * critical driver re-attach fails we fall back to cold boot (section 8). That
+ * ordering + fallback decision is the whole point of this module, so it is a
+ * pure, host-testable sequencer driven by injected step callbacks. The kernel
+ * adapter (checkpoint_boot_v2.c) binds the real subsystems to the steps.
+ *
+ * This header also carries the kernel-state blob reassembly helpers: capture
+ * (#139) chunks a blob into page records tagged (size << 32 | index); restore
+ * has to put the chunks back together, and that offset math is pure and worth
+ * testing on its own.
+ */
+
+#ifndef CHECKPOINT_RESTORE_SEQ_H
+#define CHECKPOINT_RESTORE_SEQ_H
+
+#include <stdint.h>
+
+/* ----- Restore ordering / fallback sequencer ----- */
+
+typedef enum {
+    CHECKPOINT_RESTORE_COLD_BOOT = 0, /* no checkpoint, or a fallback after failure */
+    CHECKPOINT_RESTORE_RESUMED   = 1, /* the whole machine came back */
+} checkpoint_restore_outcome_t;
+
+/* The furthest phase the sequence entered (for diagnostics / the fallback). */
+typedef enum {
+    CHECKPOINT_PHASE_NONE = 0,
+    CHECKPOINT_PHASE_KERNEL_STATE,
+    CHECKPOINT_PHASE_DRIVER_REATTACH,
+    CHECKPOINT_PHASE_USER_RESTORE,
+    CHECKPOINT_PHASE_DONE,
+} checkpoint_restore_phase_t;
+
+/* Injected restore steps. has_checkpoint returns nonzero if a valid checkpoint
+ * exists; the three restore steps return 0 on success and nonzero on a failure
+ * that forces a cold-boot fallback. The driver step folds its own
+ * continue-vs-abort policy (#143) into that 0/nonzero result. */
+typedef struct {
+    int (*has_checkpoint)(void* ctx);
+    int (*restore_kernel_state)(void* ctx);
+    int (*reattach_drivers)(void* ctx);
+    int (*restore_user)(void* ctx);
+    void* ctx;
+} checkpoint_restore_steps_t;
+
+typedef struct {
+    checkpoint_restore_outcome_t outcome;
+    checkpoint_restore_phase_t   reached;   /* last phase entered */
+    int                          fell_back; /* nonzero if a failure forced cold boot */
+} checkpoint_restore_result_t;
+
+/* Run the restore in the defined order with cold-boot fallback. A missing step
+ * callback (or missing steps struct) is treated as a fatal misconfiguration and
+ * cold-boots. No checkpoint is a clean cold boot (fell_back == 0). */
+checkpoint_restore_result_t
+checkpoint_restore_sequence(const checkpoint_restore_steps_t* steps);
+
+/* ----- Kernel-state blob reassembly (#139 chunk format) ----- */
+
+/* A kernel-blob chunk record encodes its total blob size and chunk index in the
+ * record's virt_addr field as (size << 32) | index. */
+static inline uint32_t checkpoint_blob_total(uint64_t virt_addr) {
+    return (uint32_t)(virt_addr >> 32);
+}
+static inline uint32_t checkpoint_blob_index(uint64_t virt_addr) {
+    return (uint32_t)(virt_addr & 0xFFFFFFFFu);
+}
+
+#define CHECKPOINT_BLOB_CHUNK 4096  /* bytes per chunk record (= PAGE_SIZE) */
+
+#define CHECKPOINT_BLOB_OK        0
+#define CHECKPOINT_BLOB_ERR      -1  /* bad args / index or size out of range */
+#define CHECKPOINT_BLOB_COMPLETE  1  /* this chunk completed the blob */
+
+/* Copy one chunk into its place in a reassembly buffer. `index` is the chunk's
+ * position, `total` the full blob size (both from the record's virt_addr).
+ * `chunk` holds up to CHECKPOINT_BLOB_CHUNK valid bytes; only the bytes that
+ * belong to this index (total - index*CHUNK, capped at CHUNK) are copied.
+ * *received accumulates the bytes placed so far. Returns CHECKPOINT_BLOB_COMPLETE
+ * once *received reaches total, CHECKPOINT_BLOB_OK while still in progress, or
+ * CHECKPOINT_BLOB_ERR on bad input or if the blob would overflow `cap`. */
+int checkpoint_blob_place(uint8_t* buf, uint32_t cap, uint32_t total,
+                          uint32_t index, const void* chunk, uint32_t* received);
+
+#endif /* CHECKPOINT_RESTORE_SEQ_H */

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -51,7 +51,8 @@ C_SOURCES = scheduler.c interrupts.c scheduler_test.c kalloc.c kalloc_test.c use
             checkpoint_filetable.c checkpoint_filetable_sync.c \
             checkpoint_ipc.c checkpoint_ipc_sync.c checkpoint_driver.c \
             checkpoint_disk.c checkpoint_disk_sync.c \
-            checkpoint_fb.c checkpoint_fb_sync.c
+            checkpoint_fb.c checkpoint_fb_sync.c \
+            checkpoint_restore_seq.c checkpoint_boot_v2.c
 ASM_SOURCES = context_switch.asm
 BOOT_SOURCES = $(BOOTDIR)/boot_longmode.asm
 

--- a/kernel/checkpoint_boot_v2.c
+++ b/kernel/checkpoint_boot_v2.c
@@ -1,0 +1,173 @@
+/* IKOS Orthogonal Persistence v2 - Boot restore adapter (#147)
+ *
+ * Binds the real subsystems to the pure restore sequencer
+ * (checkpoint_restore_seq.c) so a whole-machine checkpoint comes back in the
+ * defined order: kernel state, then driver re-attach, then user restore, with a
+ * cold-boot fallback if a critical step fails (orthogonal-persistence-v2.md
+ * sections 7 and 8). Compile-checked freestanding; the live restore is a QEMU
+ * integration test.
+ *
+ * kernel_init() calls checkpoint_boot_v2(store) in place of the v1
+ * checkpoint_boot(): it returns CHECKPOINT_OK when the machine resumed, or
+ * CHECKPOINT_ERR_NO_CHECKPOINT to tell the caller to continue a cold boot.
+ */
+
+#include "checkpoint_restore_seq.h"
+#include "checkpoint.h"
+#include "checkpoint_driver.h"
+#include "checkpoint_proctable.h"
+#include "checkpoint_filetable.h"
+#include "checkpoint_ipc.h"
+#include "checkpoint_fb.h"
+#include "snapshot_store.h"
+
+extern void* kmalloc(size_t size);
+extern void  kfree(void* ptr);
+
+/* One kernel-state blob under reassembly, keyed by its tag (rec->pid). */
+typedef struct {
+    uint32_t tag;
+    uint8_t* buf;
+    uint32_t total;
+    uint32_t received;
+    int      in_use;
+    int      complete;
+} blob_slot_t;
+
+#define BOOT_V2_MAX_BLOBS 6
+
+typedef struct {
+    snapshot_store_t* store;
+} boot_v2_ctx_t;
+
+static blob_slot_t* slot_for_tag(blob_slot_t* slots, uint32_t tag, uint32_t total) {
+    for (int i = 0; i < BOOT_V2_MAX_BLOBS; i++) {
+        if (slots[i].in_use && slots[i].tag == tag) {
+            return &slots[i];
+        }
+    }
+    for (int i = 0; i < BOOT_V2_MAX_BLOBS; i++) {
+        if (!slots[i].in_use) {
+            slots[i].tag = tag;
+            slots[i].buf = (uint8_t*)kmalloc(total ? total : 1);
+            slots[i].total = total;
+            slots[i].received = 0;
+            slots[i].in_use = slots[i].buf ? 1 : 0;
+            slots[i].complete = 0;
+            return slots[i].buf ? &slots[i] : 0;
+        }
+    }
+    return 0; /* more distinct blobs than expected */
+}
+
+/* Dispatch a fully reassembled blob to the owning subsystem's restorer. */
+static int dispatch_blob(blob_slot_t* s) {
+    switch (s->tag) {
+        case CHECKPOINT_TAG_PROCTABLE:        return checkpoint_restore_proctable(s->buf, s->total);
+        case CHECKPOINT_TAG_FILETABLE:        return checkpoint_restore_filetable(s->buf, s->total);
+        case CHECKPOINT_TAG_IPC:              return checkpoint_restore_ipc(s->buf, s->total);
+        case CHECKPOINT_TAG_FRAMEBUFFER:      return checkpoint_fb_restore_state(s->buf, s->total);
+        case CHECKPOINT_TAG_FRAMEBUFFER_PIXELS:
+            return checkpoint_fb_restore_pixels(s->buf, s->total);
+        default:                              return 0; /* unknown tag: ignore */
+    }
+}
+
+/* ----- restore steps ----- */
+
+static int boot_has_checkpoint(void* ctx) {
+    boot_v2_ctx_t* c = (boot_v2_ctx_t*)ctx;
+    snapshot_reader_t reader;
+    return snapshot_store_load(c->store, &reader) == SNAPSHOT_OK ? 1 : 0;
+}
+
+/* Reassemble every kernel-state blob from the checkpoint and hand each to its
+ * restorer. Page/context records are the user-restore step's job and are skipped
+ * here. Keeps the framebuffer pixels blob (which the framebuffer reattach will
+ * blit) alive past dispatch so the driver step can still read it. */
+static int boot_restore_kernel_state(void* ctx) {
+    boot_v2_ctx_t* c = (boot_v2_ctx_t*)ctx;
+
+    snapshot_reader_t reader;
+    if (snapshot_store_load(c->store, &reader) != SNAPSHOT_OK) {
+        return -1;
+    }
+
+    blob_slot_t slots[BOOT_V2_MAX_BLOBS];
+    for (int i = 0; i < BOOT_V2_MAX_BLOBS; i++) {
+        slots[i].in_use = 0; slots[i].buf = 0; slots[i].complete = 0;
+    }
+
+    uint8_t page[SNAPSHOT_PAGE_SIZE];
+    snapshot_page_record_t rec;
+    rec.page_data = page;
+
+    int rc = 0;
+    while (snapshot_reader_next(&reader, &rec) == SNAPSHOT_OK) {
+        if (!(rec.flags & CHECKPOINT_REC_KERNEL)) {
+            continue; /* pages + context belong to the user-restore step */
+        }
+        uint32_t total = checkpoint_blob_total(rec.virt_addr);
+        uint32_t index = checkpoint_blob_index(rec.virt_addr);
+
+        blob_slot_t* s = slot_for_tag(slots, rec.pid, total);
+        if (!s) { rc = -1; break; }
+
+        int pr = checkpoint_blob_place(s->buf, s->total, total, index, page, &s->received);
+        if (pr == CHECKPOINT_BLOB_ERR) { rc = -1; break; }
+        if (pr == CHECKPOINT_BLOB_COMPLETE && !s->complete) {
+            s->complete = 1;
+            if (dispatch_blob(s) != 0) { rc = -1; break; }
+        }
+    }
+
+    /* Free every blob except the framebuffer pixels: the framebuffer reattach
+     * (driver step, next) blits from that buffer, so it must outlive this pass.
+     * checkpoint_fb_restore_pixels() cached the pointer. */
+    for (int i = 0; i < BOOT_V2_MAX_BLOBS; i++) {
+        if (slots[i].in_use && slots[i].buf &&
+            slots[i].tag != CHECKPOINT_TAG_FRAMEBUFFER_PIXELS) {
+            kfree(slots[i].buf);
+        }
+    }
+    return rc;
+}
+
+/* Re-attach every registered driver (#143). CONTINUE policy: a device that
+ * cannot re-attach is severed and the restore proceeds (section 8), so this is
+ * not treated as a critical failure. */
+static int boot_reattach_drivers(void* ctx) {
+    (void)ctx;
+    checkpoint_driver_reattach_all(checkpoint_driver_global(),
+                                   CHECKPOINT_REATTACH_CONTINUE);
+    return 0;
+}
+
+/* Restore user address spaces + processes on top of the now-live kernel state,
+ * via the existing v1 boot path (which applies external-state severing). */
+static int boot_restore_user(void* ctx) {
+    boot_v2_ctx_t* c = (boot_v2_ctx_t*)ctx;
+    int restored = checkpoint_restore_boot(c->store);
+    return restored < 0 ? -1 : 0;
+}
+
+int checkpoint_boot_v2(snapshot_store_t* store) {
+    if (!store) {
+        return CHECKPOINT_ERR_NO_CHECKPOINT; /* nothing configured: cold boot */
+    }
+
+    boot_v2_ctx_t ctx;
+    ctx.store = store;
+
+    checkpoint_restore_steps_t steps;
+    steps.has_checkpoint       = boot_has_checkpoint;
+    steps.restore_kernel_state = boot_restore_kernel_state;
+    steps.reattach_drivers     = boot_reattach_drivers;
+    steps.restore_user         = boot_restore_user;
+    steps.ctx                  = &ctx;
+
+    checkpoint_restore_result_t r = checkpoint_restore_sequence(&steps);
+    return r.outcome == CHECKPOINT_RESTORE_RESUMED
+         ? CHECKPOINT_OK
+         : CHECKPOINT_ERR_NO_CHECKPOINT;
+}

--- a/kernel/checkpoint_restore_seq.c
+++ b/kernel/checkpoint_restore_seq.c
@@ -1,0 +1,81 @@
+/* IKOS Orthogonal Persistence v2 - Boot restore ordering (#147)
+ *
+ * Pure sequencer + kernel-blob reassembly math. No kernel deps. See
+ * include/checkpoint_restore_seq.h.
+ */
+
+#include "checkpoint_restore_seq.h"
+
+static checkpoint_restore_result_t cold(checkpoint_restore_phase_t reached, int fell_back) {
+    checkpoint_restore_result_t r;
+    r.outcome   = CHECKPOINT_RESTORE_COLD_BOOT;
+    r.reached   = reached;
+    r.fell_back = fell_back;
+    return r;
+}
+
+checkpoint_restore_result_t
+checkpoint_restore_sequence(const checkpoint_restore_steps_t* steps) {
+    /* A missing wiring is a fatal misconfiguration: cold-boot rather than resume
+     * a machine we cannot fully bring back. */
+    if (!steps || !steps->has_checkpoint || !steps->restore_kernel_state ||
+        !steps->reattach_drivers || !steps->restore_user) {
+        return cold(CHECKPOINT_PHASE_NONE, 1);
+    }
+
+    void* ctx = steps->ctx;
+
+    /* No checkpoint: a clean cold boot, not a fallback. */
+    if (!steps->has_checkpoint(ctx)) {
+        return cold(CHECKPOINT_PHASE_NONE, 0);
+    }
+
+    /* 1. Kernel state must come back before anything that depends on it. */
+    if (steps->restore_kernel_state(ctx) != 0) {
+        return cold(CHECKPOINT_PHASE_KERNEL_STATE, 1);
+    }
+
+    /* 2. Re-attach drivers on top of live kernel state. The step decides whether
+     * a re-attach failure is critical (abort) or tolerable (device severed). */
+    if (steps->reattach_drivers(ctx) != 0) {
+        return cold(CHECKPOINT_PHASE_DRIVER_REATTACH, 1);
+    }
+
+    /* 3. Restore user address spaces / processes last, with severing applied. */
+    if (steps->restore_user(ctx) != 0) {
+        return cold(CHECKPOINT_PHASE_USER_RESTORE, 1);
+    }
+
+    checkpoint_restore_result_t r;
+    r.outcome   = CHECKPOINT_RESTORE_RESUMED;
+    r.reached   = CHECKPOINT_PHASE_DONE;
+    r.fell_back = 0;
+    return r;
+}
+
+/* ----- Kernel-state blob reassembly ----- */
+
+int checkpoint_blob_place(uint8_t* buf, uint32_t cap, uint32_t total,
+                          uint32_t index, const void* chunk, uint32_t* received) {
+    if (!buf || !chunk || !received || total == 0 || total > cap) {
+        return CHECKPOINT_BLOB_ERR;
+    }
+
+    uint32_t off = index * CHECKPOINT_BLOB_CHUNK;
+    if (off >= total) {
+        return CHECKPOINT_BLOB_ERR; /* chunk index past the end of the blob */
+    }
+
+    uint32_t n = total - off;
+    if (n > CHECKPOINT_BLOB_CHUNK) {
+        n = CHECKPOINT_BLOB_CHUNK;
+    }
+
+    const uint8_t* src = (const uint8_t*)chunk;
+    for (uint32_t i = 0; i < n; i++) {
+        buf[off + i] = src[i];
+    }
+    *received += n;
+
+    return (*received >= total) ? CHECKPOINT_BLOB_COMPLETE : CHECKPOINT_BLOB_OK;
+}

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -232,12 +232,13 @@ void kernel_init(void) {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
     }
 
-    /* If a valid checkpoint exists, resume the saved address spaces instead of
-     * cold-starting (#116). With no device wired above, checkpoint_boot()
-     * reports no checkpoint and we fall through to the normal cold boot. */
-    int restored = checkpoint_boot();
-    if (restored >= 0) {
-        kernel_print("Resumed %d page(s) from last checkpoint\n", restored);
+    /* If a valid checkpoint exists, bring the whole machine back in the defined
+     * v2 order (#147): restore kernel state, re-attach drivers, then restore
+     * user address spaces + processes on top, with a cold-boot fallback if a
+     * critical step fails. With no device wired above, or on any fallback,
+     * checkpoint_boot_v2() reports no resume and we cold-boot normally. */
+    if (checkpoint_boot_v2(&persistence_store) == CHECKPOINT_OK) {
+        kernel_print("Resumed the whole machine from the last checkpoint\n");
         return; /* restored system is live; no fresh init process */
     }
 

--- a/tests/test_checkpoint_restore_seq.c
+++ b/tests/test_checkpoint_restore_seq.c
@@ -1,0 +1,156 @@
+/* Host-side test for the v2 boot restore ordering + blob reassembly (#147).
+ *
+ * Pure logic, no kernel deps. Verifies the restore sequencer runs the phases in
+ * order (kernel state, drivers, user), cold-boots cleanly when there is no
+ * checkpoint, and falls back to cold boot at whichever phase fails; plus the
+ * kernel-blob reassembly offset math (single/multi chunk, completion, bounds).
+ *
+ * Build: gcc -I../include -o test_checkpoint_restore_seq \
+ *            test_checkpoint_restore_seq.c ../kernel/checkpoint_restore_seq.c
+ */
+
+#include <stdint.h>
+extern int printf(const char*, ...);
+
+#include "checkpoint_restore_seq.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock steps: record the call order and let each phase be forced to fail. */
+static int g_seq[8], g_seq_n;
+static int g_has_cp;
+static int g_fail_kernel, g_fail_drivers, g_fail_user;
+
+static void seq_reset(void) {
+    g_seq_n = 0; g_has_cp = 1;
+    g_fail_kernel = g_fail_drivers = g_fail_user = 0;
+}
+
+enum { STEP_HAS = 1, STEP_KERNEL = 2, STEP_DRIVERS = 3, STEP_USER = 4 };
+
+static int m_has(void* c)     { (void)c; g_seq[g_seq_n++] = STEP_HAS;     return g_has_cp; }
+static int m_kernel(void* c)  { (void)c; g_seq[g_seq_n++] = STEP_KERNEL;  return g_fail_kernel; }
+static int m_drivers(void* c) { (void)c; g_seq[g_seq_n++] = STEP_DRIVERS; return g_fail_drivers; }
+static int m_user(void* c)    { (void)c; g_seq[g_seq_n++] = STEP_USER;    return g_fail_user; }
+
+static checkpoint_restore_steps_t make_steps(void) {
+    checkpoint_restore_steps_t s;
+    s.has_checkpoint = m_has; s.restore_kernel_state = m_kernel;
+    s.reattach_drivers = m_drivers; s.restore_user = m_user; s.ctx = 0;
+    return s;
+}
+
+int main(void) {
+    checkpoint_restore_steps_t s;
+    checkpoint_restore_result_t r;
+
+    printf("Test 1: full restore runs phases in order\n");
+    seq_reset(); s = make_steps();
+    r = checkpoint_restore_sequence(&s);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_RESUMED, "resumed");
+    CHECK(r.reached == CHECKPOINT_PHASE_DONE, "reached DONE");
+    CHECK(r.fell_back == 0, "no fallback");
+    CHECK(g_seq_n == 4 && g_seq[0] == STEP_HAS && g_seq[1] == STEP_KERNEL
+          && g_seq[2] == STEP_DRIVERS && g_seq[3] == STEP_USER,
+          "order: has, kernel-state, drivers, user");
+
+    printf("Test 2: no checkpoint is a clean cold boot\n");
+    seq_reset(); g_has_cp = 0; s = make_steps();
+    r = checkpoint_restore_sequence(&s);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_COLD_BOOT, "cold boot");
+    CHECK(r.fell_back == 0, "not a fallback (nothing to restore)");
+    CHECK(g_seq_n == 1, "no restore phase ran");
+
+    printf("Test 3: kernel-state failure falls back before drivers\n");
+    seq_reset(); g_fail_kernel = 1; s = make_steps();
+    r = checkpoint_restore_sequence(&s);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_COLD_BOOT && r.fell_back == 1, "cold-boot fallback");
+    CHECK(r.reached == CHECKPOINT_PHASE_KERNEL_STATE, "stopped at kernel-state");
+    CHECK(g_seq_n == 2, "drivers and user never ran");
+
+    printf("Test 4: driver re-attach failure falls back before user\n");
+    seq_reset(); g_fail_drivers = 1; s = make_steps();
+    r = checkpoint_restore_sequence(&s);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_COLD_BOOT && r.fell_back == 1, "cold-boot fallback");
+    CHECK(r.reached == CHECKPOINT_PHASE_DRIVER_REATTACH, "stopped at driver re-attach");
+    CHECK(g_seq_n == 3, "user restore never ran");
+
+    printf("Test 5: user restore failure falls back\n");
+    seq_reset(); g_fail_user = 1; s = make_steps();
+    r = checkpoint_restore_sequence(&s);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_COLD_BOOT && r.fell_back == 1, "cold-boot fallback");
+    CHECK(r.reached == CHECKPOINT_PHASE_USER_RESTORE, "stopped at user restore");
+
+    printf("Test 6: missing wiring cold-boots\n");
+    r = checkpoint_restore_sequence(0);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_COLD_BOOT && r.fell_back == 1, "NULL steps cold-boot");
+    s = make_steps(); s.reattach_drivers = 0;
+    r = checkpoint_restore_sequence(&s);
+    CHECK(r.outcome == CHECKPOINT_RESTORE_COLD_BOOT && r.reached == CHECKPOINT_PHASE_NONE,
+          "a NULL step is a fatal misconfiguration");
+
+    /* ----- kernel-blob reassembly ----- */
+    printf("Test 7: virt_addr header decode\n");
+    {
+        uint64_t va = ((uint64_t)5000 << 32) | 2u;
+        CHECK(checkpoint_blob_total(va) == 5000, "total decoded");
+        CHECK(checkpoint_blob_index(va) == 2, "index decoded");
+    }
+
+    printf("Test 8: single-chunk blob completes\n");
+    {
+        uint8_t chunk[CHECKPOINT_BLOB_CHUNK];
+        for (int i = 0; i < CHECKPOINT_BLOB_CHUNK; i++) chunk[i] = (uint8_t)(i * 3 + 1);
+        uint8_t buf[100];
+        uint32_t recv = 0;
+        int rc = checkpoint_blob_place(buf, sizeof(buf), 100, 0, chunk, &recv);
+        CHECK(rc == CHECKPOINT_BLOB_COMPLETE, "one chunk completes a small blob");
+        CHECK(recv == 100, "all bytes received");
+        int ok = 1; for (int i = 0; i < 100; i++) if (buf[i] != chunk[i]) ok = 0;
+        CHECK(ok, "bytes placed correctly");
+    }
+
+    printf("Test 9: two-chunk blob reassembles in order\n");
+    {
+        uint32_t total = CHECKPOINT_BLOB_CHUNK + 512; /* spills into a 2nd chunk */
+        uint8_t src[CHECKPOINT_BLOB_CHUNK + 512];
+        for (uint32_t i = 0; i < total; i++) src[i] = (uint8_t)(i & 0xFF);
+        uint8_t c0[CHECKPOINT_BLOB_CHUNK], c1[CHECKPOINT_BLOB_CHUNK];
+        for (int i = 0; i < CHECKPOINT_BLOB_CHUNK; i++) c0[i] = src[i];
+        for (int i = 0; i < 512; i++) c1[i] = src[CHECKPOINT_BLOB_CHUNK + i];
+
+        uint8_t buf[CHECKPOINT_BLOB_CHUNK + 512];
+        uint32_t recv = 0;
+        int rc0 = checkpoint_blob_place(buf, sizeof(buf), total, 0, c0, &recv);
+        CHECK(rc0 == CHECKPOINT_BLOB_OK, "first chunk in progress");
+        CHECK(recv == CHECKPOINT_BLOB_CHUNK, "first chunk full size counted");
+        int rc1 = checkpoint_blob_place(buf, sizeof(buf), total, 1, c1, &recv);
+        CHECK(rc1 == CHECKPOINT_BLOB_COMPLETE, "second chunk completes");
+        CHECK(recv == total, "total received");
+        int ok = 1; for (uint32_t i = 0; i < total; i++) if (buf[i] != src[i]) ok = 0;
+        CHECK(ok, "full blob reassembled byte-identical");
+    }
+
+    printf("Test 10: reassembly bounds\n");
+    {
+        uint8_t chunk[CHECKPOINT_BLOB_CHUNK] = {0};
+        uint8_t buf[100];
+        uint32_t recv = 0;
+        CHECK(checkpoint_blob_place(buf, sizeof(buf), 200, 0, chunk, &recv) == CHECKPOINT_BLOB_ERR,
+              "blob larger than the buffer rejected");
+        recv = 0;
+        CHECK(checkpoint_blob_place(buf, sizeof(buf), 100, 1, chunk, &recv) == CHECKPOINT_BLOB_ERR,
+              "chunk index past the end rejected");
+        recv = 0;
+        CHECK(checkpoint_blob_place(0, sizeof(buf), 100, 0, chunk, &recv) == CHECKPOINT_BLOB_ERR,
+              "NULL buffer rejected");
+    }
+
+    printf("\n%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Ties the v2 pieces together in the boot path so a restore brings the whole machine back in the correct order (`docs/architecture/orthogonal-persistence-v2.md` sections 7 and 8). This is the v2 integration capstone.

Closes #147.

## Restore order

When a valid checkpoint exists the restore runs:

1. **Kernel state** (process table + scheduler #140, VFS #141, IPC #142), reassembled from the kernel-state records (#139).
2. **Driver re-attach** (#143 framework; disk #144, framebuffer #145).
3. **User address spaces + processes** on top (the v1 path), now with live kernel state and external-state severing (#146) applied.

No checkpoint is a clean cold boot; a kernel-state or critical driver re-attach failure falls back to cold boot.

## Host-testable cores

The ordering and fallback decision is the whole point, so it is a pure sequencer (`kernel/checkpoint_restore_seq.c`) driven by injected step callbacks: it enforces the phase order and reports the furthest phase reached plus whether a failure forced the fallback. The same module carries the kernel-state blob reassembly math the restore side was missing: capture (#139) chunks a blob into page records tagged `(size << 32 | index)`, and `checkpoint_blob_place` puts the chunks back into a contiguous buffer, reporting completion and rejecting out-of-range input.

`tests/test_checkpoint_restore_seq.c` covers phase ordering, every fallback point, missing-wiring safety, single/multi-chunk reassembly, and bounds. All 33 checks pass.

## Kernel adapter

`kernel/checkpoint_boot_v2.c` binds the real subsystems to the sequencer: it loads the store, reassembles each kernel-state blob and dispatches it to the owning restorer (proctable / filetable / ipc / framebuffer geometry + pixels), drives the driver registry with the CONTINUE policy (a device that cannot re-attach is severed and the restore proceeds, section 8), then runs the existing v1 user restore. `kernel_init()` now calls `checkpoint_boot_v2()` in place of `checkpoint_boot()`.

The adapter is compile-checked freestanding; the live whole-machine resume, including the framebuffer repaint (#145), is the QEMU integration test.

## Testing

Both new modules compile clean freestanding and the end-to-end persistence demo still passes. Wired into `kernel/Makefile` and the persistence CI workflow.

Depends on #138 through #146 (all merged or in review). This completes the v2 series.