### PR TITLE
Deterministic preemption points (#162)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -12,7 +12,12 @@ on:
       - 'kernel/snapshot_store.c'
       - 'include/checkpoint*.h'
       - 'include/snapshot_store.h'
+      - 'kernel/sched_record.c'
+      - 'kernel/scheduler.c'
+      - 'include/sched_record.h'
+      - 'include/scheduler.h'
       - 'tests/test_checkpoint*.c'
+      - 'tests/test_sched_record.c'
       - 'tests/test_snapshot_store.c'
       - 'tests/test_persistence_e2e.c'
       - 'scripts/test/persistence_demo.sh'
@@ -32,7 +37,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -63,6 +68,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c   ../kernel/checkpoint_extstate.c && /tmp/t_ext
           gcc -I../include -Wall -o /tmp/t_init   test_persistence_init.c     $KR && /tmp/t_init
           gcc -I../include -Wall -o /tmp/t_ide    test_checkpoint_ide.c       ../kernel/checkpoint_ide.c ../kernel/snapshot_store.c && /tmp/t_ide
+          gcc -I../include -Wall -o /tmp/t_sr     test_sched_record.c         ../kernel/sched_record.c && /tmp/t_sr
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/sched_record.h
+++ b/include/sched_record.h
@@ -1,0 +1,75 @@
+/* IKOS Orthogonal Persistence - Deterministic Preemption (#162, epic #159)
+ *
+ * Preemption timing is the dominant source of replay divergence (see
+ * docs/architecture/time-travel.md, #160): on a live run the scheduler is
+ * preempted wherever the PIT tick happens to land in the instruction stream,
+ * which varies run to run. To make replay deterministic, this module records
+ * the logical point of every context switch on the live run, and on replay
+ * forces switches at exactly those same points instead of at the (now absent)
+ * real time-slice boundary.
+ *
+ * "Logical point" is a monotonic per-epoch clock supplied by the scheduler.
+ * The first cut advances it once per timer tick (the same cadence the
+ * checkpoint trigger already counts); a later cut can swap in a retired-
+ * instruction count without changing this interface. The clock source is
+ * injected, so this core is pure and host-testable, like the barrier (#138)
+ * and the input journal (#161).
+ *
+ * The recorded points are the per-epoch delta that pairs with the input
+ * journal; the replay engine (#165) persists and reloads them.
+ */
+
+#ifndef SCHED_RECORD_H
+#define SCHED_RECORD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    SCHED_REC_OFF = 0,   /* passthrough: the natural policy decision stands */
+    SCHED_REC_RECORD,    /* note the logical clock at each switch */
+    SCHED_REC_REPLAY     /* force switches at the recorded logical clocks */
+} sched_rec_mode_t;
+
+#define SCHED_REC_OK          0
+#define SCHED_REC_ERR_PARAM  -1
+
+typedef struct {
+    sched_rec_mode_t mode;
+    uint64_t  epoch;      /* epoch the current points belong to */
+    uint64_t* points;     /* logical clock at each switch, in recorded order */
+    uint32_t  capacity;   /* slots in points[] */
+    uint32_t  count;      /* recorded (RECORD) or loaded (REPLAY) switch count */
+    uint32_t  cursor;     /* next unmatched point (REPLAY) */
+    uint32_t  overflow;   /* switches dropped past capacity (RECORD) */
+} sched_record_t;
+
+/* Bind a record to a caller-provided points buffer and set the initial mode. */
+int sched_record_init(sched_record_t* r, sched_rec_mode_t mode,
+                      uint64_t* buf, uint32_t capacity);
+
+/* Switch modes (for example OFF to RECORD when tracing begins). */
+void sched_record_set_mode(sched_record_t* r, sched_rec_mode_t mode);
+
+/* Start a new epoch: clears the recorded count and the replay cursor. The
+ * scheduler calls this when checkpoint_current_epoch() advances. */
+void sched_record_begin_epoch(sched_record_t* r, uint64_t epoch);
+
+/* REPLAY: install the switch points recorded for `epoch`. */
+int sched_record_load(sched_record_t* r, uint64_t epoch,
+                      const uint64_t* pts, uint32_t n);
+
+/* The single decision hook the scheduler calls each tick. `want` is the
+ * policy's natural decision (for round robin: the time slice just hit zero).
+ *   OFF:    returns `want`; records nothing.
+ *   RECORD: if `want`, appends `lclock`; returns `want`.
+ *   REPLAY: ignores `want`; returns true once `lclock` reaches the next
+ *           recorded point, consuming it, so switches land at identical points.
+ */
+bool sched_record_decide(sched_record_t* r, bool want, uint64_t lclock);
+
+/* Recorded switch points for the current epoch (RECORD), for persisting into
+ * the journal. Returns the count; *out points at the buffer (may be NULL). */
+uint32_t sched_record_points(const sched_record_t* r, const uint64_t** out);
+
+#endif /* SCHED_RECORD_H */

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "sched_record.h"
 
 /* Task States */
 typedef enum {
@@ -126,6 +127,14 @@ task_t* priority_pick_next(void);
 /* Timer interrupt handling */
 void timer_interrupt_handler(void);
 void setup_timer_interrupt(uint32_t frequency);
+
+/* Deterministic preemption controls (#162). Default mode is SCHED_REC_OFF, so
+ * preemption behaves exactly as before until a record or replay run enables it.
+ * scheduler_preempt_points() returns the per-epoch switch points for the
+ * journal; scheduler_preempt_load() installs them for a replay. */
+void     scheduler_preempt_set_mode(sched_rec_mode_t mode);
+uint32_t scheduler_preempt_points(const uint64_t** out);
+int      scheduler_preempt_load(uint64_t epoch, const uint64_t* pts, uint32_t n);
 
 /* System calls */
 void sys_yield(void);

--- a/kernel/sched_record.c
+++ b/kernel/sched_record.c
@@ -1,0 +1,87 @@
+/* IKOS Orthogonal Persistence - Deterministic Preemption (#162, epic #159)
+ *
+ * See include/sched_record.h and docs/architecture/time-travel.md.
+ *
+ * Pure decision core: no allocator, no hardware, no I/O. The scheduler owns the
+ * points buffer and the logical clock and calls sched_record_decide() at the
+ * point it would otherwise consult the round-robin time slice.
+ */
+
+#include "sched_record.h"
+
+int sched_record_init(sched_record_t* r, sched_rec_mode_t mode,
+                      uint64_t* buf, uint32_t capacity) {
+    if (!r || !buf || capacity == 0) return SCHED_REC_ERR_PARAM;
+    r->mode = mode;
+    r->epoch = 0;
+    r->points = buf;
+    r->capacity = capacity;
+    r->count = 0;
+    r->cursor = 0;
+    r->overflow = 0;
+    return SCHED_REC_OK;
+}
+
+void sched_record_set_mode(sched_record_t* r, sched_rec_mode_t mode) {
+    if (!r) return;
+    r->mode = mode;
+}
+
+void sched_record_begin_epoch(sched_record_t* r, uint64_t epoch) {
+    if (!r) return;
+    r->epoch = epoch;
+    r->count = 0;
+    r->cursor = 0;
+    r->overflow = 0;
+}
+
+int sched_record_load(sched_record_t* r, uint64_t epoch,
+                      const uint64_t* pts, uint32_t n) {
+    if (!r || (!pts && n > 0)) return SCHED_REC_ERR_PARAM;
+    if (n > r->capacity) return SCHED_REC_ERR_PARAM;
+    r->epoch = epoch;
+    r->count = n;
+    r->cursor = 0;
+    r->overflow = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        r->points[i] = pts[i];
+    }
+    return SCHED_REC_OK;
+}
+
+bool sched_record_decide(sched_record_t* r, bool want, uint64_t lclock) {
+    if (!r) return want;
+
+    switch (r->mode) {
+    case SCHED_REC_RECORD:
+        if (want) {
+            if (r->count < r->capacity) {
+                r->points[r->count++] = lclock;
+            } else {
+                r->overflow++;
+            }
+        }
+        return want;
+
+    case SCHED_REC_REPLAY:
+        /* Preempt exactly where the live run did: when the logical clock has
+         * reached the next recorded switch point, consume it and switch. The
+         * natural `want` is deliberately ignored so real time-slice timing
+         * cannot perturb the replayed schedule. */
+        if (r->cursor < r->count && lclock >= r->points[r->cursor]) {
+            r->cursor++;
+            return true;
+        }
+        return false;
+
+    case SCHED_REC_OFF:
+    default:
+        return want;
+    }
+}
+
+uint32_t sched_record_points(const sched_record_t* r, const uint64_t** out) {
+    if (!r) { if (out) *out = 0; return 0; }
+    if (out) *out = r->points;
+    return r->count;
+}

--- a/kernel/scheduler.c
+++ b/kernel/scheduler.c
@@ -5,12 +5,23 @@
 #include "scheduler.h"
 #include "memory.h"
 #include "interrupts.h"
+#include "sched_record.h"
 #include <string.h>
 
 /* Orthogonal persistence (#117): drive the periodic checkpoint trigger from
  * the timer tick. Forward-declared to avoid pulling the checkpoint/store
  * headers (and their block-device deps) into the scheduler. */
 extern bool checkpoint_tick(void);
+
+/* Deterministic preemption (#162): record the logical point of every context
+ * switch so a replay can reproduce the schedule. checkpoint_current_epoch()
+ * keys the per-epoch points; forward-declared for the same reason as above. */
+extern uint64_t checkpoint_current_epoch(void);
+
+#define SCHED_REC_MAX_POINTS 256
+static uint64_t g_sched_points[SCHED_REC_MAX_POINTS];
+static sched_record_t g_sched_rec;
+static uint64_t g_sched_lclock = 0;   /* logical clock since the current epoch */
 
 /* Global scheduler state */
 static task_t* current_task = NULL;
@@ -50,7 +61,12 @@ int scheduler_init(sched_policy_t policy, uint32_t time_slice) {
     default_time_slice = time_slice;
     stats.policy = policy;
     stats.time_slice = time_slice;
-    
+
+    /* Deterministic preemption starts OFF: identical behavior to before, until
+     * a record or replay run enables it (#162). */
+    sched_record_init(&g_sched_rec, SCHED_REC_OFF, g_sched_points, SCHED_REC_MAX_POINTS);
+    g_sched_lclock = 0;
+
     // Create idle task
     idle_task = create_idle_task();
     if (!idle_task) {
@@ -208,25 +224,56 @@ void scheduler_tick(void) {
     
     // Update current task time
     current_task->cpu_time++;
-    
+
+    /* Deterministic preemption (#162): advance the per-epoch logical clock and
+     * route the preemption decision through the record/replay filter. In OFF
+     * mode (the default) the natural round-robin decision passes through
+     * unchanged; RECORD notes the switch point; REPLAY forces switches at the
+     * recorded points so real tick timing cannot perturb the schedule. */
+    if (g_sched_rec.mode != SCHED_REC_OFF) {
+        uint64_t epoch = checkpoint_current_epoch();
+        if (epoch != g_sched_rec.epoch) {
+            sched_record_begin_epoch(&g_sched_rec, epoch);
+            g_sched_lclock = 0;
+        }
+    }
+    g_sched_lclock++;
+
     // Decrement time slice for current task
     if (current_task->time_slice > 0) {
         current_task->time_slice--;
     }
-    
-    // Check if time slice expired (for Round Robin)
-    if (current_policy == SCHED_ROUND_ROBIN && current_task->time_slice == 0) {
+
+    // Preempt when Round Robin's slice expires, filtered for deterministic replay
+    bool want = (current_policy == SCHED_ROUND_ROBIN && current_task->time_slice == 0);
+    if (sched_record_decide(&g_sched_rec, want, g_sched_lclock)) {
         // Reset time slice
         current_task->time_slice = current_task->quantum;
-        
+
         // Move to end of ready queue and schedule
         if (current_task->state == TASK_RUNNING) {
             current_task->state = TASK_READY;
             ready_queue_add(current_task);
         }
-        
+
         schedule();
     }
+}
+
+/* ---- Deterministic preemption controls (#162) ----
+ * Thin wrappers the replay engine (#165) uses to drive the record/replay of
+ * preemption points. Default mode is OFF, so these have no effect until called.
+ */
+void scheduler_preempt_set_mode(sched_rec_mode_t mode) {
+    sched_record_set_mode(&g_sched_rec, mode);
+}
+
+uint32_t scheduler_preempt_points(const uint64_t** out) {
+    return sched_record_points(&g_sched_rec, out);
+}
+
+int scheduler_preempt_load(uint64_t epoch, const uint64_t* pts, uint32_t n) {
+    return sched_record_load(&g_sched_rec, epoch, pts, n);
 }
 
 /**

--- a/tests/test_sched_record.c
+++ b/tests/test_sched_record.c
@@ -1,0 +1,141 @@
+/* Host-side unit test for deterministic preemption (#162).
+ *
+ * Verifies:
+ *   1. OFF mode is exact passthrough and records nothing (unchanged behavior).
+ *   2. RECORD captures the logical clock at each context switch.
+ *   3. REPLAY reproduces switches at the identical logical points, ignoring the
+ *      natural time-slice decision (so real timing cannot perturb the schedule).
+ *   4. begin_epoch resets per-epoch state; load installs replay points.
+ *   5. Overflow past the buffer capacity is counted, not written out of bounds.
+ *
+ * Build: gcc -I../include -o test_sched_record \
+ *            test_sched_record.c ../kernel/sched_record.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "sched_record.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* A scripted "natural" round-robin decision: preempt when the simulated time
+ * slice expires. The gap between expiries jitters to mimic the nondeterministic
+ * spacing of real ticks. Returns want for the given tick index. */
+static bool natural_want(uint32_t tick, uint32_t* slice_left, const uint32_t* slices,
+                         uint32_t nslices, uint32_t* slice_idx) {
+    (void)tick;
+    if (*slice_left == 0) {
+        /* pick the next slice length and start counting down */
+        *slice_left = slices[(*slice_idx) % nslices];
+        (*slice_idx)++;
+    }
+    (*slice_left)--;
+    return (*slice_left == 0);
+}
+
+int main(void) {
+    printf("=== Deterministic preemption (#162) unit test ===\n");
+
+    /* --- 1. OFF passthrough --- */
+    {
+        uint64_t buf[64];
+        sched_record_t r;
+        sched_record_init(&r, SCHED_REC_OFF, buf, 64);
+        bool a = sched_record_decide(&r, true, 10);
+        bool b = sched_record_decide(&r, false, 11);
+        CHECK(a == true && b == false, "OFF returns the natural decision unchanged");
+        const uint64_t* pts;
+        CHECK(sched_record_points(&r, &pts) == 0, "OFF records nothing");
+    }
+
+    /* --- 2 & 3. RECORD then REPLAY reproduce identical switch points --- */
+    uint64_t rec_buf[64];
+    sched_record_t rec;
+    uint32_t recorded_switch_lclocks[64];
+    uint32_t nrecorded = 0;
+    {
+        sched_record_init(&rec, SCHED_REC_RECORD, rec_buf, 64);
+        sched_record_begin_epoch(&rec, 1);
+
+        const uint32_t slices[] = {5, 3, 7, 4, 6};
+        uint32_t slice_left = 0, slice_idx = 0;
+        uint64_t lclock = 0;
+        for (uint32_t tick = 0; tick < 50; tick++) {
+            lclock++; /* one logical unit per tick */
+            bool want = natural_want(tick, &slice_left, slices, 5, &slice_idx);
+            bool sw = sched_record_decide(&rec, want, lclock);
+            if (sw) recorded_switch_lclocks[nrecorded++] = (uint32_t)lclock;
+        }
+        const uint64_t* pts;
+        uint32_t n = sched_record_points(&rec, &pts);
+        CHECK(n == nrecorded && n > 0, "RECORD captured one point per switch");
+        int match = 1;
+        for (uint32_t i = 0; i < n; i++)
+            if (pts[i] != recorded_switch_lclocks[i]) match = 0;
+        CHECK(match, "recorded points equal the lclocks where switches occurred");
+    }
+
+    {
+        /* Replay: feed want=false on every tick (natural decision suppressed),
+         * and confirm switches land at exactly the recorded lclocks. */
+        const uint64_t* rec_pts;
+        uint32_t n = sched_record_points(&rec, &rec_pts);
+
+        uint64_t rep_buf[64];
+        sched_record_t rep;
+        sched_record_init(&rep, SCHED_REC_REPLAY, rep_buf, 64);
+        CHECK(sched_record_load(&rep, 1, rec_pts, n) == SCHED_REC_OK, "load replay points");
+
+        uint32_t replay_switch_lclocks[64];
+        uint32_t nreplay = 0;
+        for (uint64_t lclock = 1; lclock <= 50; lclock++) {
+            bool sw = sched_record_decide(&rep, /*want=*/false, lclock);
+            if (sw) replay_switch_lclocks[nreplay++] = (uint32_t)lclock;
+        }
+        CHECK(nreplay == nrecorded, "replay produced the same number of switches");
+        int same = (nreplay == nrecorded);
+        for (uint32_t i = 0; i < nreplay && same; i++)
+            if (replay_switch_lclocks[i] != recorded_switch_lclocks[i]) same = 0;
+        CHECK(same, "replay switched at the identical logical points, ignoring `want`");
+    }
+
+    /* --- 4. begin_epoch resets state --- */
+    {
+        uint64_t buf[8];
+        sched_record_t r;
+        sched_record_init(&r, SCHED_REC_RECORD, buf, 8);
+        sched_record_begin_epoch(&r, 1);
+        sched_record_decide(&r, true, 3);
+        sched_record_decide(&r, true, 9);
+        const uint64_t* pts;
+        CHECK(sched_record_points(&r, &pts) == 2, "two points before new epoch");
+        sched_record_begin_epoch(&r, 2);
+        CHECK(sched_record_points(&r, &pts) == 0, "begin_epoch cleared the points");
+        CHECK(r.epoch == 2, "epoch advanced");
+    }
+
+    /* --- 5. Overflow is counted, not written past the buffer --- */
+    {
+        uint64_t buf[4];
+        sched_record_t r;
+        sched_record_init(&r, SCHED_REC_RECORD, buf, 4);
+        sched_record_begin_epoch(&r, 1);
+        for (uint64_t i = 1; i <= 10; i++) sched_record_decide(&r, true, i);
+        const uint64_t* pts;
+        CHECK(sched_record_points(&r, &pts) == 4, "count clamped to capacity");
+        CHECK(r.overflow == 6, "overflow counted the dropped switches");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: preemption points record and replay deterministically\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Implements #162 (epic #159), isolated on its own branch off `main`. This is the deterministic-preemption step of the replay core: it makes *when* the scheduler preempts reproducible, which #160 identified as the dominant source of replay divergence.

Scope is exactly #162 (6 files, +373 lines). Default runtime behavior is unchanged.

## What changed

**`kernel/sched_record.c` + `include/sched_record.h` (new)**

A pure, host-testable record/replay decision core keyed by a per-epoch logical clock:
- `OFF` (default): exact passthrough, records nothing, behavior identical to today.
- `RECORD`: notes the logical clock at each context switch.
- `REPLAY`: forces switches at exactly the recorded points and ignores the natural time-slice decision, so real tick timing cannot perturb the replayed schedule.

No allocator, no hardware, no I/O (same pattern as the barrier core in #138).

**`kernel/scheduler.c` (seam)**

`scheduler_tick` advances a per-epoch logical clock and routes the round-robin preemption decision through `sched_record_decide()`. Mode `OFF` keeps behavior byte-identical. Adds `scheduler_preempt_{set_mode,points,load}` so the replay engine (#165) can drive record/replay and move the points to/from the input journal.

**`tests/test_sched_record.c` (new)**

12 checks: OFF passthrough, RECORD captures switch points, REPLAY reproduces switches at identical logical points, `begin_epoch` reset, and overflow handling.

**`.github/workflows/persistence.yml`**

Trigger paths, a freestanding compile check for `sched_record.c`, and the unit test.

## Testing

- `test_sched_record`: 12/12 checks pass.
- Freestanding compile clean for `sched_record.c` and the modified `scheduler.c` (only pre-existing warnings).
- Branch is exactly #162 and branches from current `main`.

## Design note

The logical clock advances once per timer tick in this first cut (the cadence the checkpoint trigger already counts). The interface takes the clock as an injected value, so a retired-instruction count can drop in later without touching `sched_record.c`. Acceptance criteria 1 and 2 are met and tested here; criterion 3 ("verified by the divergence detector") is #166's job.

## Related issues

- Implements #162
- Part of epic #159; depends on the #160 catalog; unblocks #165 (replay engine) and #166 (divergence detector)