### PR TITLE
Input journal: record external inputs between checkpoints (#161)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -84,6 +84,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_ext    test_checkpoint_extstate.c   ../kernel/checkpoint_extstate.c && /tmp/t_ext
           gcc -I../include -Wall -o /tmp/t_init   test_persistence_init.c     $KR && /tmp/t_init
           gcc -I../include -Wall -o /tmp/t_ide    test_checkpoint_ide.c       ../kernel/checkpoint_ide.c ../kernel/snapshot_store.c && /tmp/t_ide
+          gcc -I../include -Wall -o /tmp/t_jrnl   test_checkpoint_journal.c   ../kernel/checkpoint_journal.c && /tmp/t_jrnl
           gcc -I../include -Wall -o /tmp/t_sr     test_sched_record.c         ../kernel/sched_record.c && /tmp/t_sr
           gcc -I../include -Wall -o /tmp/t_time   test_time_record.c          ../kernel/time_record.c && /tmp/t_time
           gcc -I../include -Wall -o /tmp/t_ent    test_entropy_record.c       ../kernel/entropy_record.c && /tmp/t_ent

--- a/include/checkpoint_journal.h
+++ b/include/checkpoint_journal.h
@@ -1,0 +1,166 @@
+/* IKOS Orthogonal Persistence - Input Journal (#161, epic #159)
+ *
+ * The deterministic-replay input journal: a ring log written alongside the
+ * checkpoint slots that captures every nondeterministic input between two
+ * checkpoints (keystrokes, disk-completion events, timer and cycle reads,
+ * entropy), each tagged with the checkpoint epoch and a logical clock. A
+ * keyframe records the whole system state at an epoch; this journal records
+ * the delta between keyframes, so the replay engine (#165) can boot the
+ * nearest keyframe and re-drive execution forward to any past moment.
+ *
+ * The nondeterminism sources this journal exists to capture are catalogued in
+ * docs/architecture/time-travel.md (#160).
+ *
+ * On-disk layout mirrors the snapshot store (snapshot_store.h): a superblock
+ * sector plus two double-buffered slots. A new journal is always written to the
+ * INACTIVE slot; the single superblock-sector write that flips the active slot
+ * is the one and only commit point, so a crash before that write leaves the
+ * previous journal fully intact. Every slot is protected by CRC32.
+ *
+ * Like checkpoint_disk.c, this core is dependency-free and host-testable: it
+ * talks to storage only through a fat_block_device_t and carries its own sector
+ * buffers, so it needs no allocator.
+ */
+
+#ifndef CHECKPOINT_JOURNAL_H
+#define CHECKPOINT_JOURNAL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "fat.h"   /* fat_block_device_t */
+
+/* Storage geometry */
+#define JOURNAL_SECTOR_SIZE       512
+#define JOURNAL_EVENT_SIZE        32
+#define JOURNAL_EVENTS_PER_SECTOR (JOURNAL_SECTOR_SIZE / JOURNAL_EVENT_SIZE) /* 16 */
+
+/* On-disk magic numbers */
+#define JOURNAL_SB_MAGIC          0x494B4F534A524E4CULL /* "IKOSJRNL" */
+#define JOURNAL_SLOT_MAGIC        0x494B4F534A534C54ULL /* "IKOSJSLT" */
+#define JOURNAL_FORMAT_VERSION    1
+
+/* Sentinel for "no valid journal yet" in the superblock. */
+#define JOURNAL_NO_SLOT           0xFFFFFFFFu
+
+/* Event types. value carries the small inline datum for each; bulk payloads
+ * (for example a run of entropy bytes) are recorded as a sequence of 8-byte
+ * JOURNAL_EV_ENTROPY events. */
+#define JOURNAL_EV_KEY            1  /* keyboard scancode in value */
+#define JOURNAL_EV_DISK           2  /* disk-completion token/status in value */
+#define JOURNAL_EV_TIMER          3  /* timer or cycle read (RDTSC) in value */
+#define JOURNAL_EV_ENTROPY        4  /* up to 8 bytes of entropy in value */
+
+/* Error codes */
+#define JOURNAL_OK                0
+#define JOURNAL_ERR_PARAM        -1
+#define JOURNAL_ERR_IO           -2
+#define JOURNAL_ERR_FULL         -3   /* slot cannot hold another event */
+#define JOURNAL_ERR_NO_JOURNAL   -4   /* no valid journal on disk / iteration done */
+#define JOURNAL_ERR_CRC          -5   /* CRC mismatch (corrupt slot/superblock) */
+#define JOURNAL_ERR_STATE        -6   /* called in the wrong order */
+
+/* ----- On-disk structures (fields ordered for natural alignment) ----- */
+
+typedef struct {
+    uint64_t magic;            /* JOURNAL_SB_MAGIC */
+    uint32_t version;          /* JOURNAL_FORMAT_VERSION */
+    uint32_t active_slot;      /* 0, 1, or JOURNAL_NO_SLOT */
+    uint64_t epoch;            /* epoch held in the active slot */
+    uint32_t event_count;      /* events in the active slot */
+    uint32_t slot_crc;         /* crc32 over the active slot's event sectors */
+    uint32_t superblock_crc;   /* crc32 over all preceding bytes of this struct */
+    uint32_t reserved;
+} journal_superblock_t;
+
+typedef struct {
+    uint64_t magic;            /* JOURNAL_SLOT_MAGIC */
+    uint64_t epoch;            /* epoch this journal covers */
+    uint32_t event_count;      /* number of events */
+    uint32_t slot_crc;         /* crc32 over the event sectors */
+    uint64_t base_lclock;      /* logical clock at epoch open (informational) */
+} journal_slot_header_t;
+
+typedef struct {
+    uint64_t epoch;            /* checkpoint epoch this event belongs to */
+    uint64_t lclock;           /* logical clock: monotonic within the epoch */
+    uint32_t type;             /* JOURNAL_EV_* */
+    uint32_t len;              /* reserved for variable payloads; 0 in v1 */
+    uint64_t value;            /* inline datum (scancode, timer value, ...) */
+} journal_event_t;
+
+/* ----- In-memory handles (caller-allocated; no dynamic memory) ----- */
+
+typedef struct {
+    fat_block_device_t* dev;
+    uint32_t base_sector;      /* sector of the superblock */
+    uint32_t slot_sectors;     /* sectors reserved per slot (>= 2) */
+    uint32_t max_events;       /* derived: (slot_sectors - 1) * 16 */
+    bool     initialized;
+} journal_store_t;
+
+typedef struct {
+    journal_store_t* store;
+    uint32_t slot;             /* slot being written (the inactive one) */
+    uint32_t slot_base;        /* first sector of that slot */
+    uint64_t epoch;
+    uint64_t base_lclock;
+    uint32_t event_count;
+    uint32_t crc;              /* running crc over completed event sectors */
+    uint32_t buf_events;       /* events pending in sector_buf */
+    uint32_t event_sector;     /* next event-sector index within the slot */
+    uint8_t  sector_buf[JOURNAL_SECTOR_SIZE];
+    bool     active;
+} journal_writer_t;
+
+typedef struct {
+    journal_store_t* store;
+    uint32_t slot_base;
+    uint64_t epoch;
+    uint32_t event_count;
+    uint32_t next_index;
+    uint32_t buf_sector;       /* event-sector index currently in sector_buf */
+    uint8_t  sector_buf[JOURNAL_SECTOR_SIZE];
+    bool     valid;
+} journal_reader_t;
+
+/* ----- API ----- */
+
+/* Bind a journal to a block-device region. base_sector holds the superblock;
+ * the two slots follow it. slot_sectors must be >= 2 (one header sector plus at
+ * least one event sector). Writes nothing. */
+int journal_store_init(journal_store_t* store, fat_block_device_t* dev,
+                       uint32_t base_sector, uint32_t slot_sectors);
+
+/* Write a fresh, empty superblock marking "no valid journal". Use once when
+ * provisioning a brand-new journal region. */
+int journal_store_format(journal_store_t* store);
+
+/* Begin a journal for one epoch. Selects the slot NOT currently active, so the
+ * last good journal is never touched. base_lclock is the logical-clock value at
+ * which the epoch opened (informational; events carry their own lclock). */
+int journal_store_begin(journal_store_t* store, uint64_t epoch,
+                        uint64_t base_lclock, journal_writer_t* writer);
+
+/* Append one input event in order. type is a JOURNAL_EV_* code, lclock is the
+ * event's logical-clock stamp, value is the inline datum. */
+int journal_writer_append(journal_writer_t* writer, uint32_t type,
+                          uint64_t lclock, uint64_t value);
+
+/* Finalize: flush the last partial sector, write the slot header + CRC, then
+ * flip the superblock. The superblock write is the atomic commit point. */
+int journal_store_commit(journal_writer_t* writer);
+
+/* Open the latest valid journal for reading. Validates the superblock CRC, the
+ * slot magic/epoch/count, and recomputes the slot CRC; returns
+ * JOURNAL_ERR_NO_JOURNAL or JOURNAL_ERR_CRC if nothing valid is present. */
+int journal_store_load(journal_store_t* store, journal_reader_t* reader);
+
+/* Yield the next event of the loaded journal in recorded order. Returns
+ * JOURNAL_OK with *out filled, or JOURNAL_ERR_NO_JOURNAL when exhausted. */
+int journal_reader_next(journal_reader_t* reader, journal_event_t* out);
+
+/* CRC32 (IEEE 802.3, reflected, poly 0xEDB88320). Seed with 0. Exposed for
+ * tests. Kept local to this module so the core stays dependency-free. */
+uint32_t journal_crc32(uint32_t crc, const void* data, uint32_t len);
+
+#endif /* CHECKPOINT_JOURNAL_H */

--- a/kernel/checkpoint_journal.c
+++ b/kernel/checkpoint_journal.c
@@ -1,0 +1,279 @@
+/* IKOS Orthogonal Persistence - Input Journal (#161, epic #159)
+ *
+ * See include/checkpoint_journal.h and docs/architecture/time-travel.md.
+ *
+ * Crash consistency and layout mirror the snapshot store (kernel/snapshot_store.c):
+ * the new journal is written to the inactive slot and a single superblock write
+ * commits it. This core carries its own sector buffers (in the writer/reader
+ * handles) so it needs no allocator.
+ */
+
+#include "checkpoint_journal.h"
+#include <stddef.h>
+
+/* Freestanding helpers provided by the kernel. */
+extern void* memset(void* ptr, int value, size_t size);
+extern void* memcpy(void* dest, const void* src, size_t size);
+
+/* ============================ CRC32 ============================ */
+
+/* IEEE 802.3 reflected CRC32 (poly 0xEDB88320), bitwise so no table init is
+ * required. Identical to snapshot_crc32; duplicated to keep this core
+ * dependency-free and host-testable on its own. */
+uint32_t journal_crc32(uint32_t crc, const void* data, uint32_t len) {
+    const uint8_t* p = (const uint8_t*)data;
+    crc = ~crc;
+    for (uint32_t i = 0; i < len; i++) {
+        crc ^= p[i];
+        for (int b = 0; b < 8; b++) {
+            uint32_t mask = -(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+/* ===================== Sector I/O wrappers ===================== */
+
+static int dev_read(journal_store_t* store, uint32_t sector, void* buf) {
+    fat_block_device_t* d = store->dev;
+    if (!d || !d->read_sectors) return JOURNAL_ERR_IO;
+    return d->read_sectors(d->private_data, sector, 1, buf) == 0
+               ? JOURNAL_OK : JOURNAL_ERR_IO;
+}
+
+static int dev_write(journal_store_t* store, uint32_t sector, const void* buf) {
+    fat_block_device_t* d = store->dev;
+    if (!d || !d->write_sectors) return JOURNAL_ERR_IO;
+    return d->write_sectors(d->private_data, sector, 1, buf) == 0
+               ? JOURNAL_OK : JOURNAL_ERR_IO;
+}
+
+static uint32_t slot_base_sector(journal_store_t* store, uint32_t slot) {
+    /* slot 0 immediately follows the superblock; slot 1 follows slot 0. */
+    return store->base_sector + 1 + slot * store->slot_sectors;
+}
+
+/* Number of event sectors needed to hold event_count events. */
+static uint32_t event_sectors_for(uint32_t event_count) {
+    return (event_count + JOURNAL_EVENTS_PER_SECTOR - 1) / JOURNAL_EVENTS_PER_SECTOR;
+}
+
+/* ===================== Superblock helpers ===================== */
+
+static uint32_t superblock_crc(const journal_superblock_t* sb) {
+    return journal_crc32(0, sb, offsetof(journal_superblock_t, superblock_crc));
+}
+
+/* Read and validate the superblock. On JOURNAL_OK, *sb is filled and its CRC
+ * checks out. Returns JOURNAL_ERR_NO_JOURNAL when unformatted, JOURNAL_ERR_CRC
+ * on a bad checksum. */
+static int read_superblock(journal_store_t* store, journal_superblock_t* sb) {
+    uint8_t sec[JOURNAL_SECTOR_SIZE];
+    int rc = dev_read(store, store->base_sector, sec);
+    if (rc != JOURNAL_OK) return rc;
+    memcpy(sb, sec, sizeof(*sb));
+    if (sb->magic != JOURNAL_SB_MAGIC) return JOURNAL_ERR_NO_JOURNAL;
+    if (sb->superblock_crc != superblock_crc(sb)) return JOURNAL_ERR_CRC;
+    return JOURNAL_OK;
+}
+
+/* ============================ API ============================ */
+
+int journal_store_init(journal_store_t* store, fat_block_device_t* dev,
+                       uint32_t base_sector, uint32_t slot_sectors) {
+    if (!store || !dev || slot_sectors < 2) return JOURNAL_ERR_PARAM;
+    memset(store, 0, sizeof(*store));
+    store->dev = dev;
+    store->base_sector = base_sector;
+    store->slot_sectors = slot_sectors;
+    store->max_events = (slot_sectors - 1) * JOURNAL_EVENTS_PER_SECTOR;
+    store->initialized = true;
+    return JOURNAL_OK;
+}
+
+int journal_store_format(journal_store_t* store) {
+    if (!store || !store->initialized) return JOURNAL_ERR_STATE;
+    uint8_t sec[JOURNAL_SECTOR_SIZE];
+    journal_superblock_t sb;
+    memset(sec, 0, sizeof(sec));
+    memset(&sb, 0, sizeof(sb));
+    sb.magic = JOURNAL_SB_MAGIC;
+    sb.version = JOURNAL_FORMAT_VERSION;
+    sb.active_slot = JOURNAL_NO_SLOT;
+    sb.epoch = 0;
+    sb.event_count = 0;
+    sb.slot_crc = 0;
+    sb.superblock_crc = superblock_crc(&sb);
+    memcpy(sec, &sb, sizeof(sb));
+    return dev_write(store, store->base_sector, sec);
+}
+
+int journal_store_begin(journal_store_t* store, uint64_t epoch,
+                        uint64_t base_lclock, journal_writer_t* writer) {
+    if (!store || !store->initialized || !writer) return JOURNAL_ERR_PARAM;
+
+    /* Target the slot that is NOT currently active, so the last good journal is
+     * left untouched until the superblock flip commits this one. */
+    journal_superblock_t sb;
+    uint32_t target = 0;
+    int rc = read_superblock(store, &sb);
+    if (rc == JOURNAL_OK && sb.active_slot == 0) {
+        target = 1;
+    } else {
+        target = 0;
+    }
+
+    memset(writer, 0, sizeof(*writer));
+    writer->store = store;
+    writer->slot = target;
+    writer->slot_base = slot_base_sector(store, target);
+    writer->epoch = epoch;
+    writer->base_lclock = base_lclock;
+    writer->event_count = 0;
+    writer->crc = 0;
+    writer->buf_events = 0;
+    writer->event_sector = 0;
+    writer->active = true;
+    return JOURNAL_OK;
+}
+
+/* Flush the writer's pending sector buffer to disk and fold it into the running
+ * CRC. The buffer is padded with zeros beyond buf_events, so the bytes on disk
+ * (and thus the CRC) are deterministic. */
+static int flush_sector(journal_writer_t* w) {
+    uint32_t sector = w->slot_base + 1 + w->event_sector; /* +1 skips the header */
+    int rc = dev_write(w->store, sector, w->sector_buf);
+    if (rc != JOURNAL_OK) return rc;
+    w->crc = journal_crc32(w->crc, w->sector_buf, JOURNAL_SECTOR_SIZE);
+    w->event_sector++;
+    w->buf_events = 0;
+    memset(w->sector_buf, 0, JOURNAL_SECTOR_SIZE);
+    return JOURNAL_OK;
+}
+
+int journal_writer_append(journal_writer_t* writer, uint32_t type,
+                          uint64_t lclock, uint64_t value) {
+    if (!writer || !writer->active) return JOURNAL_ERR_STATE;
+    if (writer->event_count >= writer->store->max_events) return JOURNAL_ERR_FULL;
+
+    journal_event_t ev;
+    memset(&ev, 0, sizeof(ev));
+    ev.epoch = writer->epoch;
+    ev.lclock = lclock;
+    ev.type = type;
+    ev.len = 0;
+    ev.value = value;
+
+    uint32_t off = writer->buf_events * JOURNAL_EVENT_SIZE;
+    memcpy(writer->sector_buf + off, &ev, sizeof(ev));
+    writer->buf_events++;
+    writer->event_count++;
+
+    if (writer->buf_events == JOURNAL_EVENTS_PER_SECTOR) {
+        int rc = flush_sector(writer);
+        if (rc != JOURNAL_OK) { writer->active = false; return rc; }
+    }
+    return JOURNAL_OK;
+}
+
+int journal_store_commit(journal_writer_t* writer) {
+    if (!writer || !writer->active) return JOURNAL_ERR_STATE;
+    journal_store_t* store = writer->store;
+
+    /* Flush a trailing partial sector, if any. */
+    if (writer->buf_events > 0) {
+        int rc = flush_sector(writer);
+        if (rc != JOURNAL_OK) { writer->active = false; return rc; }
+    }
+
+    /* Write the slot header into sector 0 of the (inactive) slot. */
+    uint8_t sec[JOURNAL_SECTOR_SIZE];
+    journal_slot_header_t hdr;
+    memset(sec, 0, sizeof(sec));
+    memset(&hdr, 0, sizeof(hdr));
+    hdr.magic = JOURNAL_SLOT_MAGIC;
+    hdr.epoch = writer->epoch;
+    hdr.event_count = writer->event_count;
+    hdr.slot_crc = writer->crc;
+    hdr.base_lclock = writer->base_lclock;
+    memcpy(sec, &hdr, sizeof(hdr));
+    int rc = dev_write(store, writer->slot_base, sec);
+    if (rc != JOURNAL_OK) { writer->active = false; return rc; }
+
+    /* Flip the superblock. This single write is the atomic commit point. */
+    journal_superblock_t sb;
+    memset(sec, 0, sizeof(sec));
+    memset(&sb, 0, sizeof(sb));
+    sb.magic = JOURNAL_SB_MAGIC;
+    sb.version = JOURNAL_FORMAT_VERSION;
+    sb.active_slot = writer->slot;
+    sb.epoch = writer->epoch;
+    sb.event_count = writer->event_count;
+    sb.slot_crc = writer->crc;
+    sb.superblock_crc = superblock_crc(&sb);
+    memcpy(sec, &sb, sizeof(sb));
+    rc = dev_write(store, store->base_sector, sec);
+    writer->active = false;
+    return rc;
+}
+
+int journal_store_load(journal_store_t* store, journal_reader_t* reader) {
+    if (!store || !store->initialized || !reader) return JOURNAL_ERR_PARAM;
+
+    journal_superblock_t sb;
+    int rc = read_superblock(store, &sb);
+    if (rc != JOURNAL_OK) return rc;
+    if (sb.active_slot == JOURNAL_NO_SLOT) return JOURNAL_ERR_NO_JOURNAL;
+
+    uint32_t slot_base = slot_base_sector(store, sb.active_slot);
+
+    /* Validate the slot header. */
+    uint8_t sec[JOURNAL_SECTOR_SIZE];
+    journal_slot_header_t hdr;
+    rc = dev_read(store, slot_base, sec);
+    if (rc != JOURNAL_OK) return rc;
+    memcpy(&hdr, sec, sizeof(hdr));
+    if (hdr.magic != JOURNAL_SLOT_MAGIC) return JOURNAL_ERR_CRC;
+    if (hdr.epoch != sb.epoch || hdr.event_count != sb.event_count)
+        return JOURNAL_ERR_CRC;
+
+    /* Recompute the CRC over the event sectors and match both stamps. */
+    uint32_t nsec = event_sectors_for(hdr.event_count);
+    uint32_t crc = 0;
+    for (uint32_t i = 0; i < nsec; i++) {
+        rc = dev_read(store, slot_base + 1 + i, sec);
+        if (rc != JOURNAL_OK) return rc;
+        crc = journal_crc32(crc, sec, JOURNAL_SECTOR_SIZE);
+    }
+    if (crc != hdr.slot_crc || crc != sb.slot_crc) return JOURNAL_ERR_CRC;
+
+    memset(reader, 0, sizeof(*reader));
+    reader->store = store;
+    reader->slot_base = slot_base;
+    reader->epoch = hdr.epoch;
+    reader->event_count = hdr.event_count;
+    reader->next_index = 0;
+    reader->buf_sector = JOURNAL_NO_SLOT; /* nothing buffered yet */
+    reader->valid = true;
+    return JOURNAL_OK;
+}
+
+int journal_reader_next(journal_reader_t* reader, journal_event_t* out) {
+    if (!reader || !reader->valid || !out) return JOURNAL_ERR_PARAM;
+    if (reader->next_index >= reader->event_count) return JOURNAL_ERR_NO_JOURNAL;
+
+    uint32_t sidx = reader->next_index / JOURNAL_EVENTS_PER_SECTOR;
+    uint32_t within = reader->next_index % JOURNAL_EVENTS_PER_SECTOR;
+
+    if (reader->buf_sector != sidx) {
+        int rc = dev_read(reader->store, reader->slot_base + 1 + sidx,
+                          reader->sector_buf);
+        if (rc != JOURNAL_OK) return rc;
+        reader->buf_sector = sidx;
+    }
+
+    memcpy(out, reader->sector_buf + within * JOURNAL_EVENT_SIZE, sizeof(*out));
+    reader->next_index++;
+    return JOURNAL_OK;
+}

--- a/tests/test_checkpoint_journal.c
+++ b/tests/test_checkpoint_journal.c
@@ -1,0 +1,209 @@
+/* Host-side unit test for the deterministic-replay input journal (#161).
+ *
+ * Uses an in-memory mock block device to verify:
+ *   1. Events round-trip in recorded order, including across a sector boundary.
+ *   2. A crash BEFORE the superblock flip leaves journal N-1 loadable
+ *      (the new journal is written to the inactive slot).
+ *   3. A CRC mismatch (corrupted event sector) is rejected at load time.
+ *   4. An empty journal (zero events) round-trips cleanly.
+ *
+ * Build: gcc -I../include -o test_checkpoint_journal \
+ *            test_checkpoint_journal.c ../kernel/checkpoint_journal.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Declare the libc bits we use directly, rather than including <string.h>/
+ * <stdlib.h>/<stdio.h>. Those pull in <sys/types.h>, whose ssize_t typedef
+ * conflicts with the one in IKOS's vfs.h (reached via fat.h). */
+typedef __SIZE_TYPE__ size_t;
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   printf(const char*, ...);
+
+#include "checkpoint_journal.h"
+
+/* ----- Mock block device backed by a flat buffer ----- */
+
+#define MOCK_SECTORS 512
+typedef struct {
+    uint8_t data[MOCK_SECTORS * JOURNAL_SECTOR_SIZE];
+    int fail_after_writes; /* -1 = never; otherwise abort the Nth+ write */
+    int writes;
+} mock_dev_t;
+
+static int mock_read(void* device, uint32_t sector, uint32_t count, void* buffer) {
+    mock_dev_t* m = (mock_dev_t*)device;
+    if ((uint64_t)sector + count > MOCK_SECTORS) return -1;
+    memcpy(buffer, m->data + (size_t)sector * JOURNAL_SECTOR_SIZE,
+           (size_t)count * JOURNAL_SECTOR_SIZE);
+    return 0;
+}
+static int mock_write(void* device, uint32_t sector, uint32_t count, const void* buffer) {
+    mock_dev_t* m = (mock_dev_t*)device;
+    if (m->fail_after_writes >= 0 && m->writes >= m->fail_after_writes) return -1;
+    m->writes++;
+    if ((uint64_t)sector + count > MOCK_SECTORS) return -1;
+    memcpy(m->data + (size_t)sector * JOURNAL_SECTOR_SIZE, buffer,
+           (size_t)count * JOURNAL_SECTOR_SIZE);
+    return 0;
+}
+
+static mock_dev_t g_mock;
+static fat_block_device_t g_bdev;
+
+static fat_block_device_t* make_dev(void) {
+    memset(&g_mock, 0, sizeof(g_mock));
+    g_mock.fail_after_writes = -1;
+    g_bdev.read_sectors = mock_read;
+    g_bdev.write_sectors = mock_write;
+    g_bdev.sector_size = JOURNAL_SECTOR_SIZE;
+    g_bdev.total_sectors = MOCK_SECTORS;
+    g_bdev.private_data = &g_mock;
+    return &g_bdev;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Store geometry: superblock + two slots, 3 sectors each (1 header + 2 event
+ * sectors => 32 events per slot). */
+#define BASE_SECTOR 10
+#define SLOT_SECTORS 3
+
+/* Deterministic event fields for index i. */
+static uint32_t ev_type(uint32_t i)  { return (i % 4) + 1; }         /* JOURNAL_EV_* */
+static uint64_t ev_lclock(uint32_t i){ return 1000 + i; }
+static uint64_t ev_value(uint32_t i) { return 0xAB00 + i * 7; }
+
+static int write_journal(journal_store_t* store, uint64_t epoch, uint32_t n) {
+    journal_writer_t w;
+    int rc = journal_store_begin(store, epoch, 500 + epoch, &w);
+    if (rc != JOURNAL_OK) return rc;
+    for (uint32_t i = 0; i < n; i++) {
+        rc = journal_writer_append(&w, ev_type(i), ev_lclock(i), ev_value(i));
+        if (rc != JOURNAL_OK) return rc;
+    }
+    return journal_store_commit(&w);
+}
+
+/* Read back and confirm order + fields for n events at the expected epoch. */
+static int verify_journal(journal_store_t* store, uint64_t epoch, uint32_t n) {
+    journal_reader_t r;
+    int rc = journal_store_load(store, &r);
+    if (rc != JOURNAL_OK) { printf("    load rc=%d\n", rc); return rc; }
+    if (r.epoch != epoch || r.event_count != n) {
+        printf("    epoch/count mismatch: got epoch=%llu count=%u\n",
+               (unsigned long long)r.epoch, r.event_count);
+        return -100;
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        journal_event_t ev;
+        rc = journal_reader_next(&r, &ev);
+        if (rc != JOURNAL_OK) { printf("    next rc=%d at %u\n", rc, i); return rc; }
+        if (ev.epoch != epoch || ev.type != ev_type(i) ||
+            ev.lclock != ev_lclock(i) || ev.value != ev_value(i)) {
+            printf("    field mismatch at %u\n", i);
+            return -101;
+        }
+    }
+    /* Iteration must now be exhausted. */
+    journal_event_t tail;
+    if (journal_reader_next(&r, &tail) != JOURNAL_ERR_NO_JOURNAL) return -102;
+    return JOURNAL_OK;
+}
+
+int main(void) {
+    printf("=== Input journal (#161) unit test ===\n");
+
+    /* --- 1. Round-trip order, spanning two event sectors (20 > 16) --- */
+    {
+        journal_store_t store;
+        fat_block_device_t* dev = make_dev();
+        CHECK(journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS) == JOURNAL_OK,
+              "init");
+        CHECK(journal_store_format(&store) == JOURNAL_OK, "format");
+        CHECK(write_journal(&store, 1, 20) == JOURNAL_OK, "write 20 events (2 sectors)");
+        CHECK(verify_journal(&store, 1, 20) == JOURNAL_OK,
+              "read back 20 events in order across a sector boundary");
+    }
+
+    /* --- 2. Crash before the superblock flip preserves the old journal --- */
+    {
+        journal_store_t store;
+        fat_block_device_t* dev = make_dev();
+        journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS);
+        journal_store_format(&store);
+        CHECK(write_journal(&store, 7, 3) == JOURNAL_OK, "commit journal epoch 7");
+
+        /* Begin epoch 8 into the inactive slot, but fail the superblock flip.
+         * Commit order is: event sector(s), slot header, superblock. With 3
+         * events that is 1 event sector + 1 header = 2 writes; the 3rd write
+         * (the superblock) must fail. */
+        g_mock.writes = 0;
+        g_mock.fail_after_writes = 2;
+        int rc = write_journal(&store, 8, 3);
+        CHECK(rc != JOURNAL_OK, "commit of epoch 8 fails at the superblock flip");
+        g_mock.fail_after_writes = -1;
+
+        CHECK(verify_journal(&store, 7, 3) == JOURNAL_OK,
+              "epoch 7 journal still loads intact after the failed flip");
+    }
+
+    /* --- 3. A corrupted event sector is rejected at load --- */
+    {
+        journal_store_t store;
+        fat_block_device_t* dev = make_dev();
+        journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS);
+        journal_store_format(&store);
+        write_journal(&store, 5, 10);
+
+        journal_reader_t r;
+        CHECK(journal_store_load(&store, &r) == JOURNAL_OK, "loads before corruption");
+
+        /* Flip a byte in the first event sector of slot 0 (base+1 header, base+2
+         * first event sector). */
+        uint32_t evsec = (BASE_SECTOR + 1) + 1; /* superblock+1 = slot0 base; +1 = first event sector */
+        g_mock.data[(size_t)evsec * JOURNAL_SECTOR_SIZE + 4] ^= 0xFF;
+
+        CHECK(journal_store_load(&store, &r) == JOURNAL_ERR_CRC,
+              "corrupted event sector is rejected with JOURNAL_ERR_CRC");
+    }
+
+    /* --- 4. Empty journal (zero events) round-trips --- */
+    {
+        journal_store_t store;
+        fat_block_device_t* dev = make_dev();
+        journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS);
+        journal_store_format(&store);
+        CHECK(write_journal(&store, 2, 0) == JOURNAL_OK, "commit empty journal");
+
+        journal_reader_t r;
+        CHECK(journal_store_load(&store, &r) == JOURNAL_OK, "empty journal loads");
+        CHECK(r.event_count == 0, "empty journal has zero events");
+        journal_event_t ev;
+        CHECK(journal_reader_next(&r, &ev) == JOURNAL_ERR_NO_JOURNAL,
+              "empty journal yields no events");
+    }
+
+    /* --- 5. Loading an unformatted region reports no journal --- */
+    {
+        journal_store_t store;
+        fat_block_device_t* dev = make_dev();
+        journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS);
+        journal_reader_t r;
+        CHECK(journal_store_load(&store, &r) == JOURNAL_ERR_NO_JOURNAL,
+              "unformatted region reports JOURNAL_ERR_NO_JOURNAL");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: input journal records and replays inputs in order\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #161

## Summary

Implements #161 (epic #159) on its own branch off `main`. This re-homes the input journal that was written earlier but never landed in `main`: the docs branch it originally rode on (PR #174) merged docs-only, leaving the journal code stranded. It is the connective tissue the replay engine (#165) and divergence detector (#166) both consume, so it needs to be in `main`.

The input journal records nondeterministic inputs (keystrokes, disk-completion events, timer/cycle reads, entropy) between checkpoints, each tagged with the checkpoint epoch and a logical clock. That is the delta between keyframes that turns discrete checkpoints into a continuous, replayable timeline.

Scope is exactly #161 (3 files + CI). Default runtime behavior is unchanged.

## What changed

**`kernel/checkpoint_journal.c` + `include/checkpoint_journal.h` (new)**

On-disk layout mirrors the snapshot store: a superblock plus two double-buffered slots, CRC32-protected, with a single superblock-flip commit, so a crash before the flip leaves the previous journal intact. Dependency-free and host-testable: it talks to storage only through `fat_block_device_t` and carries its own sector buffers, so it needs no allocator (same pattern as `checkpoint_disk.c`).

Event records carry `type` (key / disk / timer / entropy), `lclock`, and an inline `value`, so the sources catalogued in #160 map onto them.

**`tests/test_checkpoint_journal.c` (new)**

14 checks: events round-trip in recorded order across a sector boundary; a crash before the superblock flip leaves the previous journal loadable (new journal written to the inactive slot); a corrupted event sector is rejected at load with a CRC error; and the empty and unformatted cases.

**`.github/workflows/persistence.yml`**

Freestanding compile check and unit test (the journal's paths are already covered by the existing `checkpoint*` globs).

## Testing

- `test_checkpoint_journal`: 14/14 checks pass.
- Freestanding compile clean for `checkpoint_journal.c`.
- Branch is exactly #161 and branches from current `main`.

## Related issues

- Closes #161
- Part of epic #159; consumed by the replay engine (#165) and the divergence detector (#166); records the sources catalogued in #160