### PR TITLE
Divergence detector (replay safety net) (#166)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -30,6 +30,10 @@ on:
       - 'kernel/replay_engine_sync.c'
       - 'include/replay_engine.h'
       - 'tests/test_replay_engine.c'
+      - 'kernel/divergence.c'
+      - 'kernel/divergence_sync.c'
+      - 'include/divergence.h'
+      - 'tests/test_divergence.c'
       - 'tests/test_snapshot_store.c'
       - 'tests/test_persistence_e2e.c'
       - 'scripts/test/persistence_demo.sh'
@@ -49,7 +53,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -84,6 +88,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_time   test_time_record.c          ../kernel/time_record.c && /tmp/t_time
           gcc -I../include -Wall -o /tmp/t_ent    test_entropy_record.c       ../kernel/entropy_record.c && /tmp/t_ent
           gcc -I../include -Wall -o /tmp/t_replay test_replay_engine.c        ../kernel/replay_engine.c && /tmp/t_replay
+          gcc -I../include -Wall -o /tmp/t_div    test_divergence.c           ../kernel/divergence.c && /tmp/t_div
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/divergence.h
+++ b/include/divergence.h
@@ -1,0 +1,105 @@
+/* IKOS Orthogonal Persistence - Divergence Detector (#166, epic #159)
+ *
+ * The safety net for deterministic replay. At each epoch boundary the system
+ * state is split into components (process table, scheduler, user pages, ...)
+ * and each is checksummed. On a live run the checksums are recorded; on replay
+ * they are recomputed and compared. Any mismatch is a nondeterminism leak that
+ * the catalog (#160) and the record/replay wrappers (#162-#164) missed, and it
+ * is reported with the epoch and the component that diverged. Kept on in debug
+ * builds, it keeps the whole feature honest.
+ *
+ * The core is pure and host-testable: components are checksummed by the caller
+ * (a helper crc32 is provided) and fed in by id. The kernel adapter
+ * (divergence_sync.c) supplies the concrete component ids and a global detector
+ * the replay driver drives at each epoch boundary.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef DIVERGENCE_H
+#define DIVERGENCE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    DIVERGE_OFF = 0,   /* detector disabled: checks always pass, records nothing */
+    DIVERGE_RECORD,    /* store each component's checksum per epoch */
+    DIVERGE_REPLAY     /* compare recomputed checksums against the recorded ones */
+} diverge_mode_t;
+
+#define DIVERGE_OK              0
+#define DIVERGE_ERR_PARAM      -1
+#define DIVERGE_MAX_COMPONENTS 16
+
+typedef struct {
+    diverge_mode_t mode;
+    uint64_t epoch;
+    uint32_t sums[DIVERGE_MAX_COMPONENTS];     /* recorded (RECORD) / expected (REPLAY) */
+    bool     present[DIVERGE_MAX_COMPONENTS];  /* component had a value this epoch */
+
+    /* First divergence seen this session (sticky, so the first leak is kept). */
+    bool     diverged;
+    uint64_t diverged_epoch;
+    uint32_t diverged_component;
+    uint32_t diverged_expected;
+    uint32_t diverged_actual;
+
+    /* Stats over the session. */
+    uint32_t checks;
+    uint32_t mismatches;
+} divergence_t;
+
+/* Bind a detector and set its mode. */
+int  divergence_init(divergence_t* d, diverge_mode_t mode);
+void divergence_set_mode(divergence_t* d, diverge_mode_t mode);
+
+/* Start an epoch boundary. Clears the per-epoch component values (but not the
+ * sticky divergence verdict). */
+void divergence_begin_epoch(divergence_t* d, uint64_t epoch);
+
+/* RECORD: store a component's checksum for the current epoch. */
+int  divergence_record(divergence_t* d, uint32_t component, uint32_t checksum);
+
+/* Read back a recorded component checksum (RECORD), for persisting into the
+ * journal. *present reports whether the component was recorded this epoch. */
+uint32_t divergence_recorded(const divergence_t* d, uint32_t component, bool* present);
+
+/* REPLAY: install the expected per-component checksums recorded for `epoch`.
+ * sums[i] is component i's checksum for i in [0, n). */
+int  divergence_expect(divergence_t* d, uint64_t epoch,
+                       const uint32_t* sums, uint32_t n);
+
+/* REPLAY: compare a component's recomputed checksum against the expected value.
+ * Returns true on match. On mismatch (or a component with no expected value)
+ * records the first divergence and returns false. OFF always returns true. */
+bool divergence_check(divergence_t* d, uint32_t component, uint32_t checksum);
+
+/* Whether any divergence has been detected this session. */
+bool divergence_has_diverged(const divergence_t* d);
+
+/* CRC32 (IEEE 802.3, reflected, poly 0xEDB88320), seed 0. A convenient way to
+ * checksum a component's state. Exposed for callers and tests. */
+uint32_t divergence_checksum(uint32_t seed, const void* data, uint32_t len);
+
+/* ---- Kernel adapter (divergence_sync.c) ----
+ * A global detector and the component ids the replay driver checksums at each
+ * epoch boundary. Default mode is OFF. */
+enum {
+    KDIVERGE_PROCTABLE = 0,
+    KDIVERGE_SCHEDULER,
+    KDIVERGE_USER_PAGES,
+    KDIVERGE_FILETABLE,
+    KDIVERGE_IPC,
+    KDIVERGE_COMPONENT_COUNT
+};
+
+void     kdiverge_init(void);
+void     kdiverge_set_mode(diverge_mode_t mode);
+void     kdiverge_begin_epoch(uint64_t epoch);
+int      kdiverge_record(uint32_t component, uint32_t checksum);
+int      kdiverge_expect(uint64_t epoch, const uint32_t* sums, uint32_t n);
+bool     kdiverge_check(uint32_t component, uint32_t checksum);
+bool     kdiverge_ok(void);   /* false once a divergence has been detected */
+
+#endif /* DIVERGENCE_H */

--- a/kernel/divergence.c
+++ b/kernel/divergence.c
@@ -1,0 +1,113 @@
+/* IKOS Orthogonal Persistence - Divergence Detector (#166, epic #159)
+ *
+ * See include/divergence.h and docs/architecture/time-travel.md.
+ *
+ * Pure decision core: no allocator, no hardware, no I/O. Components are
+ * checksummed by the caller and fed in by id, so this is host-testable.
+ */
+
+#include "divergence.h"
+
+/* IEEE 802.3 reflected CRC32 (poly 0xEDB88320), bitwise. Local copy so this
+ * core stays dependency-free, like the journal and disk cores. */
+uint32_t divergence_checksum(uint32_t crc, const void* data, uint32_t len) {
+    const uint8_t* p = (const uint8_t*)data;
+    crc = ~crc;
+    for (uint32_t i = 0; i < len; i++) {
+        crc ^= p[i];
+        for (int b = 0; b < 8; b++) {
+            uint32_t mask = -(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+static void clear_epoch(divergence_t* d) {
+    for (uint32_t i = 0; i < DIVERGE_MAX_COMPONENTS; i++) {
+        d->sums[i] = 0;
+        d->present[i] = false;
+    }
+}
+
+int divergence_init(divergence_t* d, diverge_mode_t mode) {
+    if (!d) return DIVERGE_ERR_PARAM;
+    d->mode = mode;
+    d->epoch = 0;
+    clear_epoch(d);
+    d->diverged = false;
+    d->diverged_epoch = 0;
+    d->diverged_component = 0;
+    d->diverged_expected = 0;
+    d->diverged_actual = 0;
+    d->checks = 0;
+    d->mismatches = 0;
+    return DIVERGE_OK;
+}
+
+void divergence_set_mode(divergence_t* d, diverge_mode_t mode) {
+    if (!d) return;
+    d->mode = mode;
+}
+
+void divergence_begin_epoch(divergence_t* d, uint64_t epoch) {
+    if (!d) return;
+    d->epoch = epoch;
+    clear_epoch(d);
+}
+
+int divergence_record(divergence_t* d, uint32_t component, uint32_t checksum) {
+    if (!d || component >= DIVERGE_MAX_COMPONENTS) return DIVERGE_ERR_PARAM;
+    if (d->mode != DIVERGE_RECORD) return DIVERGE_OK;
+    d->sums[component] = checksum;
+    d->present[component] = true;
+    return DIVERGE_OK;
+}
+
+uint32_t divergence_recorded(const divergence_t* d, uint32_t component, bool* present) {
+    if (!d || component >= DIVERGE_MAX_COMPONENTS) {
+        if (present) *present = false;
+        return 0;
+    }
+    if (present) *present = d->present[component];
+    return d->sums[component];
+}
+
+int divergence_expect(divergence_t* d, uint64_t epoch,
+                      const uint32_t* sums, uint32_t n) {
+    if (!d || (!sums && n > 0) || n > DIVERGE_MAX_COMPONENTS) return DIVERGE_ERR_PARAM;
+    d->epoch = epoch;
+    clear_epoch(d);
+    for (uint32_t i = 0; i < n; i++) {
+        d->sums[i] = sums[i];
+        d->present[i] = true;
+    }
+    return DIVERGE_OK;
+}
+
+bool divergence_check(divergence_t* d, uint32_t component, uint32_t checksum) {
+    if (!d || component >= DIVERGE_MAX_COMPONENTS) return false;
+    if (d->mode != DIVERGE_REPLAY) return true;
+
+    d->checks++;
+
+    /* A component with no expected value is itself a divergence (it appeared on
+     * replay but was not recorded). */
+    bool ok = d->present[component] && d->sums[component] == checksum;
+    if (!ok) {
+        d->mismatches++;
+        if (!d->diverged) {
+            d->diverged = true;
+            d->diverged_epoch = d->epoch;
+            d->diverged_component = component;
+            d->diverged_expected = d->present[component] ? d->sums[component] : 0;
+            d->diverged_actual = checksum;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool divergence_has_diverged(const divergence_t* d) {
+    return d ? d->diverged : false;
+}

--- a/kernel/divergence_sync.c
+++ b/kernel/divergence_sync.c
@@ -1,0 +1,45 @@
+/* IKOS Orthogonal Persistence - Divergence Detector, kernel adapter (#166)
+ *
+ * A global divergence detector and the component ids the replay driver
+ * checksums at each epoch boundary. During a record run the driver checksums
+ * each component and calls kdiverge_record(); during replay it recomputes and
+ * calls kdiverge_check(). In debug builds the driver asserts on kdiverge_ok()
+ * so a nondeterminism leak halts replay at the exact epoch and component.
+ *
+ * The component checksums themselves are computed by the driver over the
+ * restored subsystems (process table, scheduler, user pages, ...); this adapter
+ * provides only the ids and the record/compare plumbing, so it stays
+ * dependency-free.
+ */
+
+#include "divergence.h"
+
+static divergence_t g_kdiverge;
+
+void kdiverge_init(void) {
+    divergence_init(&g_kdiverge, DIVERGE_OFF);
+}
+
+void kdiverge_set_mode(diverge_mode_t mode) {
+    divergence_set_mode(&g_kdiverge, mode);
+}
+
+void kdiverge_begin_epoch(uint64_t epoch) {
+    divergence_begin_epoch(&g_kdiverge, epoch);
+}
+
+int kdiverge_record(uint32_t component, uint32_t checksum) {
+    return divergence_record(&g_kdiverge, component, checksum);
+}
+
+int kdiverge_expect(uint64_t epoch, const uint32_t* sums, uint32_t n) {
+    return divergence_expect(&g_kdiverge, epoch, sums, n);
+}
+
+bool kdiverge_check(uint32_t component, uint32_t checksum) {
+    return divergence_check(&g_kdiverge, component, checksum);
+}
+
+bool kdiverge_ok(void) {
+    return !divergence_has_diverged(&g_kdiverge);
+}

--- a/tests/test_divergence.c
+++ b/tests/test_divergence.c
@@ -1,0 +1,121 @@
+/* Host-side unit test for the divergence detector (#166).
+ *
+ * Verifies:
+ *   1. State is checksummed at epoch boundaries on both record and replay, and
+ *      an identical replay passes every check.
+ *   2. A mutated component is caught and the first divergence is reported with
+ *      the epoch and the component that diverged.
+ *   3. The detector runs as a guard: divergence_has_diverged() flips exactly
+ *      when a mismatch occurs (what a debug-build assertion keys on).
+ *   4. OFF disables checking; the checksum helper is deterministic.
+ *
+ * Build: gcc -I../include -o test_divergence \
+ *            test_divergence.c ../kernel/divergence.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "divergence.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* A simulated system state: a few components, each a byte blob we checksum. */
+#define NCOMP 4
+typedef struct { uint8_t blob[NCOMP][32]; } sysstate_t;
+
+static void state_fill(sysstate_t* s, uint64_t epoch) {
+    for (int c = 0; c < NCOMP; c++)
+        for (int i = 0; i < 32; i++)
+            s->blob[c][i] = (uint8_t)(c * 41 + epoch * 7 + i);
+}
+
+/* Checksum every component of a state into sums[NCOMP]. */
+static void state_sums(const sysstate_t* s, uint32_t* sums) {
+    for (int c = 0; c < NCOMP; c++)
+        sums[c] = divergence_checksum(0, s->blob[c], 32);
+}
+
+int main(void) {
+    printf("=== Divergence detector (#166) unit test ===\n");
+
+    /* Record checksums for a few epochs of a live run. */
+    uint32_t recorded[3][NCOMP];
+    for (uint64_t e = 0; e < 3; e++) {
+        sysstate_t s; state_fill(&s, e);
+        divergence_t d; divergence_init(&d, DIVERGE_RECORD);
+        divergence_begin_epoch(&d, e);
+        uint32_t sums[NCOMP]; state_sums(&s, sums);
+        for (int c = 0; c < NCOMP; c++) divergence_record(&d, c, sums[c]);
+        for (int c = 0; c < NCOMP; c++) {
+            bool present;
+            recorded[e][c] = divergence_recorded(&d, c, &present);
+            if (!present) recorded[e][c] = 0xBAD;
+        }
+    }
+
+    /* --- 1. Identical replay passes every check --- */
+    {
+        divergence_t d; divergence_init(&d, DIVERGE_REPLAY);
+        int all_ok = 1;
+        for (uint64_t e = 0; e < 3; e++) {
+            sysstate_t s; state_fill(&s, e); /* same state as the live run */
+            divergence_expect(&d, e, recorded[e], NCOMP);
+            uint32_t sums[NCOMP]; state_sums(&s, sums);
+            for (int c = 0; c < NCOMP; c++)
+                if (!divergence_check(&d, c, sums[c])) all_ok = 0;
+        }
+        CHECK(all_ok, "identical replay passes every component check at every epoch");
+        CHECK(!divergence_has_diverged(&d), "no divergence reported for an identical replay");
+        CHECK(d.checks == 3 * NCOMP && d.mismatches == 0, "all checks counted, zero mismatches");
+    }
+
+    /* --- 2 & 3. A mutated component at epoch 1 is caught and pinpointed --- */
+    {
+        divergence_t d; divergence_init(&d, DIVERGE_REPLAY);
+        bool flipped_when_expected = false;
+        for (uint64_t e = 0; e < 3; e++) {
+            sysstate_t s; state_fill(&s, e);
+            if (e == 1) s.blob[2][10] ^= 0xFF; /* nondeterminism leak in component 2 */
+            divergence_expect(&d, e, recorded[e], NCOMP);
+            uint32_t sums[NCOMP]; state_sums(&s, sums);
+            for (int c = 0; c < NCOMP; c++) {
+                bool before = divergence_has_diverged(&d);
+                bool ok = divergence_check(&d, c, sums[c]);
+                bool after = divergence_has_diverged(&d);
+                if (!before && !ok && after && e == 1 && c == 2)
+                    flipped_when_expected = true;
+            }
+        }
+        CHECK(divergence_has_diverged(&d), "a mutated component triggers divergence");
+        CHECK(flipped_when_expected, "the guard flips exactly at the diverging check");
+        CHECK(d.diverged_epoch == 1 && d.diverged_component == 2,
+              "divergence reported at the right epoch and component");
+        CHECK(d.diverged_expected == recorded[1][2] && d.diverged_actual != recorded[1][2],
+              "report carries expected vs actual checksum");
+    }
+
+    /* --- 4. OFF disables checking; checksum helper is deterministic --- */
+    {
+        divergence_t d; divergence_init(&d, DIVERGE_OFF);
+        CHECK(divergence_check(&d, 0, 0xDEADBEEF), "OFF always passes");
+        CHECK(!divergence_has_diverged(&d), "OFF never diverges");
+
+        uint8_t buf[16];
+        for (int i = 0; i < 16; i++) buf[i] = (uint8_t)(i * 3 + 1);
+        CHECK(divergence_checksum(0, buf, 16) == divergence_checksum(0, buf, 16),
+              "checksum is deterministic");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: divergence detector catches replay nondeterminism leaks\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #166

## Summary

Implements #166 (epic #159) on its own branch off `main`. The divergence detector is the safety net for deterministic replay: at each epoch boundary the system state is split into components (process table, scheduler, user pages, ...) and each is checksummed. On a live run the checksums are recorded; on replay they are recomputed and compared. Any mismatch is a nondeterminism leak the record/replay wrappers (#162-#164) missed, reported with the epoch and the diverging component.

Scope is exactly #166 (5 files). Default runtime behavior is unchanged.

## What changed

**`kernel/divergence.c` + `include/divergence.h` (new)**

A pure, host-testable record/compare core with a CRC32 helper:
- `OFF` (default): checks always pass, records nothing.
- `RECORD`: stores each component's checksum per epoch (for persisting into the journal).
- `REPLAY`: compares recomputed checksums against the recorded ones and records the first divergence as `(epoch, component, expected, actual)`.

**`kernel/divergence_sync.c` (new)**

Kernel adapter with a global detector and the component ids the replay driver checksums each epoch (`KDIVERGE_PROCTABLE`, `KDIVERGE_SCHEDULER`, `KDIVERGE_USER_PAGES`, ...). `kdiverge_ok()` returns false once a divergence is seen, which is what a debug-build replay assertion keys on.

**`tests/test_divergence.c` (new)**

10 checks covering the acceptance criteria: an identical replay passes every component check at every epoch; a mutated component is caught and pinpointed to the right epoch and component (with expected vs actual checksum); the guard flips exactly at the diverging check (what an assertion keys on); and OFF disables checking while the checksum stays deterministic.

**`.github/workflows/persistence.yml`**

Trigger paths, freestanding compile checks for both modules, and the unit test.

## Testing

- `test_divergence`: 10/10 checks pass.
- Freestanding compile clean for `divergence.c` and `divergence_sync.c`.
- Branch is exactly #166 and branches from current `main` (which now includes #162-#165).

## Notes and dependencies

Wiring the detector into the replay loop (checksum each restored component per epoch, then assert `kdiverge_ok()` in debug builds) assembles with the replay driver (#165) and the input journal (#161), which carries the recorded checksums alongside the per-epoch deltas.

## Related issues

- Closes #166
- Part of epic #159; verifies the replay engine (#165) against the #162/#163/#164 wrappers; recorded checksums ride in the journal (#161)