### PR TITLE
Deterministic RNG / entropy capture (#164)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -22,6 +22,10 @@ on:
       - 'tests/test_checkpoint*.c'
       - 'tests/test_sched_record.c'
       - 'tests/test_time_record.c'
+      - 'kernel/entropy_record.c'
+      - 'kernel/entropy_record_sync.c'
+      - 'include/entropy_record.h'
+      - 'tests/test_entropy_record.c'
       - 'tests/test_snapshot_store.c'
       - 'tests/test_persistence_e2e.c'
       - 'scripts/test/persistence_demo.sh'
@@ -41,7 +45,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -74,6 +78,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_ide    test_checkpoint_ide.c       ../kernel/checkpoint_ide.c ../kernel/snapshot_store.c && /tmp/t_ide
           gcc -I../include -Wall -o /tmp/t_sr     test_sched_record.c         ../kernel/sched_record.c && /tmp/t_sr
           gcc -I../include -Wall -o /tmp/t_time   test_time_record.c          ../kernel/time_record.c && /tmp/t_time
+          gcc -I../include -Wall -o /tmp/t_ent    test_entropy_record.c       ../kernel/entropy_record.c && /tmp/t_ent
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/entropy_record.h
+++ b/include/entropy_record.h
@@ -1,0 +1,94 @@
+/* IKOS Orthogonal Persistence - Deterministic Entropy (#164, epic #159)
+ *
+ * Random bytes differ on every run, so any code that branches on them diverges
+ * under replay (see the nondeterminism catalog in
+ * docs/architecture/time-travel.md, #160). The catalog pinpoints the live
+ * source: auth_core.c's auth_generate_random reads /dev/urandom. This module
+ * wraps such a read: on a live run it draws from the real entropy source and
+ * records the bytes; on replay it returns the recorded bytes instead of drawing
+ * fresh randomness, so a program that branches on random values replays
+ * identically.
+ *
+ * Byte-stream analogue of the time-read wrapper (#163): where time reads are a
+ * sequence of fixed 64-bit values, entropy is an arbitrary-length byte stream,
+ * so the log is a byte buffer and reads may span or split across calls.
+ *
+ * The core is pure and host-testable: the live entropy source is injected as a
+ * function pointer. The kernel adapter (entropy_record_sync.c) registers the
+ * real source and exposes the gate future callers route through.
+ *
+ * The recorded bytes are the per-epoch delta that pairs with the input journal
+ * (#161); the replay engine (#165) persists and reloads them.
+ */
+
+#ifndef ENTROPY_RECORD_H
+#define ENTROPY_RECORD_H
+
+#include <stdint.h>
+
+typedef enum {
+    ENTROPY_REC_OFF = 0,   /* passthrough: draw from the live source, record nothing */
+    ENTROPY_REC_RECORD,    /* draw from the live source and log the bytes */
+    ENTROPY_REC_REPLAY     /* return logged bytes; never draw fresh randomness */
+} entropy_rec_mode_t;
+
+#define ENTROPY_REC_OK          0
+#define ENTROPY_REC_ERR_PARAM  -1
+#define ENTROPY_REC_ERR_SOURCE -2   /* live source failed */
+
+/* Fills `len` bytes of `buf` from the live entropy source; returns 0 on success. */
+typedef int (*entropy_source_fn)(void* ctx, void* buf, uint32_t len);
+
+typedef struct {
+    entropy_rec_mode_t mode;
+    entropy_source_fn  source;   /* live entropy (OFF and RECORD) */
+    void*              ctx;
+    uint64_t           epoch;    /* epoch the current bytes belong to */
+    uint8_t*           log;      /* recorded bytes in draw order */
+    uint32_t           capacity; /* bytes in log[] */
+    uint32_t           count;    /* recorded (RECORD) or loaded (REPLAY) bytes */
+    uint32_t           cursor;   /* next byte to return (REPLAY) */
+    uint32_t           overflow; /* bytes dropped past capacity (RECORD) */
+    uint32_t           underflow;/* bytes requested past the recorded count (REPLAY) */
+} entropy_record_t;
+
+/* Bind a record to a caller-provided byte buffer and a live source. source may
+ * be NULL when mode is REPLAY (the live source is never drawn from). */
+int entropy_record_init(entropy_record_t* er, entropy_rec_mode_t mode,
+                        entropy_source_fn source, void* ctx,
+                        uint8_t* buf, uint32_t capacity);
+
+void entropy_record_set_mode(entropy_record_t* er, entropy_rec_mode_t mode);
+
+/* Start a new epoch: clears the recorded count and the replay cursor. */
+void entropy_record_begin_epoch(entropy_record_t* er, uint64_t epoch);
+
+/* REPLAY: install the bytes recorded for `epoch`. */
+int entropy_record_load(entropy_record_t* er, uint64_t epoch,
+                        const uint8_t* bytes, uint32_t n);
+
+/* The wrapped draw. OFF: fills from the live source. RECORD: fills from the
+ * live source and logs the bytes. REPLAY: fills from the log without drawing
+ * fresh randomness (past the end, zero-fills and counts an underflow). Returns
+ * ENTROPY_REC_OK, or ENTROPY_REC_ERR_SOURCE if the live source failed. */
+int entropy_record_fill(entropy_record_t* er, void* out, uint32_t len);
+
+/* Recorded bytes for the current epoch (RECORD), for persisting into the
+ * journal. Returns the count; *out points at the buffer (may be NULL). */
+uint32_t entropy_record_bytes(const entropy_record_t* er, const uint8_t** out);
+
+/* ---- Kernel adapter (entropy_record_sync.c) ----
+ * A global entropy_record. Kernel code that needs randomness (for example
+ * auth_generate_random) should register its live source once via
+ * kentropy_set_source() and draw through kentropy_fill(), so the bytes are
+ * captured on a record run and reproduced on replay. Default mode is OFF. */
+#define KENTROPY_LOG_MAX 4096
+void     kentropy_init(void);
+void     kentropy_set_source(entropy_source_fn source, void* ctx);
+int      kentropy_fill(void* out, uint32_t len);
+void     kentropy_set_mode(entropy_rec_mode_t mode);
+void     kentropy_begin_epoch(uint64_t epoch);
+uint32_t kentropy_bytes(const uint8_t** out);
+int      kentropy_load(uint64_t epoch, const uint8_t* bytes, uint32_t n);
+
+#endif /* ENTROPY_RECORD_H */

--- a/kernel/entropy_record.c
+++ b/kernel/entropy_record.c
@@ -1,0 +1,109 @@
+/* IKOS Orthogonal Persistence - Deterministic Entropy (#164, epic #159)
+ *
+ * See include/entropy_record.h and docs/architecture/time-travel.md.
+ *
+ * Pure decision core: no allocator, no hardware, no I/O. The caller owns the
+ * byte buffer and injects the live entropy source, so this is host-testable
+ * with a mock source.
+ */
+
+#include "entropy_record.h"
+
+int entropy_record_init(entropy_record_t* er, entropy_rec_mode_t mode,
+                        entropy_source_fn source, void* ctx,
+                        uint8_t* buf, uint32_t capacity) {
+    if (!er || !buf || capacity == 0) return ENTROPY_REC_ERR_PARAM;
+    er->mode = mode;
+    er->source = source;
+    er->ctx = ctx;
+    er->epoch = 0;
+    er->log = buf;
+    er->capacity = capacity;
+    er->count = 0;
+    er->cursor = 0;
+    er->overflow = 0;
+    er->underflow = 0;
+    return ENTROPY_REC_OK;
+}
+
+void entropy_record_set_mode(entropy_record_t* er, entropy_rec_mode_t mode) {
+    if (!er) return;
+    er->mode = mode;
+}
+
+void entropy_record_begin_epoch(entropy_record_t* er, uint64_t epoch) {
+    if (!er) return;
+    er->epoch = epoch;
+    er->count = 0;
+    er->cursor = 0;
+    er->overflow = 0;
+    er->underflow = 0;
+}
+
+int entropy_record_load(entropy_record_t* er, uint64_t epoch,
+                        const uint8_t* bytes, uint32_t n) {
+    if (!er || (!bytes && n > 0)) return ENTROPY_REC_ERR_PARAM;
+    if (n > er->capacity) return ENTROPY_REC_ERR_PARAM;
+    er->epoch = epoch;
+    er->count = n;
+    er->cursor = 0;
+    er->overflow = 0;
+    er->underflow = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        er->log[i] = bytes[i];
+    }
+    return ENTROPY_REC_OK;
+}
+
+/* Draw from the live source, tolerating a NULL source (zero-fills). */
+static int draw_live(entropy_record_t* er, uint8_t* out, uint32_t len) {
+    if (!er->source) {
+        for (uint32_t i = 0; i < len; i++) out[i] = 0;
+        return ENTROPY_REC_OK;
+    }
+    return er->source(er->ctx, out, len) == 0 ? ENTROPY_REC_OK
+                                              : ENTROPY_REC_ERR_SOURCE;
+}
+
+int entropy_record_fill(entropy_record_t* er, void* out, uint32_t len) {
+    if (!er || (!out && len > 0)) return ENTROPY_REC_ERR_PARAM;
+    uint8_t* o = (uint8_t*)out;
+
+    switch (er->mode) {
+    case ENTROPY_REC_RECORD: {
+        int rc = draw_live(er, o, len);
+        if (rc != ENTROPY_REC_OK) return rc;
+        for (uint32_t i = 0; i < len; i++) {
+            if (er->count < er->capacity) {
+                er->log[er->count++] = o[i];
+            } else {
+                er->overflow++;
+            }
+        }
+        return ENTROPY_REC_OK;
+    }
+
+    case ENTROPY_REC_REPLAY:
+        /* Return recorded bytes; never draw fresh randomness. Past the end,
+         * zero-fill and count an underflow so #166 can flag the divergence. */
+        for (uint32_t i = 0; i < len; i++) {
+            if (er->cursor < er->count) {
+                o[i] = er->log[er->cursor++];
+            } else {
+                o[i] = 0;
+                er->underflow++;
+            }
+        }
+        return ENTROPY_REC_OK;
+
+    case ENTROPY_REC_OFF:
+    default:
+        return draw_live(er, o, len);
+    }
+}
+
+uint32_t entropy_record_bytes(const entropy_record_t* er, const uint8_t** out) {
+    if (!er) { if (out) *out = 0; return 0; }
+    if (out) *out = er->log;
+    return er->count;
+}

--- a/kernel/entropy_record_sync.c
+++ b/kernel/entropy_record_sync.c
@@ -1,0 +1,51 @@
+/* IKOS Orthogonal Persistence - Deterministic Entropy, kernel adapter (#164)
+ *
+ * Wires the pure entropy_record core (entropy_record.c) to a global instance
+ * and exposes the gate kernel randomness routes through. Because the real
+ * entropy source in IKOS is /dev/urandom (read by auth_core.c's
+ * auth_generate_random, which is not freestanding), the live source is
+ * registered at runtime via kentropy_set_source() rather than hard-wired here,
+ * keeping this adapter dependency-free.
+ *
+ * Intended use: at init the kernel calls kentropy_set_source() with a reader
+ * for its entropy device, and code that needs randomness draws through
+ * kentropy_fill(). On a record run the bytes are captured; on replay they are
+ * reproduced.
+ */
+
+#include "entropy_record.h"
+
+static uint8_t        g_kentropy_log[KENTROPY_LOG_MAX];
+static entropy_record_t g_kentropy;
+
+void kentropy_init(void) {
+    /* No source yet: kentropy_set_source() installs the real one. Until then
+     * OFF mode zero-fills, which is safe and obviously non-random. */
+    entropy_record_init(&g_kentropy, ENTROPY_REC_OFF, 0, 0,
+                        g_kentropy_log, KENTROPY_LOG_MAX);
+}
+
+void kentropy_set_source(entropy_source_fn source, void* ctx) {
+    g_kentropy.source = source;
+    g_kentropy.ctx = ctx;
+}
+
+int kentropy_fill(void* out, uint32_t len) {
+    return entropy_record_fill(&g_kentropy, out, len);
+}
+
+void kentropy_set_mode(entropy_rec_mode_t mode) {
+    entropy_record_set_mode(&g_kentropy, mode);
+}
+
+void kentropy_begin_epoch(uint64_t epoch) {
+    entropy_record_begin_epoch(&g_kentropy, epoch);
+}
+
+uint32_t kentropy_bytes(const uint8_t** out) {
+    return entropy_record_bytes(&g_kentropy, out);
+}
+
+int kentropy_load(uint64_t epoch, const uint8_t* bytes, uint32_t n) {
+    return entropy_record_load(&g_kentropy, epoch, bytes, n);
+}

--- a/tests/test_entropy_record.c
+++ b/tests/test_entropy_record.c
@@ -1,0 +1,165 @@
+/* Host-side unit test for deterministic entropy (#164).
+ *
+ * Verifies:
+ *   1. OFF is passthrough and records nothing.
+ *   2. RECORD logs the drawn bytes, across calls of differing lengths.
+ *   3. REPLAY returns the recorded bytes and never draws fresh randomness: a
+ *      program that branches on random values replays identically even when the
+ *      live source is hostile.
+ *   4. begin_epoch resets state; load installs replay bytes.
+ *   5. Overflow (record) and underflow (replay) are counted, not out of bounds.
+ *
+ * Build: gcc -I../include -o test_entropy_record \
+ *            test_entropy_record.c ../kernel/entropy_record.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "entropy_record.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* A mock entropy source: a simple LCG, so "random" but reproducible per seed. */
+typedef struct { uint32_t state; } mock_prng_t;
+static int mock_prng_fill(void* ctx, void* buf, uint32_t len) {
+    mock_prng_t* p = (mock_prng_t*)ctx;
+    uint8_t* b = (uint8_t*)buf;
+    for (uint32_t i = 0; i < len; i++) {
+        p->state = p->state * 1103515245u + 12345u;
+        b[i] = (uint8_t)(p->state >> 24);
+    }
+    return 0;
+}
+
+/* A hostile source: if replay ever draws from it, bytes will diverge. */
+static int hostile_fill(void* ctx, void* buf, uint32_t len) {
+    (void)ctx;
+    uint8_t* b = (uint8_t*)buf;
+    for (uint32_t i = 0; i < len; i++) b[i] = 0xFF;
+    return 0;
+}
+
+/* The "program under test": draw randomness in a few differently-sized chunks
+ * and derive a branch bit from each byte, returning the bit pattern and the raw
+ * bytes it saw. */
+static uint32_t run_program(entropy_record_t* er, uint8_t* seen, uint32_t total) {
+    uint32_t bits = 0, got = 0;
+    const uint32_t chunks[] = {3, 1, 5, 7, 4}; /* uneven draw sizes */
+    uint32_t ci = 0;
+    while (got < total) {
+        uint32_t want = chunks[ci++ % 5];
+        if (got + want > total) want = total - got;
+        entropy_record_fill(er, seen + got, want);
+        got += want;
+    }
+    for (uint32_t i = 0; i < total; i++)
+        if ((seen[i] & 3) == 0) bits |= (1u << (i & 31)); /* entropy-dependent branch */
+    return bits;
+}
+
+int main(void) {
+    printf("=== Deterministic entropy (#164) unit test ===\n");
+
+    /* --- 1. OFF passthrough --- */
+    {
+        mock_prng_t prng = { 1 };
+        uint8_t buf[64];
+        entropy_record_t er;
+        entropy_record_init(&er, ENTROPY_REC_OFF, mock_prng_fill, &prng, buf, 64);
+        uint8_t out[8];
+        CHECK(entropy_record_fill(&er, out, 8) == ENTROPY_REC_OK, "OFF fills from live source");
+        const uint8_t* bytes;
+        CHECK(entropy_record_bytes(&er, &bytes) == 0, "OFF records nothing");
+    }
+
+    /* --- 2 & 3. RECORD then REPLAY reproduce bytes and branches identically --- */
+    uint8_t rec_buf[64];
+    entropy_record_t rec;
+    uint8_t rec_seen[20];
+    uint32_t rec_bits;
+    {
+        mock_prng_t prng = { 0xC0FFEE };
+        entropy_record_init(&rec, ENTROPY_REC_RECORD, mock_prng_fill, &prng, rec_buf, 64);
+        entropy_record_begin_epoch(&rec, 1);
+        rec_bits = run_program(&rec, rec_seen, 20);
+        const uint8_t* bytes;
+        uint32_t n = entropy_record_bytes(&rec, &bytes);
+        CHECK(n == 20, "RECORD logged every drawn byte across uneven chunks");
+        int match = 1;
+        for (uint32_t i = 0; i < 20; i++) if (bytes[i] != rec_seen[i]) match = 0;
+        CHECK(match, "logged bytes equal what the program drew");
+    }
+
+    {
+        /* Replay with a HOSTILE live source: if fresh randomness is ever drawn,
+         * the program's bytes and branch bits will not match the recording. */
+        const uint8_t* rec_bytes;
+        uint32_t n = entropy_record_bytes(&rec, &rec_bytes);
+
+        uint8_t rep_buf[64];
+        entropy_record_t rep;
+        entropy_record_init(&rep, ENTROPY_REC_REPLAY, hostile_fill, 0, rep_buf, 64);
+        CHECK(entropy_record_load(&rep, 1, rec_bytes, n) == ENTROPY_REC_OK, "load replay bytes");
+
+        uint8_t rep_seen[20];
+        uint32_t rep_bits = run_program(&rep, rep_seen, 20);
+
+        int same = 1;
+        for (uint32_t i = 0; i < 20; i++) if (rep_seen[i] != rec_seen[i]) same = 0;
+        CHECK(same, "REPLAY returns recorded bytes, not the hostile source");
+        CHECK(rep_bits == rec_bits, "entropy-dependent branches replay identically");
+    }
+
+    /* --- 4. begin_epoch reset --- */
+    {
+        mock_prng_t prng = { 7 };
+        uint8_t buf[64];
+        entropy_record_t er;
+        entropy_record_init(&er, ENTROPY_REC_RECORD, mock_prng_fill, &prng, buf, 64);
+        entropy_record_begin_epoch(&er, 1);
+        uint8_t tmp[10];
+        entropy_record_fill(&er, tmp, 10);
+        const uint8_t* bytes;
+        CHECK(entropy_record_bytes(&er, &bytes) == 10, "ten bytes before new epoch");
+        entropy_record_begin_epoch(&er, 2);
+        CHECK(entropy_record_bytes(&er, &bytes) == 0, "begin_epoch cleared the bytes");
+        CHECK(er.epoch == 2, "epoch advanced");
+    }
+
+    /* --- 5. Overflow (record) and underflow (replay) are counted --- */
+    {
+        mock_prng_t prng = { 3 };
+        uint8_t buf[4];
+        entropy_record_t er;
+        entropy_record_init(&er, ENTROPY_REC_RECORD, mock_prng_fill, &prng, buf, 4);
+        entropy_record_begin_epoch(&er, 1);
+        uint8_t tmp[10];
+        entropy_record_fill(&er, tmp, 10);
+        const uint8_t* bytes;
+        CHECK(entropy_record_bytes(&er, &bytes) == 4, "record count clamped to capacity");
+        CHECK(er.overflow == 6, "record overflow counted the dropped bytes");
+
+        uint8_t vbuf[4] = {0x11, 0x22, 0x33, 0x44};
+        entropy_record_t rp;
+        entropy_record_init(&rp, ENTROPY_REC_REPLAY, hostile_fill, 0, buf, 4);
+        entropy_record_load(&rp, 1, vbuf, 4);
+        uint8_t out[6];
+        entropy_record_fill(&rp, out, 6); /* two past the end */
+        CHECK(out[0] == 0x11 && out[3] == 0x44, "replay returns recorded bytes in order");
+        CHECK(out[4] == 0 && out[5] == 0 && rp.underflow == 2,
+              "replay past the end zero-fills and counts underflow");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: entropy records and replays deterministically\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #164

## Summary

Implements #164 (epic #159) on its own branch off `main`. Random bytes differ every run, so any code that branches on them diverges under replay (#160). The catalog pinpoints the live source: `auth_core.c`'s `auth_generate_random` reads `/dev/urandom`. This wraps the draw: on a live run it draws from the real source and records the bytes; on replay it returns the recorded bytes without drawing fresh randomness.

Scope is exactly #164 (5 files). Default runtime behavior is unchanged.

## What changed

**`kernel/entropy_record.c` + `include/entropy_record.h` (new)**

A pure, host-testable byte-stream record/replay core (the entropy analogue of the time-read wrapper #163):
- `OFF` (default): draws from the live source, records nothing.
- `RECORD`: draws from the live source and logs the bytes.
- `REPLAY`: returns logged bytes and never draws fresh randomness; past the end it zero-fills and counts an underflow (a divergence the detector, #166, can flag).

Reads may span or split across calls. The live source is injected as a function pointer, so tests drive it with a mock PRNG (no allocator, no I/O).

**`kernel/entropy_record_sync.c` (new)**

Kernel adapter with a registerable live source (`kentropy_set_source`) and `kentropy_fill()` as the gate future callers route through. The source is injected rather than hard-wired because the real one (`/dev/urandom` via `auth_generate_random`) is not freestanding; at init the kernel registers its reader, and randomness draws through `kentropy_fill()`.

**`tests/test_entropy_record.c` (new)**

14 checks. The key one: a program that branches on random values is run in RECORD, then in REPLAY while the live source is **hostile** (returns `0xFF`); the replay reproduces the exact bytes and identical branch outcomes, proving fresh randomness is never drawn. Plus OFF passthrough, uneven-sized draws, epoch reset, and overflow/underflow counting.

**`.github/workflows/persistence.yml`**

Trigger paths, freestanding compile checks for `entropy_record.c` and `entropy_record_sync.c`, and the unit test.

## Testing

- `test_entropy_record`: 14/14 checks pass.
- Freestanding compile clean for both `entropy_record.c` and `entropy_record_sync.c`.
- Branch is exactly #164 and branches from current `main` (which already includes #162 and #163).

## Related issues

- Closes #164
- Part of epic #159; completes the Milestone A record/replay wrappers (preemption #162, time #163, entropy #164). The recorded bytes pair with the input journal (#161) and are driven by the replay engine (#165); underflow/overflow surface to the divergence detector (#166).