### PR TITLE
Replay engine: keyframe + journal to target epoch (#165)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -26,6 +26,10 @@ on:
       - 'kernel/entropy_record_sync.c'
       - 'include/entropy_record.h'
       - 'tests/test_entropy_record.c'
+      - 'kernel/replay_engine.c'
+      - 'kernel/replay_engine_sync.c'
+      - 'include/replay_engine.h'
+      - 'tests/test_replay_engine.c'
       - 'tests/test_snapshot_store.c'
       - 'tests/test_persistence_e2e.c'
       - 'scripts/test/persistence_demo.sh'
@@ -45,7 +49,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -79,6 +83,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_sr     test_sched_record.c         ../kernel/sched_record.c && /tmp/t_sr
           gcc -I../include -Wall -o /tmp/t_time   test_time_record.c          ../kernel/time_record.c && /tmp/t_time
           gcc -I../include -Wall -o /tmp/t_ent    test_entropy_record.c       ../kernel/entropy_record.c && /tmp/t_ent
+          gcc -I../include -Wall -o /tmp/t_replay test_replay_engine.c        ../kernel/replay_engine.c && /tmp/t_replay
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/replay_engine.h
+++ b/include/replay_engine.h
@@ -1,0 +1,86 @@
+/* IKOS Orthogonal Persistence - Replay Engine (#165, epic #159)
+ *
+ * "Replay mode: keyframe + journal to target epoch." A keyframe (checkpoint)
+ * captures the whole system at an epoch; the input journal (#161) plus the
+ * record/replay wrappers (preemption #162, time #163, entropy #164) capture the
+ * delta between keyframes. This engine reconstructs any past moment: restore
+ * the nearest keyframe at or before the target, then re-drive execution forward
+ * epoch by epoch, feeding each epoch's recorded deltas, until the target is
+ * reached. The target is a checkpoint epoch plus an offset into that epoch's
+ * journal.
+ *
+ * The orchestration core is pure and host-testable: restoring a keyframe,
+ * loading an epoch's deltas, and re-driving an epoch are injected as hooks, so
+ * tests drive them with mocks. The kernel adapter (replay_engine_sync.c) wires
+ * the real restore path (checkpoint_restore_boot) and the in-tree REPLAY-mode
+ * loaders for the three wrappers.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef REPLAY_ENGINE_H
+#define REPLAY_ENGINE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define REPLAY_OK            0
+#define REPLAY_ERR_PARAM    -1
+#define REPLAY_ERR_RESTORE  -2   /* restore_keyframe hook failed */
+#define REPLAY_ERR_LOAD     -3   /* load_epoch hook failed */
+#define REPLAY_ERR_RUN      -4   /* run_epoch hook failed */
+
+/* Passed to run_epoch to mean "re-drive the whole epoch" (as opposed to a
+ * bounded number of steps for the final, partial epoch). */
+#define REPLAY_WHOLE_EPOCH  0xFFFFFFFFFFFFFFFFULL
+
+/* Injected steps. All return 0 on success. */
+typedef struct {
+    /* Restore the whole-system keyframe at `epoch` (the nearest checkpoint at
+     * or before the target). Reconstructs process table, scheduler, contexts. */
+    int (*restore_keyframe)(void* ctx, uint64_t epoch);
+    /* Load epoch `epoch`'s recorded deltas into the replay wrappers and put
+     * them in REPLAY mode. */
+    int (*load_epoch)(void* ctx, uint64_t epoch);
+    /* Re-drive up to `limit` steps of epoch `epoch` (REPLAY_WHOLE_EPOCH = all
+     * of it). Consumes that epoch's loaded deltas. */
+    int (*run_epoch)(void* ctx, uint64_t epoch, uint64_t limit);
+    void* ctx;
+} replay_hooks_t;
+
+typedef struct {
+    replay_hooks_t hooks;
+    uint64_t keyframe_epoch;   /* epoch we restored from */
+    uint64_t target_epoch;     /* epoch to stop at */
+    uint64_t target_offset;    /* steps into the target epoch to stop after */
+    uint64_t current_epoch;    /* progress */
+    uint32_t epochs_run;       /* full + partial epochs re-driven */
+    bool     done;
+} replay_engine_t;
+
+/* Bind the engine to its hooks. */
+int replay_init(replay_engine_t* re, const replay_hooks_t* hooks);
+
+/* Restore `keyframe_epoch`, then re-drive forward to (target_epoch,
+ * target_offset). keyframe_epoch must be at or before target_epoch. Full epochs
+ * from the keyframe up to target_epoch are run whole; the target epoch is run
+ * for target_offset steps (0 stops exactly at the target epoch boundary). */
+int replay_run(replay_engine_t* re, uint64_t keyframe_epoch,
+               uint64_t target_epoch, uint64_t target_offset);
+
+/* ---- Kernel adapter (replay_engine_sync.c) ----
+ * Concrete wiring to the in-tree subsystems. replay_enter/exit toggle the three
+ * wrappers between REPLAY and OFF; replay_load_subsystems installs one epoch's
+ * deltas; replay_bind_store/replay_restore_current wire the checkpoint restore
+ * path. The store is passed as void* so this header stays free of the snapshot
+ * types. */
+void replay_enter(void);
+void replay_exit(void);
+int  replay_load_subsystems(uint64_t epoch,
+                            const uint64_t* preempt_pts, uint32_t n_pts,
+                            const uint64_t* time_vals,   uint32_t n_time,
+                            const uint8_t*  entropy,     uint32_t n_entropy);
+void replay_bind_store(void* snapshot_store);
+int  replay_restore_current(void);
+
+#endif /* REPLAY_ENGINE_H */

--- a/kernel/replay_engine.c
+++ b/kernel/replay_engine.c
@@ -1,0 +1,63 @@
+/* IKOS Orthogonal Persistence - Replay Engine (#165, epic #159)
+ *
+ * See include/replay_engine.h and docs/architecture/time-travel.md.
+ *
+ * Pure orchestration core: no allocator, no hardware, no I/O. The three steps
+ * (restore a keyframe, load an epoch's deltas, re-drive an epoch) are injected,
+ * so this is host-testable with mocks.
+ */
+
+#include "replay_engine.h"
+
+int replay_init(replay_engine_t* re, const replay_hooks_t* hooks) {
+    if (!re || !hooks) return REPLAY_ERR_PARAM;
+    if (!hooks->restore_keyframe || !hooks->load_epoch || !hooks->run_epoch)
+        return REPLAY_ERR_PARAM;
+    re->hooks = *hooks;
+    re->keyframe_epoch = 0;
+    re->target_epoch = 0;
+    re->target_offset = 0;
+    re->current_epoch = 0;
+    re->epochs_run = 0;
+    re->done = false;
+    return REPLAY_OK;
+}
+
+int replay_run(replay_engine_t* re, uint64_t keyframe_epoch,
+               uint64_t target_epoch, uint64_t target_offset) {
+    if (!re) return REPLAY_ERR_PARAM;
+    if (keyframe_epoch > target_epoch) return REPLAY_ERR_PARAM;
+
+    replay_hooks_t* h = &re->hooks;
+    void* c = h->ctx;
+
+    re->keyframe_epoch = keyframe_epoch;
+    re->target_epoch = target_epoch;
+    re->target_offset = target_offset;
+    re->epochs_run = 0;
+    re->done = false;
+
+    /* 1. Restore the nearest keyframe at or before the target. */
+    if (h->restore_keyframe(c, keyframe_epoch) != 0) return REPLAY_ERR_RESTORE;
+    re->current_epoch = keyframe_epoch;
+
+    /* 2. Re-drive whole epochs from the keyframe up to the target epoch. */
+    for (uint64_t e = keyframe_epoch; e < target_epoch; e++) {
+        if (h->load_epoch(c, e) != 0) return REPLAY_ERR_LOAD;
+        if (h->run_epoch(c, e, REPLAY_WHOLE_EPOCH) != 0) return REPLAY_ERR_RUN;
+        re->current_epoch = e + 1;
+        re->epochs_run++;
+    }
+
+    /* 3. Re-drive the target epoch for target_offset steps. An offset of 0
+     * stops exactly at the target epoch's keyframe boundary. */
+    if (target_offset > 0) {
+        if (h->load_epoch(c, target_epoch) != 0) return REPLAY_ERR_LOAD;
+        if (h->run_epoch(c, target_epoch, target_offset) != 0) return REPLAY_ERR_RUN;
+        re->epochs_run++;
+    }
+
+    re->current_epoch = target_epoch;
+    re->done = true;
+    return REPLAY_OK;
+}

--- a/kernel/replay_engine_sync.c
+++ b/kernel/replay_engine_sync.c
@@ -1,0 +1,59 @@
+/* IKOS Orthogonal Persistence - Replay Engine, kernel adapter (#165)
+ *
+ * Concrete wiring of the pure replay engine (replay_engine.c) to the in-tree
+ * subsystems that are already merged: the checkpoint restore path and the
+ * REPLAY-mode loaders for the three record/replay wrappers (preemption #162,
+ * time #163, entropy #164).
+ *
+ * The per-epoch deltas themselves come from the input journal (#161); a kernel
+ * replay driver reads an epoch's events from the journal and calls
+ * replay_load_subsystems() with them, then re-drives that epoch. Those two
+ * halves (journal read + re-drive loop) assemble the load_epoch/run_epoch hooks
+ * for replay_run(); this adapter provides the pieces that are unambiguously in
+ * tree today.
+ */
+
+#include "replay_engine.h"
+#include "scheduler.h"       /* scheduler_preempt_{set_mode,load} (#162) */
+#include "time_record.h"     /* ktime_{set_mode,load} (#163) */
+#include "entropy_record.h"  /* kentropy_{set_mode,load} (#164) */
+#include "checkpoint.h"      /* checkpoint_restore_boot, snapshot_store_t */
+
+void replay_enter(void) {
+    scheduler_preempt_set_mode(SCHED_REC_REPLAY);
+    ktime_set_mode(TIME_REC_REPLAY);
+    kentropy_set_mode(ENTROPY_REC_REPLAY);
+}
+
+void replay_exit(void) {
+    scheduler_preempt_set_mode(SCHED_REC_OFF);
+    ktime_set_mode(TIME_REC_OFF);
+    kentropy_set_mode(ENTROPY_REC_OFF);
+}
+
+int replay_load_subsystems(uint64_t epoch,
+                           const uint64_t* preempt_pts, uint32_t n_pts,
+                           const uint64_t* time_vals,   uint32_t n_time,
+                           const uint8_t*  entropy,     uint32_t n_entropy) {
+    if (scheduler_preempt_load(epoch, preempt_pts, n_pts) != 0) return REPLAY_ERR_LOAD;
+    if (ktime_load(epoch, time_vals, n_time) != 0) return REPLAY_ERR_LOAD;
+    if (kentropy_load(epoch, entropy, n_entropy) != 0) return REPLAY_ERR_LOAD;
+    return REPLAY_OK;
+}
+
+/* The checkpoint store backing the keyframes, bound once at init. */
+static snapshot_store_t* g_replay_store;
+
+void replay_bind_store(void* snapshot_store) {
+    g_replay_store = (snapshot_store_t*)snapshot_store;
+}
+
+int replay_restore_current(void) {
+    if (!g_replay_store) return REPLAY_ERR_RESTORE;
+    /* Reuses the existing restore path: reconstructs process table, scheduler,
+     * and contexts from the store's checkpoint. Selecting an arbitrary past
+     * keyframe (rather than the latest) needs the keyframe retention ring
+     * (#168); today the store holds the nearest available checkpoint. */
+    return checkpoint_restore_boot(g_replay_store) < 0 ? REPLAY_ERR_RESTORE
+                                                       : REPLAY_OK;
+}

--- a/tests/test_replay_engine.c
+++ b/tests/test_replay_engine.c
@@ -1,0 +1,175 @@
+/* Host-side unit test for the replay engine (#165).
+ *
+ * Verifies:
+ *   1. Given a keyframe and target, replay restores the keyframe and re-drives
+ *      the right epochs (whole epochs up to the target, then a partial epoch).
+ *   2. The reconstructed state is usable: the restore hook rebuilds a simulated
+ *      process table / scheduler state that the re-driven epochs then advance.
+ *   3. Replaying the same target twice is deterministic (identical trace and
+ *      identical final state).
+ *   4. keyframe == target with offset 0 restores only; bad params and hook
+ *      failures are reported.
+ *
+ * Build: gcc -I../include -o test_replay_engine \
+ *            test_replay_engine.c ../kernel/replay_engine.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "replay_engine.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* A simulated reconstructed system: a process count and a running state hash
+ * the re-driven epochs deterministically fold forward. Plus a call trace so we
+ * can assert the exact sequence of restore/load/run steps. */
+typedef struct {
+    /* reconstructed "state" */
+    uint32_t proc_count;
+    uint64_t state_hash;
+    /* trace */
+    char     trace[256];
+    uint32_t tlen;
+    /* fault injection */
+    int      fail_restore;
+    int      fail_load_at;   /* -1 = never; else epoch to fail load */
+} sim_t;
+
+static void trace_put(sim_t* s, char kind, uint64_t a, uint64_t b) {
+    /* compact, deterministic encoding of one step */
+    if (s->tlen + 4 <= sizeof(s->trace)) {
+        s->trace[s->tlen++] = kind;
+        s->trace[s->tlen++] = (char)('0' + (a % 10));
+        s->trace[s->tlen++] = (char)('0' + (b % 10));
+        s->trace[s->tlen++] = '|';
+    }
+}
+
+static int sim_restore(void* ctx, uint64_t epoch) {
+    sim_t* s = (sim_t*)ctx;
+    if (s->fail_restore) return -1;
+    /* Rebuild a usable state from the keyframe. */
+    s->proc_count = 3 + (uint32_t)epoch;
+    s->state_hash = 0x100 + epoch;
+    trace_put(s, 'R', epoch, 0);
+    return 0;
+}
+
+static int sim_load(void* ctx, uint64_t epoch) {
+    sim_t* s = (sim_t*)ctx;
+    if (s->fail_load_at >= 0 && (uint64_t)s->fail_load_at == epoch) return -1;
+    trace_put(s, 'L', epoch, 0);
+    return 0;
+}
+
+static int sim_run(void* ctx, uint64_t epoch, uint64_t limit) {
+    sim_t* s = (sim_t*)ctx;
+    /* Fold the epoch (and how far into it) into the state deterministically. */
+    uint64_t steps = (limit == REPLAY_WHOLE_EPOCH) ? 10 : limit;
+    for (uint64_t i = 0; i < steps; i++)
+        s->state_hash = s->state_hash * 31 + epoch * 7 + i;
+    trace_put(s, 'X', epoch, steps);
+    return 0;
+}
+
+static void sim_reset(sim_t* s) {
+    for (unsigned i = 0; i < sizeof(*s); i++) ((char*)s)[i] = 0;
+    s->fail_load_at = -1;
+}
+
+static replay_hooks_t hooks_for(sim_t* s) {
+    replay_hooks_t h;
+    h.restore_keyframe = sim_restore;
+    h.load_epoch = sim_load;
+    h.run_epoch = sim_run;
+    h.ctx = s;
+    return h;
+}
+
+static int streq(const char* a, const char* b, uint32_t n) {
+    for (uint32_t i = 0; i < n; i++) if (a[i] != b[i]) return 0;
+    return 1;
+}
+
+int main(void) {
+    printf("=== Replay engine (#165) unit test ===\n");
+
+    /* --- 1. Reaches the target: whole epochs then a partial epoch --- */
+    {
+        sim_t s; sim_reset(&s);
+        replay_hooks_t h = hooks_for(&s);
+        replay_engine_t re;
+        CHECK(replay_init(&re, &h) == REPLAY_OK, "init");
+        /* keyframe 5, target 8, offset 4: restore 5; run 5,6,7 whole; run 8 x4 */
+        CHECK(replay_run(&re, 5, 8, 4) == REPLAY_OK, "replay 5 -> (8, +4) succeeds");
+        CHECK(re.done && re.current_epoch == 8, "engine reports done at target epoch");
+        CHECK(re.epochs_run == 4, "three whole epochs plus one partial re-driven");
+        /* Expected trace: R5 L5 X5 L6 X6 L7 X7 L8 X8, where whole-epoch runs
+         * encode steps 10 as '0' (10 % 10) and the final run encodes 4. */
+        const char* want = "R50|L50|X50|L60|X60|L70|X70|L80|X84|";
+        CHECK(streq(s.trace, want, s.tlen) && s.tlen == 36,
+              "restore/load/run trace is exactly the expected sequence");
+    }
+
+    /* --- 2. Reconstructed state is usable (restore populated it) --- */
+    {
+        sim_t s; sim_reset(&s);
+        replay_hooks_t h = hooks_for(&s);
+        replay_engine_t re; replay_init(&re, &h);
+        replay_run(&re, 2, 4, 0);
+        CHECK(s.proc_count == 3 + 2, "restore rebuilt a usable process table (from keyframe 2)");
+        CHECK(s.state_hash != 0, "re-driven epochs advanced the reconstructed state");
+    }
+
+    /* --- 3. Deterministic across repeated replays of the same target --- */
+    {
+        sim_t a; sim_reset(&a);
+        sim_t b; sim_reset(&b);
+        replay_hooks_t ha = hooks_for(&a);
+        replay_hooks_t hb = hooks_for(&b);
+        replay_engine_t rea, reb;
+        replay_init(&rea, &ha); replay_init(&reb, &hb);
+        replay_run(&rea, 1, 6, 3);
+        replay_run(&reb, 1, 6, 3);
+        CHECK(a.state_hash == b.state_hash, "same target yields identical final state");
+        CHECK(a.tlen == b.tlen && streq(a.trace, b.trace, a.tlen),
+              "same target yields identical step trace");
+    }
+
+    /* --- 4. Edge cases and error propagation --- */
+    {
+        sim_t s; sim_reset(&s);
+        replay_hooks_t h = hooks_for(&s);
+        replay_engine_t re; replay_init(&re, &h);
+        CHECK(replay_run(&re, 4, 4, 0) == REPLAY_OK && s.trace[0] == 'R' && s.tlen == 4,
+              "keyframe == target, offset 0 restores only (no load/run)");
+
+        sim_reset(&s);
+        CHECK(replay_run(&re, 9, 8, 0) == REPLAY_ERR_PARAM,
+              "keyframe after target is rejected");
+
+        sim_reset(&s); s.fail_restore = 1;
+        CHECK(replay_run(&re, 5, 7, 0) == REPLAY_ERR_RESTORE, "restore failure reported");
+
+        sim_reset(&s); s.fail_load_at = 6;
+        CHECK(replay_run(&re, 5, 8, 0) == REPLAY_ERR_LOAD, "load failure reported");
+
+        replay_engine_t bad;
+        replay_hooks_t empty; empty.restore_keyframe = 0; empty.load_epoch = 0;
+        empty.run_epoch = 0; empty.ctx = 0;
+        CHECK(replay_init(&bad, &empty) == REPLAY_ERR_PARAM, "init rejects missing hooks");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: replay reconstructs a target from keyframe + journal deterministically\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #165

## Summary

Implements #165 (epic #159) on its own branch off `main`. The replay engine reconstructs any past moment: restore the nearest keyframe (checkpoint) at or before the target, then re-drive execution forward epoch by epoch, feeding each epoch's recorded deltas, until the target (a checkpoint epoch plus an offset into that epoch's journal) is reached.

Scope is exactly #165 (5 files). Default runtime behavior is unchanged.

## What changed

**`kernel/replay_engine.c` + `include/replay_engine.h` (new)**

A pure, host-testable orchestration state machine. The three steps are injected hooks:
- `restore_keyframe(epoch)`: reconstruct process table / scheduler / contexts from the keyframe.
- `load_epoch(epoch)`: install that epoch's recorded deltas and set the wrappers to REPLAY.
- `run_epoch(epoch, limit)`: re-drive the epoch (whole, or a bounded number of steps).

`replay_run(keyframe, target_epoch, target_offset)` restores the keyframe, runs whole epochs up to the target, then runs the target epoch for `target_offset` steps (offset 0 stops exactly at the target keyframe boundary).

**`kernel/replay_engine_sync.c` (new)**

Kernel adapter wiring the pieces already merged in `main`:
- `replay_enter`/`replay_exit` toggle the three wrappers (preemption #162, time #163, entropy #164) between REPLAY and OFF.
- `replay_load_subsystems` installs one epoch's deltas via `scheduler_preempt_load` / `ktime_load` / `kentropy_load`.
- `replay_bind_store` / `replay_restore_current` reuse the existing restore path (`checkpoint_restore_boot`).

**`tests/test_replay_engine.c` (new)**

14 checks covering all three acceptance criteria: replay reaches the target (asserted against the exact restore/load/run trace), the reconstructed state is usable (restore rebuilds a simulated process table that re-driven epochs advance), and replaying the same target twice is deterministic (identical trace and final state). Plus edge cases (`keyframe == target`, bad params) and hook-failure propagation.

**`.github/workflows/persistence.yml`**

Trigger paths, freestanding compile checks for both new modules, and the unit test.

## Testing

- `test_replay_engine`: 14/14 checks pass.
- Freestanding compile clean for `replay_engine.c` and `replay_engine_sync.c` (the adapter pulls `checkpoint.h`, `scheduler.h`, `time_record.h`, `entropy_record.h`).
- Branch is exactly #165 and branches from current `main`.

## Notes and dependencies

- The per-epoch deltas are read from the input journal (**#161**). Assembling the `load_epoch` / `run_epoch` hooks from a journal read plus the re-drive loop lands once #161 is in `main`; this PR provides the orchestration core and the in-tree wiring (restore path + the three REPLAY loaders).
- Selecting an arbitrary past keyframe (rather than the latest) needs the keyframe retention ring (**#168**); today the store holds the nearest available checkpoint.
- End-to-end byte-equivalence of a replay is verified by the divergence detector (**#166**).

## Related issues

- Closes #165
- Part of epic #159; consumes #161 (journal) and the #162/#163/#164 wrappers; verified by #166