### PR TITLE
Deterministic replay core: catalog (#160), input journal (#161), preemption (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 > The entire running system is the durable state. Pull the power cord, plug it back
 > in, and your work is exactly where you left it, mid-instruction.
 
-This is a real, proven idea (KeyKOS, EROS, Phantom OS; IBM i's single-level store in
-production) that **no other hobby-tier microkernel implements**. It is IKOS's reason to
+This is a real, proven idea (KeyKOS, EROS, Phantom OS, and IBM i's single-level store
+in production) that no other hobby-tier microkernel implements. It is IKOS's reason to
 exist, and it rides directly on the kernel's copy-on-write virtual memory.
 
-## ⚡ The headline: pull the plug, keep your work
+## The headline: pull the plug, keep your work
 
 A program does **nothing special** to be durable. The counter below has no `save()`,
 no `load()`, no serialization. The OS checkpoints the whole system periodically and
@@ -29,15 +29,15 @@ The end-to-end demo (`scripts/test/persistence_demo.sh`) proves it against the r
 checkpoint engine and on-disk store, modeling a power cut as a process restart:
 
 ```
-==> power cycle 1: boot fresh, count to 5
-  [run] counter now = 5 (then 'power is cut')
-==> reboot: counter must have survived at 5
-  [verify] counter = 5  == expected 5  -> REMEMBERED
-==> power cycle 2: count 5 more (resumes from 5)
-  [run] counter now = 10 (then 'power is cut')
-==> reboot: counter must have survived at 10
-  [verify] counter = 10  == expected 10  -> REMEMBERED
-==> crash test: cut power MID-RUN (kill -9), then reboot
+[cycle 1] boot fresh, count to 5
+  [run] counter now = 5 (then power is cut)
+[reboot] counter must have survived at 5
+  [verify] counter = 5  == expected 5  : REMEMBERED
+[cycle 2] count 5 more (resumes from 5)
+  [run] counter now = 10 (then power is cut)
+[reboot] counter must have survived at 10
+  [verify] counter = 10  == expected 10  : REMEMBERED
+[crash test] cut power mid-run (kill -9), then reboot
   [crash] reloaded a valid checkpoint; counter = 3903 (>= 10, monotonic)
 PASSED: the counter remembered itself across every power cycle
 ```
@@ -47,7 +47,7 @@ PASSED: the counter remembered itself across every power cycle
 A checkpoint marks every writable page read-only and copy-on-write (cheap; it copies
 nothing). The first write to a marked page faults, and the kernel preserves the page's
 pre-checkpoint contents before letting the write proceed. A background pass streams
-those pages into the **inactive** one of two on-disk slots; a single superblock-sector
+those pages into the **inactive** one of two on-disk slots. A single superblock-sector
 write flips the active slot and is the only commit point, so a crash before the flip
 always leaves the previous checkpoint intact (CRC32 guards every slot). On boot, if a
 valid checkpoint exists, the kernel reloads it instead of cold-starting.
@@ -67,24 +67,24 @@ Full design: [`docs/architecture/orthogonal-persistence.md`](docs/architecture/o
 The checkpoint store can live on the volatile RAM disk (survives a warm reboot) or, for
 true power-cut durability, on a real IDE disk via `checkpoint_ide_bind`.
 
-## ✅ What actually works vs. roadmap
+## What actually works vs. roadmap
 
 Being honest about maturity:
 
 | Area | Status |
 |------|--------|
-| Orthogonal persistence: snapshot store (double-buffered slots + CRC) | ✅ implemented, unit-tested |
-| Checkpoint engine: stop-the-world COW marking, page-fault capture, writeback | ✅ implemented, unit-tested |
-| Restore + boot decision (restore vs cold boot) | ✅ implemented, unit-tested |
-| Periodic checkpoint trigger (scheduler tick) | ✅ implemented, unit-tested |
-| External-state policy (sockets/DMA/devices severed on restore) | ✅ implemented, unit-tested |
-| Context persistence + process-table/scheduler reconstruction on restore | ✅ implemented, unit-tested |
-| End-to-end "yank power" proof over a file-backed disk | ✅ passing in CI |
-| Boot store wired to a block device (RAM disk, volatile) | ✅ implemented, unit-tested |
-| IDE-backed durable store (survives a real power cut) | 🚧 adapter implemented + unit-tested; in-kernel wiring + QEMU boot pending |
-| Process register/scheduler-state resume actually executing | 🚧 table/context restore done; scheduler bridge + QEMU boot pending |
-| In-QEMU boot demo + README GIF | 🚧 script ready; needs QEMU + a bootable image |
-| Persisting kernel-internal and driver state | 🔭 v2 (v1 cold-inits the kernel/drivers and restores user spaces on top) |
+| Orthogonal persistence: snapshot store (double-buffered slots + CRC) | Implemented, unit-tested |
+| Checkpoint engine: stop-the-world COW marking, page-fault capture, writeback | Implemented, unit-tested |
+| Restore + boot decision (restore vs cold boot) | Implemented, unit-tested |
+| Periodic checkpoint trigger (scheduler tick) | Implemented, unit-tested |
+| External-state policy (sockets/DMA/devices severed on restore) | Implemented, unit-tested |
+| Context persistence + process-table/scheduler reconstruction on restore | Implemented, unit-tested |
+| End-to-end "yank power" proof over a file-backed disk | Passing in CI |
+| Boot store wired to a block device (RAM disk, volatile) | Implemented, unit-tested |
+| IDE-backed durable store (survives a real power cut) | Adapter implemented + unit-tested; in-kernel wiring + QEMU boot pending |
+| Process register/scheduler-state resume actually executing | Table/context restore done; scheduler bridge + QEMU boot pending |
+| In-QEMU boot demo + README recording | Script ready; needs QEMU + a bootable image |
+| Persisting kernel-internal and driver state | v2 (v1 cold-inits the kernel/drivers and restores user spaces on top) |
 
 The broader subsystems below describe the project's overall scope; several are partial
 or aspirational. The persistence stack is the part with end-to-end tests and CI today.
@@ -95,114 +95,88 @@ or aspirational. The persistence stack is the part with end-to-end tests and CI 
 (desktops, laptops, embedded systems), organized around the orthogonal-persistence thesis
 above. Alongside it the project includes:
 
-- ♾️ **Orthogonal Persistence** with periodic system checkpoints and resume-on-boot
-- 🚀 **Custom Multi-Stage Bootloader** with real mode to long mode transition
-- 🧠 **Advanced Virtual Memory Manager (VMM)** with copy-on-write and demand paging
-- 💬 **Message-Passing IPC** for secure inter-process communication
-- 🎵 **Comprehensive Audio System** with AC97 codec support
-- 🖥️ **GUI Framework** with window management and graphics acceleration
-- 🌐 **TCP/IP Network Stack** with socket programming interface
-- 📁 **Virtual File System (VFS)** supporting multiple filesystems
-- 🔐 **Security Framework** with authentication and authorization
+- **Orthogonal Persistence** with periodic system checkpoints and resume-on-boot
+- **Custom Multi-Stage Bootloader** with a real mode to long mode transition
+- **Advanced Virtual Memory Manager (VMM)** with copy-on-write and demand paging
+- **Message-Passing IPC** for secure inter-process communication
+- **Audio System** scaffolding with AC97 codec support
+- **GUI Framework** with window management and graphics
+- **TCP/IP Network Stack** with a socket programming interface
+- **Virtual File System (VFS)** targeting multiple filesystems
+- **Security Framework** with authentication and authorization
 
-IKOS is developed with a **modular and parallel development approach**, enabling independent evolution of system components while maintaining clean interfaces and robust integration.
+IKOS is developed with a modular approach, enabling independent evolution of system
+components while maintaining clean interfaces and robust integration.
 
-## 🎯 Key Features
+## Key Concepts
 
-### 🏗️ **Microkernel Architecture**
-- **Minimal kernel space**: Only essential services (IPC, scheduling, memory management)
-- **User-space drivers**: Device drivers and system services run in protected user space
-- **Message-passing communication**: Secure and efficient inter-process communication
-- **Fault isolation**: System component failures don't crash the entire OS
+### Microkernel Architecture
+- **Minimal kernel space**: only essential services (IPC, scheduling, memory management)
+- **User-space drivers**: device drivers and system services run in protected user space
+- **Message-passing communication**: secure and efficient inter-process communication
+- **Fault isolation**: a failed component does not crash the entire system
 
-### 💾 **Advanced Memory Management**
-- **Virtual Memory Manager (VMM)**: Full x86_64 paging with 4-level page tables
-- **Copy-on-Write (COW)**: Efficient memory sharing and process forking
-- **Demand Paging**: Load pages only when needed for optimal memory usage
-- **Memory Protection**: Hardware-enforced isolation between processes
-- **NUMA Support**: Non-uniform memory access optimization
+### Advanced Memory Management
+- **Virtual Memory Manager (VMM)**: x86_64 paging with 4-level page tables
+- **Copy-on-Write (COW)**: efficient memory sharing, process forking, and the basis of persistence
+- **Demand Paging**: load pages only when needed
+- **Memory Protection**: hardware-enforced isolation between processes
 
-### 🎵 **Multimedia Support**
-- **Audio System**: Comprehensive audio framework with AC97 codec driver
-- **Sound Playback & Recording**: Multiple format support (PCM 8/16/24/32-bit)
-- **Volume Control**: Per-device volume and mute functionality
-- **Tone Generation**: Built-in tone generator for system sounds and testing
+### Graphics and GUI
+- **Framebuffer Driver**: direct graphics memory access
+- **Window Manager**: windowing system with compositing
+- **GUI Framework**: widget library for application development
+- **Input Handling**: keyboard and mouse support
 
-### 🖥️ **Graphics & GUI**
-- **Framebuffer Driver**: Direct graphics memory access
-- **Window Manager**: Advanced windowing system with compositing
-- **GUI Framework**: Rich widget library for application development
-- **Input Handling**: Comprehensive keyboard and mouse support
-- **Terminal Emulator**: Feature-rich terminal with escape sequence support
-
-### 🌐 **Networking**
-- **TCP/IP Stack**: Full IPv4 networking implementation
+### Networking
+- **TCP/IP Stack**: IPv4 networking implementation
 - **Socket API**: Berkeley sockets compatible interface
 - **Network Drivers**: Ethernet and Wi-Fi device support
-- **DNS & TLS**: Domain name resolution and secure connections
 
-### 📁 **File System**
-- **Virtual File System (VFS)**: Unified interface for multiple filesystems
-- **FAT32 Support**: Read/write support for FAT32 filesystems
+### File System
+- **Virtual File System (VFS)**: unified interface for multiple filesystems
+- **FAT32 Support**: read/write support for FAT32
 - **EXT2/EXT4 Support**: Linux-compatible filesystem support
-- **File Explorer**: Graphical file management application
-- **POSIX Compliance**: Standard file operations and permissions
 
-### 🔐 **Security & Authentication**
-- **User Authentication**: Multi-factor authentication support
-- **Authorization Framework**: Role-based access control
-- **Process Isolation**: Hardware-enforced process boundaries
-- **Secure Boot**: Verified boot chain from bootloader to kernel
+### Security and Authentication
+- **User Authentication**: authentication framework with multi-factor support
+- **Authorization Framework**: role-based access control
+- **Process Isolation**: hardware-enforced process boundaries
 
-### 🛠️ **Development Tools**
-- **Runtime Debugger**: Kernel-level debugging with symbol support
-- **Logging System**: Comprehensive system logging and analysis
-- **Build System**: Automated build and testing infrastructure
-- **Documentation**: Extensive technical documentation for all components
+## Architecture Overview
 
-## 🏗️ Architecture Overview
-
-IKOS follows a **microkernel architecture** with clear separation between kernel space and user space:
+IKOS follows a microkernel architecture with clear separation between kernel space and
+user space:
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    User Applications                            │
-│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌──────────── │
-│  │  GUI Apps   │ │   Terminal  │ │ File Manager│ │  Web Browser │
-│  └─────────────┘ └─────────────┘ └─────────────┘ └──────────── │
-├─────────────────────────────────────────────────────────────────┤
-│                    System Services                              │
-│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌──────────── │
-│  │ File System │ │   Network   │ │    Audio    │ │   Graphics  │
-│  │   Service   │ │   Service   │ │   Service   │ │   Service   │
-│  └─────────────┘ └─────────────┘ └─────────────┘ └──────────── │
-├─────────────────────────────────────────────────────────────────┤
-│                    Device Drivers                               │
-│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌──────────── │
-│  │   Storage   │ │   Network   │ │    Audio    │ │    Input    │
-│  │   Drivers   │ │   Drivers   │ │   Drivers   │ │   Drivers   │
-│  └─────────────┘ └─────────────┘ └─────────────┘ └──────────── │
-├─────────────────────────────────────────────────────────────────┤
-│                      Microkernel                                │
-│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌──────────── │
-│  │     IPC     │ │  Scheduler  │ │     VMM     │ │ Interrupts  │
-│  │   Manager   │ │   Manager   │ │   Manager   │ │   Handler   │
-│  └─────────────┘ └─────────────┘ └─────────────┘ └──────────── │
-├─────────────────────────────────────────────────────────────────┤
-│                      Hardware Layer                             │
-│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌──────────── │
-│  │     CPU     │ │    Memory   │ │   Storage   │ │  Peripherals│
-│  └─────────────┘ └─────────────┘ └─────────────┘ └──────────── │
-└─────────────────────────────────────────────────────────────────┘
++-----------------------------------------------------------------+
+|                    User Applications                            |
+|   GUI Apps      Terminal      File Manager      Web Browser     |
++-----------------------------------------------------------------+
+|                    System Services                              |
+|   File System   Network       Audio            Graphics        |
+|   Service       Service       Service          Service         |
++-----------------------------------------------------------------+
+|                    Device Drivers                               |
+|   Storage       Network       Audio            Input           |
+|   Drivers       Drivers       Drivers          Drivers         |
++-----------------------------------------------------------------+
+|                      Microkernel                                |
+|   IPC           Scheduler     VMM              Interrupts      |
+|   Manager       Manager       Manager          Handler         |
++-----------------------------------------------------------------+
+|                      Hardware Layer                             |
+|   CPU           Memory        Storage          Peripherals     |
++-----------------------------------------------------------------+
 ```
 
 ### Communication Flow
-- **System Calls**: User applications communicate with kernel via system call interface
-- **Message Passing**: Inter-process communication through secure message queues
-- **Shared Memory**: High-performance data sharing between authorized processes
-- **Interrupts**: Hardware events handled by kernel and forwarded to appropriate drivers
+- **System Calls**: user applications reach the kernel via the system call interface
+- **Message Passing**: inter-process communication through secure message queues
+- **Shared Memory**: high-performance data sharing between authorized processes
+- **Interrupts**: hardware events handled by the kernel and forwarded to drivers
 
-## 🚀 Getting Started
+## Getting Started
 
 ### Prerequisites
 
@@ -230,37 +204,35 @@ brew install nasm gcc make qemu git
 
 ### Quick Start
 
-1. **Clone the repository:**
+1. Clone the repository:
    ```bash
    git clone https://github.com/Ikey168/IKOS.git
    cd IKOS
    ```
 
-2. **Build the complete system:**
+2. Build the complete system:
    ```bash
    make all
    ```
 
-3. **Test the latest bootloader (ELF kernel loading):**
+3. Test the ELF-loading bootloader:
    ```bash
    make test-elf-compact
    ```
 
-4. **Run specific components:**
+4. Run specific components:
    ```bash
    # Audio system
    cd kernel && make audio-system && make audio-test
-   
+
    # GUI system
    make gui-system && ./test_gui.sh
-   
+
    # Network stack
    make network-test
    ```
 
 ### Build Targets
-
-IKOS provides multiple build targets for different components:
 
 | Target | Description |
 |--------|-------------|
@@ -273,9 +245,9 @@ IKOS provides multiple build targets for different components:
 | `make test` | Run comprehensive test suite |
 | `make clean` | Clean all build artifacts |
 
-### Testing & Debugging
+## Testing and Debugging
 
-#### Running Tests
+### Running Tests
 ```bash
 # Complete system test
 make test
@@ -295,25 +267,12 @@ make test
 
 # Memory and process testing
 ./scripts/test/test_advanced_memory.sh   # Advanced memory management
-./scripts/test/test_paging.sh           # Paging system tests
+./scripts/test/test_paging.sh            # Paging system tests
 ```
 
-#### Validation & Verification
+### Debugging with QEMU and GDB
 ```bash
-# System validation
-./scripts/validation/validate_scheduler.sh    # Scheduler validation
-./scripts/validation/validate_cli.sh          # CLI validation
-./scripts/validation/verify_device_framework.sh # Device framework verification
-
-# Debugging
-./scripts/debug/debug_boot.sh                 # Boot process debugging
-./scripts/validation/validate_kernel_debug.sh # Kernel debugging validation
-```
-```
-
-#### Debugging with QEMU + GDB
-```bash
-# Start QEMU with GDB server
+# Start QEMU with a GDB server
 make debug
 
 # In another terminal, connect GDB
@@ -323,329 +282,140 @@ gdb kernel/kernel.elf
 (gdb) continue
 ```
 
-#### Expected Output
-
-**ELF Kernel Loading Bootloader:**
-```
-IKOS Bootloader v2.0 - Long Mode
-Initializing system...
-Loading ELF kernel...
-IKOS: ELF->LOAD->KERNEL
-Kernel loaded successfully
-Switching to long mode...
-IKOS Kernel v1.0 starting...
-```
-
-**Audio System Test:**
-```
-=== IKOS Audio System Test ===
-Initializing audio library...
-Found 1 audio devices
-Device 0: AC97 Audio Controller
-Volume control: OK
-Stream operations: OK
-Tone generation: OK
-All tests PASSED!
-## 📁 Project Structure
+## Project Structure
 
 ```
 IKOS/
-├── 🚀 boot/                           # Multi-stage bootloader implementations
-│   ├── boot.asm                      # Basic real mode bootloader
-│   ├── boot_enhanced.asm             # Enhanced bootloader with memory detection
-│   ├── boot_longmode.asm             # Long mode (64-bit) bootloader
-│   ├── boot_elf_loader.asm           # ELF kernel loading bootloader
-│   └── boot.ld                       # Bootloader linker script
-├── 🧠 kernel/                         # Microkernel implementation
-│   ├── audio.c                       # Audio system framework
-│   ├── scheduler.c                   # Process scheduler
-│   ├── interrupts.c                  # Interrupt handling
-│   ├── vmm.c                         # Virtual memory manager
-│   ├── ipc.c                         # Inter-process communication
-│   ├── gui.c                         # GUI framework
-│   ├── framebuffer.c                 # Graphics framebuffer driver
-│   ├── network_driver.c              # Network stack implementation
-│   └── Makefile                      # Kernel build system
-├── 📋 include/                        # System headers and definitions
-│   ├── audio.h                       # Audio system API
-│   ├── audio_ac97.h                  # AC97 codec driver
-│   ├── audio_user.h                  # User-space audio library
-│   ├── vmm.h                         # Virtual memory management
-│   ├── scheduler.h                   # Process scheduling
-│   ├── gui.h                         # GUI framework
-│   ├── framebuffer.h                 # Graphics API
-│   └── syscalls.h                    # System call interface
-├── 🧪 tests/                          # Comprehensive test suites
-│   ├── test_audio.c                  # Audio system tests
-│   ├── test_gui.c                    # GUI system tests
-│   ├── test_scheduler.c              # Scheduler tests
-│   └── test_memory.c                 # Memory management tests
-├── 👤 user/                           # User-space applications
-│   ├── shell/                        # Command-line shell
-│   ├── gui_apps/                     # Graphical applications
-│   └── demos/                        # Example applications
-├── 📚 docs/                           # Comprehensive documentation
-│   ├── README.md                     # Documentation index
-│   ├── architecture/                 # System architecture docs
-│   │   ├── VMM_README.md            # Virtual memory architecture
-│   │   ├── DEVICE_DRIVER_FRAMEWORK.md # Driver framework design
-│   │   ├── USB_DRIVER_FRAMEWORK.md  # USB framework architecture
-│   │   ├── NETWORK_STACK.md         # Network stack design
-│   │   └── TCPIP.md                 # TCP/IP implementation
-│   ├── implementation/               # Implementation documentation
-│   │   ├── AUDIO_IMPLEMENTATION.md  # Audio system implementation
-│   │   ├── GUI_IMPLEMENTATION.md    # GUI framework implementation
-│   │   ├── SCHEDULER_IMPLEMENTATION.md # Scheduler implementation
-│   │   ├── VMM_IMPLEMENTATION_SUMMARY.md # Memory management
-│   │   └── ...                      # Other component implementations
-│   └── testing/                      # Testing and debugging docs
-│       ├── QEMU_REAL_HARDWARE_TEST.md # Hardware testing guide
-│       ├── RUNTIME_KERNEL_DEBUGGER.md # Debugging guide
-│       └── real_hardware_test.md    # Real hardware testing
-├── 🔧 scripts/                        # Build, test, and utility scripts
-│   ├── README.md                     # Scripts documentation
-│   ├── build/                        # Build scripts
-│   │   ├── build_kernel_debug.sh    # Debug kernel build
-│   │   ├── build_userspace.sh       # User-space build
-│   │   └── create_bios_uefi_compat.sh # Boot image creation
-│   ├── test/                         # Test scripts
-│   │   ├── test_audio_system.sh     # Audio system tests
-│   │   ├── test_gui.sh              # GUI system tests
-│   │   ├── test_advanced_memory.sh  # Memory management tests
-│   │   ├── qemu_test.sh             # QEMU testing
-│   │   └── ...                      # Other test scripts
-│   ├── validation/                   # Validation scripts
-│   │   ├── validate_scheduler.sh    # Scheduler validation
-│   │   ├── validate_cli.sh          # CLI validation
-│   │   └── verify_device_framework.sh # Device framework verification
-│   └── debug/                        # Debug scripts
-│       └── debug_boot.sh            # Boot debugging
-├── 🔧 tools/                          # Development tools and utilities
-│   ├── analyze_paging.py            # Paging analysis tool
-│   └── test_signal_compile.c        # Signal testing utility
-├── 📋 examples/                       # Demo scripts and examples
-│   ├── demo_issue_17.sh             # Issue #17 demonstration
-│   └── demo_issue_18.sh             # Issue #18 demonstration
-├── 🏗️ build/                          # Build artifacts (generated)
-├── 📦 bin/                            # Binary executables
-├── 📚 lib/                            # System libraries
-└── 🛠️ Makefile                        # Main build system
+  boot/                  Multi-stage bootloader implementations
+    boot.asm             Basic real mode bootloader
+    boot_enhanced.asm    Enhanced bootloader with memory detection
+    boot_longmode.asm    Long mode (64-bit) bootloader
+    boot_elf_loader.asm  ELF kernel loading bootloader
+    boot.ld              Bootloader linker script
+  kernel/                Microkernel implementation
+    checkpoint*.c        Orthogonal persistence: engine, store, restore
+    scheduler.c          Process scheduler
+    interrupts.c         Interrupt handling
+    vmm.c                Virtual memory manager
+    ipc.c                Inter-process communication
+    gui.c                GUI framework
+    framebuffer.c        Graphics framebuffer driver
+    network_driver.c     Network stack implementation
+    Makefile             Kernel build system
+  include/               System headers and definitions
+  tests/                 Component and integration test suites
+  user/                  User-space applications and demos
+  docs/                  Architecture, implementation, and testing docs
+  scripts/               Build, test, validation, and debug scripts
+  tools/                 Development tools and utilities
+  examples/              Demo scripts and examples
+  Makefile               Main build system
 ```
 
-## 🎯 Current Status & Milestones
+## Roadmap
 
-### ✅ **Completed Components**
+The near-term focus is the persistence stack and the capabilities that build on it.
 
-#### 🚀 **Bootloader & Initialization** 
-- ✅ Real mode initialization and memory detection
-- ✅ Protected mode transition with A20 line enablement
-- ✅ Long mode (64-bit) transition and setup
-- ✅ ELF kernel loading and execution
-- ✅ Multi-stage bootloader architecture
+### Time-Travel Debugging (in design)
 
-#### 🧠 **Microkernel Core**
-- ✅ Process scheduler with preemptive multitasking
-- ✅ Virtual memory manager (VMM) with paging
-- ✅ Interrupt handling and system calls
-- ✅ Inter-process communication (IPC)
-- ✅ Memory allocation and management
+The checkpoint engine already produces periodic whole-system keyframes. Adding a
+deterministic input journal between keyframes makes execution reproducible, which turns
+"remember the last moment" into "remember every moment, and move through them." This
+enables whole-system reverse debugging (rewind, reverse-step, reverse breakpoints)
+inside the guest. Tracked in the epic and its sub-issues on the issue tracker.
 
-#### 🎵 **Audio System**
-- ✅ Comprehensive audio framework
-- ✅ AC97 codec driver implementation
-- ✅ Audio streaming and buffer management
-- ✅ Volume control and device management
-- ✅ User-space audio library and API
+Planned milestones:
+- Deterministic replay core: catalog nondeterminism, input journal, deterministic
+  preemption, virtualized time and entropy
+- Replay engine plus a divergence detector that proves a replay is byte-exact
+- Time-travel UX: keyframe retention, rewind-to, reverse execution
+- Tooling: a GDB reverse-execution bridge and, as an experiment, an MCP interface so an
+  AI agent can drive record and rewind as callable tools
 
-#### 🖥️ **Graphics & GUI**
-- ✅ Framebuffer driver for direct graphics access
-- ✅ GUI framework with widget system
-- ✅ Window management and compositing
-- ✅ Input handling (keyboard and mouse)
-- ✅ Terminal emulator with advanced features
+### Systems Roadmap
 
-#### 🌐 **Networking**
-- ✅ TCP/IP stack implementation
-- ✅ Socket programming interface
-- ✅ Network device drivers (Ethernet/Wi-Fi)
-- ✅ DNS resolution and TLS support
+Short term:
+- [ ] IDE-backed durable store wired into the in-kernel boot path
+- [ ] In-QEMU boot demo for the persistence resume
+- [ ] UEFI boot support
+- [ ] Performance optimizations
 
-#### 📁 **File System**
-- ✅ Virtual File System (VFS) framework
-- ✅ FAT32 filesystem support
-- ✅ EXT2/EXT4 filesystem support
-- ✅ File operations and permissions
+Medium term:
+- [ ] SMP (symmetric multiprocessing) support
+- [ ] Persisting kernel-internal and driver state (persistence v2)
+- [ ] Broader networking features
+- [ ] Package management
 
-#### 🔐 **Security & Authentication**
-- ✅ User authentication system
-- ✅ Multi-factor authentication support
-- ✅ Authorization and access control
-- ✅ Process isolation and protection
+Long term:
+- [ ] Container and virtualization support
+- [ ] Advanced power management
+- [ ] Hardware abstraction layer
 
-#### 🛠️ **Development Tools**
-- ✅ Runtime kernel debugger
-- ✅ Comprehensive logging system
-- ✅ Build automation and testing
-- ✅ Memory analysis tools
+## Contributing
 
-### 🚧 **In Progress**
-- 🔄 Advanced memory management optimizations
-- 🔄 Hardware acceleration for graphics
-- 🔄 Advanced networking protocols
-- 🔄 Package management system
-
-### 📋 **Planned Features**
-- 📅 UEFI boot support
-- 📅 SMP (multi-processor) support
-- 📅 Advanced power management
-- 📅 Container/virtualization support
-- 📅 Package repository and installer
-
-## 🧪 Testing & Quality Assurance
-
-IKOS includes comprehensive testing infrastructure:
-
-### Test Categories
-- **Unit Tests**: Individual component testing
-- **Integration Tests**: Component interaction testing  
-- **System Tests**: End-to-end functionality testing
-- **Performance Tests**: Benchmarking and optimization
-- **Hardware Tests**: Real hardware compatibility testing
-
-### Automated Testing
-```bash
-# Run all tests
-make test-all
-
-# Component-specific testing
-make test-audio      # Audio system tests
-make test-gui        # GUI framework tests
-make test-memory     # Memory management tests
-make test-network    # Network stack tests
-make test-fs         # Filesystem tests
-```
-
-### Continuous Integration
-- Automated builds on multiple architectures
-- Regression testing for all components
-- Performance benchmarking
-- Code quality analysis
-- Documentation validation
-
-## 🤝 Contributing
-
-We welcome contributions from developers of all skill levels! Here's how to get started:
+Contributions are welcome from developers of all skill levels.
 
 ### Development Setup
-1. **Fork and clone the repository:**
+1. Fork and clone the repository:
    ```bash
    git clone https://github.com/yourusername/IKOS.git
    cd IKOS
    ```
 
-2. **Set up development environment:**
+2. Set up the development environment:
    ```bash
    make install-deps    # Install development dependencies
-   make all            # Build the complete system
-   make test           # Run test suite
+   make all             # Build the complete system
+   make test            # Run the test suite
    ```
 
-3. **Create a feature branch:**
+3. Create a feature branch:
    ```bash
    git checkout -b feature/your-feature-name
    ```
 
 ### Contribution Guidelines
-- **Code Style**: Follow the established coding conventions
-- **Testing**: Add tests for new features and bug fixes
-- **Documentation**: Update documentation for any API changes
-- **Commit Messages**: Use clear, descriptive commit messages
-- **Pull Requests**: Provide detailed descriptions of changes
+- **Code Style**: follow the established coding conventions
+- **Testing**: add tests for new features and bug fixes
+- **Documentation**: update documentation for any API changes
+- **Commit Messages**: use clear, descriptive commit messages
+- **Pull Requests**: provide detailed descriptions of changes
 
 ### Areas Looking for Contributors
-- 🔧 Device drivers (graphics, sound, network)
-- 🎮 Game and multimedia applications
-- 🌐 Web browser and internet applications
-- 📚 Documentation and tutorials
-- 🧪 Testing and quality assurance
-- 🎨 UI/UX design and themes
+- The persistence stack: IDE-backed store wiring and the in-QEMU boot demo
+- Time-travel debugging: deterministic replay and the divergence detector
+- Device drivers (graphics, sound, network)
+- Documentation and tutorials
+- Testing and quality assurance
 
-## 📚 Documentation
+## Documentation
 
-### Technical Documentation
-- **[Audio System](AUDIO_IMPLEMENTATION.md)** - Complete audio framework documentation
-- **[GUI Framework](GUI_IMPLEMENTATION.md)** - Graphics and windowing system
-- **[Scheduler](SCHEDULER_IMPLEMENTATION.md)** - Process scheduling and multitasking
-- **[Memory Management](ADVANCED_MEMORY_MANAGEMENT.md)** - VMM and memory allocation
-- **[Network Stack](NETWORK_STACK.md)** - TCP/IP implementation
-- **[File Systems](VFS_IMPLEMENTATION.md)** - Virtual file system and storage
+### Architecture
+- [Orthogonal Persistence](docs/architecture/orthogonal-persistence.md)
+- [Virtual Memory Architecture](docs/architecture/VMM_README.md)
+- [Device Driver Framework](docs/architecture/DEVICE_DRIVER_FRAMEWORK.md)
+- [Network Stack](docs/architecture/NETWORK_STACK.md)
+- [TCP/IP Implementation](docs/architecture/TCPIP.md)
 
-### User Documentation
-- **[Getting Started](docs/getting-started.md)** - Installation and basic usage
-- **[User Guide](docs/user-guide.md)** - Complete user manual
-- **[Application Development](docs/app-development.md)** - Writing applications for IKOS
-- **[System Administration](docs/system-admin.md)** - System configuration and management
+### Implementation and Testing
+- [Audio System](docs/implementation/AUDIO_IMPLEMENTATION.md)
+- [GUI Framework](docs/implementation/GUI_IMPLEMENTATION.md)
+- [Scheduler](docs/implementation/SCHEDULER_IMPLEMENTATION.md)
+- [Memory Management](docs/implementation/VMM_IMPLEMENTATION_SUMMARY.md)
+- [Hardware Testing Guide](docs/testing/QEMU_REAL_HARDWARE_TEST.md)
+- [Runtime Kernel Debugger](docs/testing/RUNTIME_KERNEL_DEBUGGER.md)
 
-### Developer Documentation
-- **[Kernel API](docs/kernel-api.md)** - Kernel programming interface
-- **[Driver Development](docs/driver-development.md)** - Writing device drivers
-- **[Debugging Guide](docs/debugging.md)** - Debugging tools and techniques
-- **[Testing Guide](docs/testing.md)** - Testing frameworks and procedures
+## License
 
-## 🚀 Roadmap
+This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) file for
+the full text.
 
-### Short Term (Q1 2026)
-- [ ] UEFI boot support implementation
-- [ ] Advanced graphics acceleration
-- [ ] Enhanced audio codec support
-- [ ] Improved memory management
-- [ ] Performance optimizations
+## Acknowledgments
 
-### Medium Term (Q2-Q3 2026)
-- [ ] SMP (symmetric multiprocessing) support
-- [ ] Advanced networking features
-- [ ] Package management system
-- [ ] Container support
-- [ ] Advanced security features
+- **Contributors**: thanks to everyone who has contributed to IKOS
+- **Community**: thanks to the open-source OS development community
+- **Tools**: built with GCC, NASM, QEMU, and Git
+- **Inspiration**: the orthogonal-persistence lineage of KeyKOS, EROS, Phantom OS, and
+  IBM i's single-level store
 
-### Long Term (Q4 2026 and beyond)
-- [ ] Virtualization support
-- [ ] Advanced power management
-- [ ] Hardware abstraction layer
-- [ ] Mobile device support
-- [ ] Cloud integration features
-
-## 📄 License
-
-This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
-
-```
-MIT License
-
-Copyright (c) 2025 IKOS Operating System Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-```
-
-## 🙏 Acknowledgments
-
-- **Contributors**: Thanks to all the developers who have contributed to IKOS
-- **Community**: Special thanks to the open-source OS development community
-- **Tools**: Built with amazing open-source tools like GCC, NASM, QEMU, and Git
-- **Inspiration**: Inspired by classic operating systems and modern design principles
-
----
-
-**IKOS Operating System** - Building the future of computing, one commit at a time! 🚀
-
-*For questions, suggestions, or support, please open an issue or join our community discussions.*
-
-
+For questions, suggestions, or support, please open an issue or start a discussion.

--- a/README.md
+++ b/README.md
@@ -322,15 +322,17 @@ The checkpoint engine already produces periodic whole-system keyframes. Adding a
 deterministic input journal between keyframes makes execution reproducible, which turns
 "remember the last moment" into "remember every moment, and move through them." This
 enables whole-system reverse debugging (rewind, reverse-step, reverse breakpoints)
-inside the guest. Tracked in the epic and its sub-issues on the issue tracker.
+inside the guest. Tracked in the epic and its sub-issues on the issue tracker. Full
+design: [`docs/architecture/time-travel.md`](docs/architecture/time-travel.md).
 
 Planned milestones:
 - Deterministic replay core: catalog nondeterminism, input journal, deterministic
   preemption, virtualized time and entropy
 - Replay engine plus a divergence detector that proves a replay is byte-exact
 - Time-travel UX: keyframe retention, rewind-to, reverse execution
-- Tooling: a GDB reverse-execution bridge and, as an experiment, an MCP interface so an
-  AI agent can drive record and rewind as callable tools
+- Tooling: a GDB reverse-execution bridge
+- MCP interface: expose record, rewind, and reverse execution as tools an AI agent can
+  call, with a demo where an agent debugs a planted heisenbug by rewinding the machine
 
 ### Systems Roadmap
 

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -1,0 +1,146 @@
+# Time-Travel Debugging: Deterministic Replay Core and MCP Interface
+
+This document is the design home for turning IKOS from a system that remembers the last
+moment into one that remembers every moment and lets you move through them. It covers two
+plans:
+
+1. The **Deterministic Replay Core**: make execution between checkpoints reproducible.
+2. The **MCP Interface**: expose record, rewind, and reverse execution as tools an AI
+   agent can call.
+
+Both build on the existing checkpoint engine (`kernel/checkpoint.c`,
+`kernel/checkpoint_barrier.c`, the scheduler-tick trigger, and the restore and
+reconstruct path). See [orthogonal-persistence.md](orthogonal-persistence.md) for that
+foundation. Work is tracked in the epic and its sub-issues on the issue tracker.
+
+## Why this is tractable here
+
+The checkpoint engine already produces periodic whole-system keyframes. A keyframe is a
+consistent snapshot of every user address space plus the process table and scheduler
+state. What it does not capture is the path between two keyframes: the exact sequence of
+inputs and preemptions that led from one to the next.
+
+If that path is made reproducible, then any past instant can be reconstructed by taking
+the nearest keyframe at or before it and replaying forward. Reverse execution then falls
+out for free: to step backward, restore the prior keyframe and replay to just before the
+current point. A small purpose-built kernel is far easier to make fully deterministic
+than a general-purpose OS, which is the core advantage IKOS has here.
+
+## Plan 1: Deterministic Replay Core
+
+Goal: two runs from the same keyframe, given the same recorded inputs, reach a
+byte-identical state at every epoch boundary.
+
+### Sources of nondeterminism
+
+Every source that can make two runs diverge must be either recorded and replayed,
+virtualized, or gated to a deterministic point.
+
+| Source | How it leaks in | Strategy |
+|--------|-----------------|----------|
+| Interrupt and preemption timing | The scheduler preempts at hardware-timer edges that vary run to run | Record the logical point of each context switch; replay switches at the same points |
+| Scheduler tick | Drives periodic checkpoints and time slicing | Fold into the recorded preemption sequence |
+| Time and cycle reads (RDTSC, timers) | User or kernel code branches on wall-clock or cycle values | Record the value on the live run; return the recorded value on replay |
+| Device input (keyboard, IDE completion IRQs, network) | External events arrive at arbitrary times | Record each event with its epoch and logical clock in the input journal |
+| RNG and entropy | Seeds differ per boot | Capture seeds into the checkpoint so sequences replay identically |
+
+### Components
+
+**Input journal.** A ring log written alongside each checkpoint slot that captures every
+nondeterministic input, tagged with the epoch and a logical clock. It reuses the
+double-buffered slot and CRC conventions in `kernel/checkpoint_disk.c`, and must survive a
+crash as cleanly as the checkpoint slots: a crash before commit leaves the last good
+journal intact. The journal is the delta that turns discrete keyframes into a continuous,
+replayable timeline.
+
+**Deterministic preemption.** Record the tick or instruction-count sequence at which
+context switches occur, so replay switches contexts at the identical points a live run
+did. This touches `kernel/interrupt_stubs.asm`, the timer and scheduler path, and the
+existing tick-based checkpoint trigger. Preemption timing is the single largest divergence
+risk; getting it right removes most replay drift.
+
+**Time and entropy capture.** Trap or wrap RDTSC, timer counters, and RNG seeding so that
+on replay they return recorded values rather than live hardware.
+
+### Replay engine and verification
+
+**Replay mode.** Boot from the nearest keyframe and apply the input journal forward to
+reach an arbitrary target epoch. This reuses the existing restore plus process-table,
+scheduler, and context reconstruction path. A target epoch is a checkpoint epoch plus an
+offset into the journal.
+
+**Divergence detector.** During replay, checksum system state at each epoch boundary and
+compare against what was recorded live. Any mismatch is a nondeterminism leak the catalog
+missed. Build this early and keep it on in debug builds; it is the harness that keeps the
+whole feature honest.
+
+**CI test.** A `scripts/test/timetravel_demo.sh` in the spirit of
+`scripts/test/persistence_demo.sh`: run a session, replay it headless, and assert the
+final state is byte-identical. This gates the milestone and guards against regressions.
+
+### Time-travel UX
+
+- **Keyframe retention ring.** Keep the last N checkpoints on disk, not just the
+  double-buffered latest, so rewind targets are not limited to the most recent snapshot.
+- **rewind-to.** Restore the nearest keyframe at or before a target epoch and replay to
+  the exact target point.
+- **Reverse execution.** `reverse-step` and `reverse-continue`, implemented as restore
+  the prior keyframe and replay forward to just before the current point.
+- **Reverse breakpoints and watchpoints.** Replay forward from the nearest keyframe until
+  a condition is hit, to answer "where did this value last change?"
+
+## Plan 2: MCP Interface
+
+Goal: expose record, rewind, and reverse execution as Model Context Protocol tools so an
+AI agent can drive a time-traveling debugger over a well-defined interface.
+
+The interface changes who the customer is. Instead of a human who must adopt a new OS, the
+consumer is an agent that calls tools. Agents are poor at exactly what this engine is good
+at: reproducing a non-deterministic bug, stepping backward, and keeping the world stable
+between runs. Running a program inside IKOS gives the agent a fully reproducible, rewindable
+world it cannot get on a general-purpose OS.
+
+### Tool surface
+
+The MCP server is a thin wrapper over the replay engine. Proposed tools:
+
+- `record_session(program)`: run the program under the input journal and return a session
+  handle
+- `list_checkpoints()`: list available keyframes and their epochs
+- `diff_epochs(a, b)`: report what changed between two moments
+- `rewind_to(epoch)`: restore the nearest keyframe and replay to the target
+- `reverse_step()` and `reverse_continue()`: step or run backward
+- `watch_last_write(addr_or_symbol)`: find the last write to an address or symbol
+- `replay(from, to)`: deterministically replay a range
+
+### Agent debugging flow
+
+1. The agent runs suspect code with `record_session`.
+2. On a failure, it calls `watch_last_write` or `diff_epochs` to localize the cause.
+3. It uses `rewind_to` and `reverse_step` to inspect the exact moment the state went bad.
+4. It proposes a fix, re-records, and confirms the failure no longer reproduces.
+
+### Positioning and limits
+
+- MCP is the interface, not the value. It exposes the replay engine; it does not create
+  it. The Deterministic Replay Core must land first, or the tools return garbage.
+- MCP is not a moat. Anyone can wrap an existing record-replay tool in MCP. The defensible
+  asset is the deterministic-sandbox property that off-the-shelf engines cannot match.
+- Scope it to code the agent runs inside IKOS: greenfield code, reproducible verification,
+  embedded targets, and teaching. It is not a way to rewind an existing production
+  deployment.
+
+## Milestones
+
+- **A. Deterministic replay core**: catalog nondeterminism, input journal, deterministic
+  preemption, virtualized time and entropy.
+- **B. Replay engine and verification**: replay mode plus the divergence detector, gated
+  by a byte-identical CI test.
+- **C. Time-travel UX**: keyframe retention, rewind-to, reverse execution, reverse
+  breakpoints.
+- **D. Tooling**: a GDB reverse-execution bridge.
+- **E. MCP interface**: the tool surface above, plus a demo in which an agent debugs a
+  planted heisenbug by rewinding the machine.
+
+Suggested order: land the A chain first, since it proves the whole thesis before any UX,
+GDB, or MCP work. Milestone E depends on C.

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -33,16 +33,58 @@ byte-identical state at every epoch boundary.
 
 ### Sources of nondeterminism
 
-Every source that can make two runs diverge must be either recorded and replayed,
-virtualized, or gated to a deterministic point.
+This section is the spike deliverable for the catalog. Every source that can make two runs
+diverge must be either recorded and replayed, virtualized, or gated to a deterministic
+point. Each entry below is grounded in the current code.
 
-| Source | How it leaks in | Strategy |
-|--------|-----------------|----------|
-| Interrupt and preemption timing | The scheduler preempts at hardware-timer edges that vary run to run | Record the logical point of each context switch; replay switches at the same points |
-| Scheduler tick | Drives periodic checkpoints and time slicing | Fold into the recorded preemption sequence |
-| Time and cycle reads (RDTSC, timers) | User or kernel code branches on wall-clock or cycle values | Record the value on the live run; return the recorded value on replay |
-| Device input (keyboard, IDE completion IRQs, network) | External events arrive at arbitrary times | Record each event with its epoch and logical clock in the input journal |
-| RNG and entropy | Seeds differ per boot | Capture seeds into the checkpoint so sequences replay identically |
+#### Spike findings (current code)
+
+A read of the kernel established the facts that shape the plan:
+
+- Preemption is driven by the PIT on IRQ0. `kernel/interrupts.c` programs the PIT
+  (`setup_timer_interrupt`, ports 0x43 and 0x40) and routes IRQ0 to INT 32
+  (`timer_interrupt_entry`). `scheduler_tick` in `kernel/scheduler.c` is the handler and
+  does round-robin preemption when a task's `time_slice` reaches zero. Where each tick
+  lands in the instruction stream is the dominant source of divergence.
+- The checkpoint cadence is already tick-counted, not wall-clock. `checkpoint_tick`
+  (`kernel/checkpoint.c:668`) increments `g_timer_ticks` and fires every
+  `g_timer_interval` ticks. Keyframe epochs are therefore already deterministic once the
+  tick sequence itself is deterministic; checkpoint timing needs no separate work.
+- RDTSC is not yet a live source. `get_rdtsc` in `kernel/numa_allocator.c` is a stub that
+  returns 0. It must be recorded or virtualized before any real RDTSC read is added, but
+  it does not cause divergence today.
+- The random MAC generator `eth_addr_random` in `kernel/net/ethernet.c` is actually
+  hardcoded, so it is deterministic despite its name. Networking state is also severed on
+  restore by the external-state policy, so net-path randomness does not affect persistence
+  correctness.
+- Real external entropy enters through `auth_generate_random` in `kernel/auth_core.c`,
+  which reads `/dev/urandom`. This is a genuine nondeterministic source.
+- The IDE driver polls rather than taking completion interrupts (`ide_wait_ready` and
+  `ide_wait_drq` in `kernel/ide_driver.c` spin on the status register). Disk data content
+  is deterministic; only the number of poll iterations varies, which perturbs timing.
+
+#### Catalog and strategies
+
+| Source | Where it enters | Strategy | Files touched |
+|--------|-----------------|----------|---------------|
+| Interrupt and preemption timing | PIT IRQ0 lands at a hardware-timed point in the instruction stream; `scheduler_tick` may preempt | Record the logical point of each context switch (an instruction or event count since the epoch); on replay, deliver the tick and preempt at the same point | `kernel/interrupt_stubs.asm`, `kernel/interrupts.c`, `kernel/scheduler.c` |
+| Checkpoint cadence | `checkpoint_tick` fires on a tick count | Already deterministic given a deterministic tick sequence; no change beyond the preemption work | `kernel/checkpoint.c` (no change expected) |
+| Keyboard input | Scancodes arrive via IRQ1 and are read and translated in `kernel/input_keyboard.c` | Record each scancode with its epoch and logical clock in the input journal; feed from the journal on replay | `kernel/input_keyboard.c`, `kernel/input_manager.c`, journal |
+| External entropy (/dev/urandom) | `auth_generate_random` reads `/dev/urandom` | Record the returned bytes on the live run and return them on replay, or seed a recorded PRNG captured in the checkpoint | `kernel/auth_core.c`, journal |
+| RDTSC and cycle reads (latent) | `get_rdtsc` stub today; any future real read branches on cycles | Record on the live run and return recorded values on replay; gate before a real RDTSC is introduced | `kernel/numa_allocator.c`, journal |
+| IDE completion timing | Poll-loop iteration counts vary in `ide_wait_ready` and `ide_wait_drq` | Content is deterministic; keep polling from perturbing the logical clock, or drain completions at a fixed logical point | `kernel/ide_driver.c` |
+| MAC and TLS randomness (not active) | `eth_addr_random` is hardcoded; net state is severed on restore | No action for persistence; if net replay is wanted later, record like other entropy | `kernel/net/*` (future) |
+
+The input journal referenced above is the deliverable of the next issue and reuses the
+double-buffered slot and CRC conventions in `kernel/checkpoint_disk.c`.
+
+#### Decision: not started pending review
+
+Per the issue, no implementation begins until this catalog is reviewed. The catalog fixes
+the scope of the deterministic replay core: the primary work is deterministic preemption,
+the input journal for keyboard input and entropy, and a gate for RDTSC before it goes
+live. RDTSC (stub today), the hardcoded MAC, and severed network randomness need no work
+now.
 
 ### Components
 


### PR DESCRIPTION
## Summary

The first three steps of the deterministic replay core (epic #159), on the same branch and so sharing one PR. Each is independently tested; default runtime behavior is unchanged.

- Implements #160: nondeterminism catalog (design doc).
- Implements #161: input journal (new module + unit test + CI).
- Implements #162: deterministic preemption points (new module + scheduler seam + unit test + CI).

## What is in this PR

**Implements #162: deterministic preemption (`kernel/sched_record.c`, `include/sched_record.h`)**

Preemption timing is the dominant divergence source (#160): a live run is preempted wherever the PIT tick lands in the instruction stream. This records the logical point of every context switch and, on replay, forces switches at exactly those points.

- Pure, host-testable decision core keyed by a per-epoch logical clock. `OFF` is exact passthrough; `RECORD` notes the lclock at each switch; `REPLAY` forces switches at the recorded points and ignores the natural time-slice decision so real timing cannot perturb the schedule.
- `kernel/scheduler.c` advances a per-epoch logical clock in `scheduler_tick` and routes the round-robin decision through `sched_record_decide()`. Default mode `OFF` keeps behavior byte-identical; adds `scheduler_preempt_{set_mode,points,load}` for the replay engine (#165).
- `tests/test_sched_record.c`: 12 checks (OFF passthrough, RECORD captures points, REPLAY reproduces switches at identical logical points, epoch reset, overflow).

Acceptance criteria: context-switch points recorded on a live run; replay reproduces switches at the same logical points. End-to-end verification lands with the divergence detector (#166).

**Implements #161: input journal (`kernel/checkpoint_journal.c`, `include/checkpoint_journal.h`)**

Records nondeterministic inputs (keystrokes, disk completions, timer/cycle reads, entropy) between checkpoints, each tagged with epoch + logical clock. On-disk layout mirrors the snapshot store: superblock + two double-buffered slots, CRC32-protected, single superblock-flip commit (crash before the flip leaves the previous journal intact). Dependency-free and host-testable. `tests/test_checkpoint_journal.c`: 14 checks.

**Implements #160: nondeterminism catalog (`docs/architecture/time-travel.md`)**

Code-grounded spike with a decided strategy per source and the files each touches.

**Time-travel design doc + README rewrite**

The doc also lays out the replay core and MCP interface plans. The README is rewritten with an honest maturity framing and all emojis, arrow glyphs, and em-dashes removed.

## Testing

- `test_sched_record` (12 checks) and `test_checkpoint_journal` (14 checks) pass.
- Freestanding compile check passes for `sched_record.c`, `checkpoint_journal.c`, and the modified `scheduler.c` (no new warnings).
- Docs verified free of emojis, arrow glyphs, and em-dashes.
- Branch merges into `main` with no conflicts.

## Related issues

- Implements #160, #161, #162
- Part of epic #159; unblocks #164 (entropy capture), #165 (replay engine), #166 (divergence detector)