### PR TITLE
Virtualize timestamp / cycle reads (RDTSC, timers) (#163)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -16,8 +16,12 @@ on:
       - 'kernel/scheduler.c'
       - 'include/sched_record.h'
       - 'include/scheduler.h'
+      - 'kernel/time_record.c'
+      - 'kernel/time_record_sync.c'
+      - 'include/time_record.h'
       - 'tests/test_checkpoint*.c'
       - 'tests/test_sched_record.c'
+      - 'tests/test_time_record.c'
       - 'tests/test_snapshot_store.c'
       - 'tests/test_persistence_e2e.c'
       - 'scripts/test/persistence_demo.sh'
@@ -37,7 +41,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -69,6 +73,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_init   test_persistence_init.c     $KR && /tmp/t_init
           gcc -I../include -Wall -o /tmp/t_ide    test_checkpoint_ide.c       ../kernel/checkpoint_ide.c ../kernel/snapshot_store.c && /tmp/t_ide
           gcc -I../include -Wall -o /tmp/t_sr     test_sched_record.c         ../kernel/sched_record.c && /tmp/t_sr
+          gcc -I../include -Wall -o /tmp/t_time   test_time_record.c          ../kernel/time_record.c && /tmp/t_time
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/time_record.h
+++ b/include/time_record.h
@@ -1,0 +1,91 @@
+/* IKOS Orthogonal Persistence - Virtualized Time Reads (#163, epic #159)
+ *
+ * Time and cycle reads (RDTSC, timer counters) return a different value on
+ * every run, so any code that branches on them diverges under replay (see the
+ * nondeterminism catalog in docs/architecture/time-travel.md, #160). This
+ * module wraps such a read: on a live run it reads the real clock and records
+ * the value; on replay it returns the recorded value instead of touching
+ * hardware, so a program that branches on the clock replays identically.
+ *
+ * The catalog notes that IKOS has no live RDTSC read yet (numa_allocator.c's
+ * get_rdtsc is a stub returning 0), so this lands the gate first: future time
+ * reads go through time_record_read()/ktime_read() rather than a raw RDTSC.
+ *
+ * The core is pure and host-testable: the live clock is injected as a function
+ * pointer, so tests drive it with a mock source. The kernel adapter
+ * (time_record_sync.c) supplies the real x86 RDTSC source.
+ *
+ * The recorded values are the per-epoch delta that pairs with the input journal
+ * (#161); the replay engine (#165) persists and reloads them.
+ */
+
+#ifndef TIME_RECORD_H
+#define TIME_RECORD_H
+
+#include <stdint.h>
+
+typedef enum {
+    TIME_REC_OFF = 0,   /* passthrough: read the live clock, record nothing */
+    TIME_REC_RECORD,    /* read the live clock and log each value */
+    TIME_REC_REPLAY     /* return logged values; never touch hardware */
+} time_rec_mode_t;
+
+#define TIME_REC_OK          0
+#define TIME_REC_ERR_PARAM  -1
+
+/* Reads the live hardware clock (RDTSC or a timer counter). */
+typedef uint64_t (*time_source_fn)(void* ctx);
+
+typedef struct {
+    time_rec_mode_t mode;
+    time_source_fn  source;   /* live clock read (OFF and RECORD) */
+    void*           ctx;
+    uint64_t        epoch;    /* epoch the current values belong to */
+    uint64_t*       log;      /* recorded values in read order */
+    uint32_t        capacity; /* slots in log[] */
+    uint32_t        count;    /* recorded (RECORD) or loaded (REPLAY) count */
+    uint32_t        cursor;   /* next value to return (REPLAY) */
+    uint32_t        overflow; /* reads past capacity (RECORD) */
+    uint32_t        underflow;/* reads past the recorded count (REPLAY) */
+    uint64_t        last;     /* last value returned */
+} time_record_t;
+
+/* Bind a record to a caller-provided value buffer and a live clock source.
+ * source may be NULL when mode is REPLAY (hardware is never read). */
+int time_record_init(time_record_t* tr, time_rec_mode_t mode,
+                     time_source_fn source, void* ctx,
+                     uint64_t* buf, uint32_t capacity);
+
+void time_record_set_mode(time_record_t* tr, time_rec_mode_t mode);
+
+/* Start a new epoch: clears the recorded count and the replay cursor. */
+void time_record_begin_epoch(time_record_t* tr, uint64_t epoch);
+
+/* REPLAY: install the values recorded for `epoch`. */
+int time_record_load(time_record_t* tr, uint64_t epoch,
+                     const uint64_t* vals, uint32_t n);
+
+/* The wrapped read. OFF: returns the live clock. RECORD: reads the live clock,
+ * logs it, and returns it. REPLAY: returns the next logged value without
+ * touching hardware (past the end, returns the last value and counts an
+ * underflow). */
+uint64_t time_record_read(time_record_t* tr);
+
+/* Recorded values for the current epoch (RECORD), for persisting into the
+ * journal. Returns the count; *out points at the buffer (may be NULL). */
+uint32_t time_record_values(const time_record_t* tr, const uint64_t** out);
+
+/* ---- Kernel adapter (time_record_sync.c) ----
+ * A global time_record backed by the real x86 RDTSC. Kernel code that needs a
+ * cycle/time value should call ktime_read() so the read is captured for replay.
+ * Default mode is OFF, so this reads live hardware until a record/replay run
+ * enables it. */
+#define KTIME_LOG_MAX 4096
+void     ktime_init(void);
+uint64_t ktime_read(void);
+void     ktime_set_mode(time_rec_mode_t mode);
+void     ktime_begin_epoch(uint64_t epoch);
+uint32_t ktime_values(const uint64_t** out);
+int      ktime_load(uint64_t epoch, const uint64_t* vals, uint32_t n);
+
+#endif /* TIME_RECORD_H */

--- a/kernel/time_record.c
+++ b/kernel/time_record.c
@@ -1,0 +1,108 @@
+/* IKOS Orthogonal Persistence - Virtualized Time Reads (#163, epic #159)
+ *
+ * See include/time_record.h and docs/architecture/time-travel.md.
+ *
+ * Pure decision core: no allocator, no hardware, no I/O. The caller owns the
+ * value buffer and injects the live clock as a function pointer, so this is
+ * host-testable with a mock source.
+ */
+
+#include "time_record.h"
+
+int time_record_init(time_record_t* tr, time_rec_mode_t mode,
+                     time_source_fn source, void* ctx,
+                     uint64_t* buf, uint32_t capacity) {
+    if (!tr || !buf || capacity == 0) return TIME_REC_ERR_PARAM;
+    tr->mode = mode;
+    tr->source = source;
+    tr->ctx = ctx;
+    tr->epoch = 0;
+    tr->log = buf;
+    tr->capacity = capacity;
+    tr->count = 0;
+    tr->cursor = 0;
+    tr->overflow = 0;
+    tr->underflow = 0;
+    tr->last = 0;
+    return TIME_REC_OK;
+}
+
+void time_record_set_mode(time_record_t* tr, time_rec_mode_t mode) {
+    if (!tr) return;
+    tr->mode = mode;
+}
+
+void time_record_begin_epoch(time_record_t* tr, uint64_t epoch) {
+    if (!tr) return;
+    tr->epoch = epoch;
+    tr->count = 0;
+    tr->cursor = 0;
+    tr->overflow = 0;
+    tr->underflow = 0;
+}
+
+int time_record_load(time_record_t* tr, uint64_t epoch,
+                     const uint64_t* vals, uint32_t n) {
+    if (!tr || (!vals && n > 0)) return TIME_REC_ERR_PARAM;
+    if (n > tr->capacity) return TIME_REC_ERR_PARAM;
+    tr->epoch = epoch;
+    tr->count = n;
+    tr->cursor = 0;
+    tr->overflow = 0;
+    tr->underflow = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        tr->log[i] = vals[i];
+    }
+    return TIME_REC_OK;
+}
+
+/* Read the live source, tolerating a NULL source (returns the last value). */
+static uint64_t read_live(time_record_t* tr) {
+    if (!tr->source) return tr->last;
+    return tr->source(tr->ctx);
+}
+
+uint64_t time_record_read(time_record_t* tr) {
+    if (!tr) return 0;
+
+    switch (tr->mode) {
+    case TIME_REC_RECORD: {
+        uint64_t v = read_live(tr);
+        if (tr->count < tr->capacity) {
+            tr->log[tr->count++] = v;
+        } else {
+            tr->overflow++;
+        }
+        tr->last = v;
+        return v;
+    }
+
+    case TIME_REC_REPLAY: {
+        uint64_t v;
+        if (tr->cursor < tr->count) {
+            v = tr->log[tr->cursor++];
+        } else {
+            /* More reads than were recorded: a divergence. Return the last
+             * value so callers stay monotonic, and count it so #166 can flag
+             * it. Hardware is deliberately never read here. */
+            tr->underflow++;
+            v = tr->last;
+        }
+        tr->last = v;
+        return v;
+    }
+
+    case TIME_REC_OFF:
+    default: {
+        uint64_t v = read_live(tr);
+        tr->last = v;
+        return v;
+    }
+    }
+}
+
+uint32_t time_record_values(const time_record_t* tr, const uint64_t** out) {
+    if (!tr) { if (out) *out = 0; return 0; }
+    if (out) *out = tr->log;
+    return tr->count;
+}

--- a/kernel/time_record_sync.c
+++ b/kernel/time_record_sync.c
@@ -1,0 +1,49 @@
+/* IKOS Orthogonal Persistence - Virtualized Time Reads, kernel adapter (#163)
+ *
+ * Wires the pure time_record core (time_record.c) to the real x86 cycle
+ * counter and exposes a global instance. Kernel code that needs a time or
+ * cycle value should call ktime_read() instead of a raw RDTSC, so the value is
+ * captured on a record run and reproduced on replay.
+ *
+ * This is the "trap or wrap" site named in #163: today IKOS has no live RDTSC
+ * read (numa_allocator.c's get_rdtsc is a stub), so ktime_read() is the single
+ * gate future callers route through.
+ */
+
+#include "time_record.h"
+
+/* Read the x86 timestamp counter. */
+static uint64_t ktime_rdtsc(void* ctx) {
+    (void)ctx;
+    uint32_t lo, hi;
+    __asm__ volatile("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)hi << 32) | (uint64_t)lo;
+}
+
+static uint64_t     g_ktime_log[KTIME_LOG_MAX];
+static time_record_t g_ktime;
+
+void ktime_init(void) {
+    time_record_init(&g_ktime, TIME_REC_OFF, ktime_rdtsc, 0,
+                     g_ktime_log, KTIME_LOG_MAX);
+}
+
+uint64_t ktime_read(void) {
+    return time_record_read(&g_ktime);
+}
+
+void ktime_set_mode(time_rec_mode_t mode) {
+    time_record_set_mode(&g_ktime, mode);
+}
+
+void ktime_begin_epoch(uint64_t epoch) {
+    time_record_begin_epoch(&g_ktime, epoch);
+}
+
+uint32_t ktime_values(const uint64_t** out) {
+    return time_record_values(&g_ktime, out);
+}
+
+int ktime_load(uint64_t epoch, const uint64_t* vals, uint32_t n) {
+    return time_record_load(&g_ktime, epoch, vals, n);
+}

--- a/tests/test_time_record.c
+++ b/tests/test_time_record.c
@@ -1,0 +1,151 @@
+/* Host-side unit test for virtualized time reads (#163).
+ *
+ * Verifies:
+ *   1. OFF is passthrough and records nothing.
+ *   2. RECORD logs each live clock read.
+ *   3. REPLAY returns the recorded values and never touches hardware: a program
+ *      that branches on the clock replays identically even when the live source
+ *      is fed hostile values.
+ *   4. begin_epoch resets state; load installs replay values.
+ *   5. Overflow (record) and underflow (replay) are counted, not out of bounds.
+ *
+ * Build: gcc -I../include -o test_time_record \
+ *            test_time_record.c ../kernel/time_record.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "time_record.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* A mock "TSC": returns a running counter that jumps by an irregular stride,
+ * mimicking the nondeterministic spacing of a real cycle counter. */
+typedef struct { uint64_t now; int step; } mock_tsc_t;
+static uint64_t mock_tsc_read(void* ctx) {
+    mock_tsc_t* m = (mock_tsc_t*)ctx;
+    static const uint64_t strides[] = {97, 13, 251, 41, 5, 163};
+    m->now += strides[(m->step++) % 6];
+    return m->now;
+}
+
+/* A hostile source: if replay ever touches it, values will diverge. */
+static uint64_t hostile_read(void* ctx) { (void)ctx; return 0xDEADBEEFDEADBEEFULL; }
+
+/* The "program under test": read the clock N times and derive a branch bit from
+ * each value, returning the bit pattern plus the raw reads. */
+static uint32_t run_program(time_record_t* tr, uint32_t n, uint64_t* reads_out) {
+    uint32_t bits = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        uint64_t t = time_record_read(tr);
+        reads_out[i] = t;
+        if ((t % 7) < 3) bits |= (1u << (i & 31)); /* a clock-dependent branch */
+    }
+    return bits;
+}
+
+int main(void) {
+    printf("=== Virtualized time reads (#163) unit test ===\n");
+
+    /* --- 1. OFF passthrough --- */
+    {
+        mock_tsc_t tsc = { 0, 0 };
+        uint64_t buf[16];
+        time_record_t tr;
+        time_record_init(&tr, TIME_REC_OFF, mock_tsc_read, &tsc, buf, 16);
+        uint64_t a = time_record_read(&tr);
+        uint64_t b = time_record_read(&tr);
+        CHECK(a != b && b > a, "OFF returns live, advancing clock values");
+        const uint64_t* vals;
+        CHECK(time_record_values(&tr, &vals) == 0, "OFF records nothing");
+    }
+
+    /* --- 2 & 3. RECORD then REPLAY reproduce values and branches identically --- */
+    uint64_t rec_buf[16];
+    time_record_t rec;
+    uint64_t rec_reads[8];
+    uint32_t rec_bits;
+    {
+        mock_tsc_t tsc = { 1000, 0 };
+        time_record_init(&rec, TIME_REC_RECORD, mock_tsc_read, &tsc, rec_buf, 16);
+        time_record_begin_epoch(&rec, 1);
+        rec_bits = run_program(&rec, 8, rec_reads);
+        const uint64_t* vals;
+        uint32_t n = time_record_values(&rec, &vals);
+        CHECK(n == 8, "RECORD logged one value per read");
+        int match = 1;
+        for (uint32_t i = 0; i < 8; i++) if (vals[i] != rec_reads[i]) match = 0;
+        CHECK(match, "logged values equal the reads the program saw");
+    }
+
+    {
+        /* Replay with a HOSTILE live source: if hardware is ever read, the
+         * program's reads and branch bits will not match the recording. */
+        const uint64_t* rec_vals;
+        uint32_t n = time_record_values(&rec, &rec_vals);
+
+        uint64_t rep_buf[16];
+        time_record_t rep;
+        time_record_init(&rep, TIME_REC_REPLAY, hostile_read, 0, rep_buf, 16);
+        CHECK(time_record_load(&rep, 1, rec_vals, n) == TIME_REC_OK, "load replay values");
+
+        uint64_t rep_reads[8];
+        uint32_t rep_bits = run_program(&rep, 8, rep_reads);
+
+        int same = 1;
+        for (uint32_t i = 0; i < 8; i++) if (rep_reads[i] != rec_reads[i]) same = 0;
+        CHECK(same, "REPLAY returns the recorded values, not the hostile hardware");
+        CHECK(rep_bits == rec_bits, "clock-dependent branches replay identically");
+    }
+
+    /* --- 4. begin_epoch reset --- */
+    {
+        mock_tsc_t tsc = { 0, 0 };
+        uint64_t buf[16];
+        time_record_t tr;
+        time_record_init(&tr, TIME_REC_RECORD, mock_tsc_read, &tsc, buf, 16);
+        time_record_begin_epoch(&tr, 1);
+        time_record_read(&tr); time_record_read(&tr);
+        const uint64_t* vals;
+        CHECK(time_record_values(&tr, &vals) == 2, "two values before new epoch");
+        time_record_begin_epoch(&tr, 2);
+        CHECK(time_record_values(&tr, &vals) == 0, "begin_epoch cleared the values");
+        CHECK(tr.epoch == 2, "epoch advanced");
+    }
+
+    /* --- 5. Overflow (record) and underflow (replay) are counted --- */
+    {
+        mock_tsc_t tsc = { 0, 0 };
+        uint64_t buf[4];
+        time_record_t tr;
+        time_record_init(&tr, TIME_REC_RECORD, mock_tsc_read, &tsc, buf, 4);
+        time_record_begin_epoch(&tr, 1);
+        for (int i = 0; i < 9; i++) time_record_read(&tr);
+        const uint64_t* vals;
+        CHECK(time_record_values(&tr, &vals) == 4, "record count clamped to capacity");
+        CHECK(tr.overflow == 5, "record overflow counted");
+
+        uint64_t vbuf[4] = {10, 20, 30, 40};
+        time_record_t rp;
+        time_record_init(&rp, TIME_REC_REPLAY, 0, 0, buf, 4);
+        time_record_load(&rp, 1, vbuf, 4);
+        uint64_t v = 0;
+        for (int i = 0; i < 4; i++) v = time_record_read(&rp);
+        CHECK(v == 40, "replay returns recorded values in order");
+        uint64_t extra = time_record_read(&rp); /* past the end */
+        CHECK(extra == 40 && rp.underflow == 1, "replay past the end returns last, counts underflow");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: time reads record and replay deterministically\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #163

## Summary

Implements #163 (epic #159) on its own branch off `main`. Time and cycle reads (RDTSC, timer counters) return a different value every run, so any code that branches on them diverges under replay (#160). This wraps such a read: on a live run it reads the real clock and records the value; on replay it returns the recorded value without touching hardware.

Scope is exactly #163 (5 files). Default runtime behavior is unchanged.

## What changed

**`kernel/time_record.c` + `include/time_record.h` (new)**

A pure, host-testable record/replay core:
- `OFF` (default): reads the live clock, records nothing.
- `RECORD`: reads the live clock and logs each value.
- `REPLAY`: returns logged values and never touches hardware; past the end it returns the last value and counts an underflow (a divergence the detector, #166, can flag).

The live clock is injected as a function pointer, so tests drive it with a mock source (no allocator, no hardware).

**`kernel/time_record_sync.c` (new)**

Kernel adapter binding the core to the real x86 RDTSC and exposing `ktime_read()`, the single gate future time reads route through. This is the "trap or wrap" site #163 asks for: today IKOS has no live RDTSC read (`numa_allocator.c`'s `get_rdtsc` is a stub returning 0), so landing the gate first means new callers use `ktime_read()` rather than a raw RDTSC.

**`tests/test_time_record.c` (new)**

14 checks. The key one: a program that branches on the clock is run in RECORD, then in REPLAY while the live source is fed **hostile** values (`0xDEADBEEF...`); the replay reproduces the exact reads and identical branch outcomes, proving hardware is never consulted. Plus OFF passthrough, epoch reset, and overflow/underflow counting.

**`.github/workflows/persistence.yml`**

Trigger paths, freestanding compile checks for `time_record.c` and `time_record_sync.c`, and the unit test.

## Testing

- `test_time_record`: 14/14 checks pass.
- Freestanding compile clean for both `time_record.c` and the RDTSC adapter `time_record_sync.c`.
- Branch is exactly #163 and branches from current `main` (which already includes #162).

## Related issues

- Closes #163
- Part of epic #159; depends on the #160 catalog; the recorded values pair with the input journal (#161) and are driven by the replay engine (#165); underflow/overflow surface to the divergence detector (#156)