### PR TITLE
Capture file paths so restored processes reopen their files (#141)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -47,7 +47,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_bar    test_checkpoint_barrier.c   ../kernel/checkpoint_barrier.c && /tmp/t_bar
           gcc -I../include -Wall -o /tmp/t_kern   test_checkpoint_kernel.c    $K && /tmp/t_kern
           gcc -I../include -Wall -o /tmp/t_proc   test_checkpoint_proctable.c ../kernel/checkpoint_proctable.c && /tmp/t_proc
-          gcc -I../include -Wall -o /tmp/t_file   test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c && /tmp/t_file
+          gcc -I../include -Wall -o /tmp/t_file   test_checkpoint_filetable.c ../kernel/checkpoint_filetable.c ../kernel/checkpoint_extstate.c && /tmp/t_file
           gcc -I../include -Wall -o /tmp/t_ipc    test_checkpoint_ipc.c       ../kernel/checkpoint_ipc.c && /tmp/t_ipc
           gcc -I../include -Wall -o /tmp/t_drv    test_checkpoint_driver.c    ../kernel/checkpoint_driver.c && /tmp/t_drv
           gcc -I../include -Wall -o /tmp/t_disk   test_checkpoint_disk.c      ../kernel/checkpoint_disk.c && /tmp/t_disk

--- a/include/checkpoint_filetable.h
+++ b/include/checkpoint_filetable.h
@@ -58,6 +58,13 @@ const checkpoint_file_record_t* checkpoint_filetable_find(const checkpoint_filet
 
 uint32_t checkpoint_filetable_blob_size(uint32_t count);
 
+/* Restore decision for one record: true if it names a persistable file with a
+ * captured path, so restore should reopen it by path and seek to the saved
+ * offset; false if it must be severed (non-persistable kind, or no path was
+ * captured). Single-sources the capture/restore reopen-vs-sever choice so both
+ * sides agree. */
+bool checkpoint_file_record_reopenable(const checkpoint_file_record_t* r);
+
 /* ----- Kernel capture/restore adapters (kernel sync module) ----- */
 #define CHECKPOINT_TAG_FILETABLE 2
 

--- a/include/process.h
+++ b/include/process.h
@@ -66,12 +66,19 @@ typedef enum {
 #define MAX_PROCESS_NAME        32              /* Maximum process name length */
 #define MAX_COMMAND_LINE        256             /* Maximum command line length */
 
+/* Backing-path length stored per descriptor. Sized to match the persistence
+ * record (CHECKPOINT_FILE_PATH_MAX) so a file's path round-trips through a
+ * checkpoint and can be reopened on restore. */
+#define FD_PATH_MAX             128
+
 /* File descriptor structure */
 typedef struct {
     int fd;                     /* File descriptor number */
     uint64_t offset;            /* Current file offset */
     uint32_t flags;             /* File flags (read/write/etc) */
     void* file_data;            /* Pointer to file data structure */
+    char path[FD_PATH_MAX];     /* Backing file path (empty if none); persisted
+                                 * so orthogonal-persistence restore can reopen */
 } file_descriptor_t;
 
 /* Process context structure - saved during context switches */

--- a/kernel/checkpoint_filetable.c
+++ b/kernel/checkpoint_filetable.c
@@ -5,6 +5,7 @@
  */
 
 #include "checkpoint_filetable.h"
+#include "checkpoint_extstate.h"   /* extstate_survives_checkpoint */
 
 extern void* memcpy(void* dest, const void* src, unsigned long n);
 
@@ -87,6 +88,16 @@ static bool path_is_terminated(const char* path) {
         }
     }
     return false;
+}
+
+bool checkpoint_file_record_reopenable(const checkpoint_file_record_t* r) {
+    if (!r) {
+        return false;
+    }
+    /* Reopen only a persistable kind (a regular file) that actually carries a
+     * path; anything else is severed so the app re-establishes it. */
+    return extstate_survives_checkpoint((extstate_kind_t)r->kind) &&
+           r->path[0] != '\0';
 }
 
 bool checkpoint_filetable_validate(const checkpoint_filetable_t* t) {

--- a/kernel/checkpoint_filetable_sync.c
+++ b/kernel/checkpoint_filetable_sync.c
@@ -42,10 +42,14 @@ int checkpoint_capture_filetable(uint32_t pid) {
         r->offset = fd->offset;
         r->kind = (uint32_t)extstate_kind_from_fd_flags(fd->flags);
         r->reserved = 0;
-        /* The descriptor does not currently store its backing path; leave it
-         * empty until the VFS exposes it (records still carry offset/flags/kind
-         * so non-persistable handles are severed and metadata is restored). */
-        for (int k = 0; k < CHECKPOINT_FILE_PATH_MAX; k++) {
+        /* Capture the descriptor's backing path so restore can reopen the file.
+         * Copy up to the record bound and always NUL-terminate; an empty path
+         * (no backing file recorded) is left empty and the handle is severed. */
+        int k = 0;
+        for (; k < CHECKPOINT_FILE_PATH_MAX - 1 && fd->path[k] != '\0'; k++) {
+            r->path[k] = fd->path[k];
+        }
+        for (; k < CHECKPOINT_FILE_PATH_MAX; k++) {
             r->path[k] = '\0';
         }
     }
@@ -105,8 +109,15 @@ int checkpoint_restore_filetable(const void* blob, uint32_t size) {
         slot->offset = r->offset;
         slot->flags = r->flags;
         slot->file_data = NULL;
+        /* Carry the path back onto the descriptor so the restored file is itself
+         * re-checkpointable (the next checkpoint captures it again). */
+        int pk = 0;
+        for (; pk < FD_PATH_MAX - 1 && r->path[pk] != '\0'; pk++) {
+            slot->path[pk] = r->path[pk];
+        }
+        slot->path[pk] = '\0';
 
-        if (extstate_survives_checkpoint((extstate_kind_t)r->kind) && r->path[0] != '\0') {
+        if (checkpoint_file_record_reopenable(r)) {
             /* Regular file: reopen by path and seek to the saved offset. (The
              * VFS-level fd is reconciled with r->fd by a later VFS change.) */
             int vfd = vfs_open(r->path, r->flags, 0);

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -6,6 +6,7 @@
 #include "elf.h"
 #include "vmm.h"
 #include "interrupts.h"
+#include "vfs.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
@@ -101,6 +102,7 @@ process_t* process_create_from_elf(const char* name, void* elf_data, size_t size
     /* Initialize file descriptors */
     for (int i = 0; i < MAX_OPEN_FILES; i++) {
         proc->fds[i].fd = -1;
+        proc->fds[i].path[0] = '\0';
     }
     proc->next_fd = 0;
     
@@ -363,6 +365,41 @@ process_t* process_get_next_ready(void) {
  */
 process_t* process_get_current(void) {
     return current_process;
+}
+
+/**
+ * Open a file into a process's descriptor table.
+ *
+ * Opens `path` via the VFS and records it in the first free descriptor slot,
+ * storing the backing path so orthogonal-persistence checkpoints can reopen the
+ * file on restore (see checkpoint_capture_filetable, #141). Returns the VFS file
+ * descriptor, or a negative error if the open failed or the table is full.
+ */
+int process_open_file(process_t* proc, const char* path, int flags) {
+    if (!proc || !path) {
+        return -1;
+    }
+
+    int vfd = vfs_open(path, (uint32_t)flags, 0);
+    if (vfd < 0) {
+        return vfd;
+    }
+
+    for (int i = 0; i < MAX_OPEN_FILES; i++) {
+        if (proc->fds[i].fd < 0) {
+            proc->fds[i].fd = vfd;
+            proc->fds[i].offset = 0;
+            proc->fds[i].flags = (uint32_t)flags;
+            proc->fds[i].file_data = NULL;
+            strncpy(proc->fds[i].path, path, FD_PATH_MAX - 1);
+            proc->fds[i].path[FD_PATH_MAX - 1] = '\0';
+            return vfd;
+        }
+    }
+
+    /* No free slot: don't leak the VFS handle. */
+    vfs_close(vfd);
+    return -1;
 }
 
 /**

--- a/tests/test_checkpoint_filetable.c
+++ b/tests/test_checkpoint_filetable.c
@@ -85,7 +85,33 @@ int main(void) {
     buf[2] ^= 0xFF;
     CHECK(!checkpoint_filetable_deserialize(&out, buf, w), "bad magic rejected");
 
-    printf("Test 4: full table spans multiple pages\n");
+    printf("Test 4: reopen-vs-sever decision\n");
+    /* A regular file with a captured path is reopened; a regular file whose path
+     * was not captured, and any non-persistable kind, are severed. This is the
+     * decision the restore adapter keys on, so file-backed state actually comes
+     * back instead of being severed for want of a path. */
+    {
+        checkpoint_file_record_t file_with_path = in.records[0]; /* kind 0, "/etc/motd" */
+        CHECK(checkpoint_file_record_reopenable(&file_with_path),
+              "regular file with a path is reopenable");
+
+        checkpoint_file_record_t file_no_path = in.records[0];
+        set_path(&file_no_path, "");
+        CHECK(!checkpoint_file_record_reopenable(&file_no_path),
+              "regular file without a captured path is severed");
+
+        checkpoint_file_record_t sock = in.records[1]; /* kind 1 socket, no path */
+        CHECK(!checkpoint_file_record_reopenable(&sock), "socket is severed");
+
+        checkpoint_file_record_t dev = in.records[0];
+        dev.kind = 3 /* EXTSTATE_DEVICE */;
+        CHECK(!checkpoint_file_record_reopenable(&dev),
+              "device with a path is still severed (non-persistable kind)");
+
+        CHECK(!checkpoint_file_record_reopenable(0), "NULL record is not reopenable");
+    }
+
+    printf("Test 5: full table spans multiple pages\n");
     checkpoint_filetable_t big;
     memset(&big, 0, sizeof(big));
     big.pid = 1; big.count = CHECKPOINT_FILETABLE_MAX;


### PR DESCRIPTION
## What

Closes the file-restore correctness gap left by #141. `file_descriptor_t` had no path field, so `checkpoint_capture_filetable` hard-coded an empty path and every open file was **severed** on restore instead of reopened. A resumed process lost its files, which undercuts the "exactly where you left it" thesis for anything file-backed.

## Changes

- Add a backing path to `file_descriptor_t` (`FD_PATH_MAX`, sized to match the persistence record so paths round-trip), initialized empty in `process_create`.
- Define `process_open_file()`, which was declared in `process.h` but never implemented: it opens via the VFS and records the path in the descriptor, giving the capture path a real path to serialize.
- `checkpoint_capture_filetable` now copies the descriptor path into the record (bounded and NUL-terminated) instead of forcing it empty; the restore adapter carries the path back onto the rebuilt descriptor so the file stays re-checkpointable.
- Add a pure `checkpoint_file_record_reopenable()` predicate that single-sources the reopen-vs-sever decision (persistable kind with a captured path), used on both capture and restore so the two sides always agree.

## Testing

The predicate and path round-trip are host-tested: a regular file with a path is reopenable; a pathless file, a socket, and a device are severed. The pure core, both adapters, and `process.c` compile clean freestanding, and the end-to-end persistence demo still passes. CI links `checkpoint_extstate` into the filetable test since the predicate uses the external-state classification.

Before this, a process that had a file open at checkpoint time came back with that file severed; now the path is captured and the file is reopened at its saved offset.