### PR TITLE
Keyframe retention ring (#168)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -37,6 +37,9 @@ on:
       - 'tests/test_snapshot_store.c'
       - 'tests/test_persistence_e2e.c'
       - 'scripts/test/persistence_demo.sh'
+      - 'kernel/keyframe_ring.c'
+      - 'include/keyframe_ring.h'
+      - 'tests/test_keyframe_ring.c'
       - 'tests/timetravel_e2e.c'
       - 'scripts/test/timetravel_demo.sh'
       - '.github/workflows/persistence.yml'
@@ -55,7 +58,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -92,6 +95,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_ent    test_entropy_record.c       ../kernel/entropy_record.c && /tmp/t_ent
           gcc -I../include -Wall -o /tmp/t_replay test_replay_engine.c        ../kernel/replay_engine.c && /tmp/t_replay
           gcc -I../include -Wall -o /tmp/t_div    test_divergence.c           ../kernel/divergence.c && /tmp/t_div
+          gcc -I../include -Wall -o /tmp/t_kfr    test_keyframe_ring.c        ../kernel/keyframe_ring.c && /tmp/t_kfr
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/keyframe_ring.h
+++ b/include/keyframe_ring.h
@@ -1,0 +1,94 @@
+/* IKOS Orthogonal Persistence - Keyframe Retention Ring (#168, epic #159)
+ *
+ * The snapshot store keeps two double-buffered slots: the latest checkpoint and
+ * the previous one. That is enough to resume on boot, but time-travel needs to
+ * rewind to any of the last N moments (#169), not just the most recent. This
+ * ring tracks the last N checkpoint keyframes: each new checkpoint claims the
+ * next slot, reclaiming the oldest when the ring is full, and a lookup finds the
+ * nearest retained keyframe at or before a target epoch (the starting point a
+ * rewind restores from, then replays forward).
+ *
+ * This core is the ring index only: which slots hold which epochs, plus a
+ * CRC-protected pack/unpack so the index can live in a superblock sector. The
+ * per-slot page data is stored by the snapshot store; a slot here maps to a
+ * store region. The core is pure and host-testable, like the barrier (#138).
+ *
+ * Disk-cost trade-off (AC): the retention window in wall-clock time is about
+ * N * checkpoint_interval, and the disk cost is about N * checkpoint_size in the
+ * worst case (less if slots share unchanged pages). Larger N buys deeper rewind
+ * at linear disk cost; a shorter interval buys finer rewind granularity at more
+ * frequent writeback. Pick N and the interval for the rewind depth and
+ * granularity the deployment needs against its disk budget.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef KEYFRAME_RING_H
+#define KEYFRAME_RING_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define KEYFRAME_RING_MAX   64   /* upper bound on retained keyframes */
+
+#define KEYFRAME_RING_OK        0
+#define KEYFRAME_RING_ERR_PARAM -1
+#define KEYFRAME_RING_ERR_CRC   -2   /* unpack: checksum mismatch */
+#define KEYFRAME_RING_ERR_SIZE  -3   /* pack/unpack: buffer too small / bad */
+
+typedef struct {
+    uint64_t epoch;   /* epoch stored in this slot */
+    uint32_t valid;   /* 1 if the slot holds a retained keyframe */
+    uint32_t reserved;
+} keyframe_slot_t;
+
+typedef struct {
+    uint32_t capacity;         /* N: retained keyframes (1..KEYFRAME_RING_MAX) */
+    uint32_t count;            /* currently retained (<= capacity) */
+    uint32_t head;             /* index the next keyframe will claim */
+    uint32_t reserved;
+    /* Bookkeeping for the most recent reclaim (for logging what fell off). */
+    uint32_t reclaimed_valid;  /* 1 if the last keyframe_ring_advance evicted one */
+    uint32_t reserved2;
+    uint64_t reclaimed_epoch;  /* the evicted epoch, when reclaimed_valid */
+    keyframe_slot_t slots[KEYFRAME_RING_MAX];
+} keyframe_ring_t;
+
+/* Initialize an empty ring retaining `capacity` keyframes. */
+int keyframe_ring_init(keyframe_ring_t* r, uint32_t capacity);
+
+/* Claim the next slot for a checkpoint at `epoch`, reclaiming the oldest slot
+ * when the ring is full. Returns the slot index the checkpoint should use.
+ * After the call, keyframe_ring_reclaimed() reports whether (and which) old
+ * keyframe was evicted. */
+uint32_t keyframe_ring_advance(keyframe_ring_t* r, uint64_t epoch);
+
+/* Find the nearest retained keyframe at or before `target`. On success returns
+ * true and fills *slot_out / *epoch_out (either may be NULL). Returns false if
+ * `target` predates the oldest retained keyframe (outside the rewind horizon). */
+bool keyframe_ring_find(const keyframe_ring_t* r, uint64_t target,
+                        uint32_t* slot_out, uint64_t* epoch_out);
+
+/* Oldest / newest retained epochs (the rewind horizon and the latest keyframe).
+ * Return false if the ring is empty. */
+bool keyframe_ring_oldest(const keyframe_ring_t* r, uint64_t* epoch_out);
+bool keyframe_ring_newest(const keyframe_ring_t* r, uint64_t* epoch_out);
+
+/* Whether the last advance() reclaimed a keyframe, and which epoch. */
+bool keyframe_ring_reclaimed(const keyframe_ring_t* r, uint64_t* epoch_out);
+
+uint32_t keyframe_ring_count(const keyframe_ring_t* r);
+
+/* Serialize the ring index into `buf` with a trailing CRC32, for persisting to
+ * a superblock sector. Returns the number of bytes written, or a negative error
+ * if the buffer is too small. keyframe_ring_packed_size() gives the size. */
+int keyframe_ring_pack(const keyframe_ring_t* r, void* buf, uint32_t buflen);
+uint32_t keyframe_ring_packed_size(void);
+
+/* Restore a ring index from a packed buffer, validating the CRC. */
+int keyframe_ring_unpack(keyframe_ring_t* r, const void* buf, uint32_t buflen);
+
+/* CRC32 (IEEE 802.3, reflected, poly 0xEDB88320), seed 0. Exposed for tests. */
+uint32_t keyframe_ring_crc32(uint32_t crc, const void* data, uint32_t len);
+
+#endif /* KEYFRAME_RING_H */

--- a/kernel/keyframe_ring.c
+++ b/kernel/keyframe_ring.c
@@ -1,0 +1,155 @@
+/* IKOS Orthogonal Persistence - Keyframe Retention Ring (#168, epic #159)
+ *
+ * See include/keyframe_ring.h and docs/architecture/time-travel.md.
+ *
+ * Pure ring-index core: no allocator, no hardware, no I/O.
+ */
+
+#include "keyframe_ring.h"
+
+/* IEEE 802.3 reflected CRC32 (poly 0xEDB88320), bitwise. Local copy so this
+ * core stays dependency-free, like the journal and divergence cores. */
+uint32_t keyframe_ring_crc32(uint32_t crc, const void* data, uint32_t len) {
+    const uint8_t* p = (const uint8_t*)data;
+    crc = ~crc;
+    for (uint32_t i = 0; i < len; i++) {
+        crc ^= p[i];
+        for (int b = 0; b < 8; b++) {
+            uint32_t mask = -(crc & 1u);
+            crc = (crc >> 1) ^ (0xEDB88320u & mask);
+        }
+    }
+    return ~crc;
+}
+
+int keyframe_ring_init(keyframe_ring_t* r, uint32_t capacity) {
+    if (!r || capacity == 0 || capacity > KEYFRAME_RING_MAX)
+        return KEYFRAME_RING_ERR_PARAM;
+    r->capacity = capacity;
+    r->count = 0;
+    r->head = 0;
+    r->reserved = 0;
+    r->reclaimed_valid = 0;
+    r->reserved2 = 0;
+    r->reclaimed_epoch = 0;
+    for (uint32_t i = 0; i < KEYFRAME_RING_MAX; i++) {
+        r->slots[i].epoch = 0;
+        r->slots[i].valid = 0;
+        r->slots[i].reserved = 0;
+    }
+    return KEYFRAME_RING_OK;
+}
+
+uint32_t keyframe_ring_advance(keyframe_ring_t* r, uint64_t epoch) {
+    if (!r || r->capacity == 0) return 0;
+    uint32_t slot = r->head;
+
+    /* Record whether we are evicting a valid keyframe from this slot. */
+    r->reclaimed_valid = r->slots[slot].valid;
+    r->reclaimed_epoch = r->slots[slot].valid ? r->slots[slot].epoch : 0;
+
+    r->slots[slot].epoch = epoch;
+    r->slots[slot].valid = 1;
+
+    r->head = (r->head + 1) % r->capacity;
+    if (r->count < r->capacity) r->count++;
+    return slot;
+}
+
+bool keyframe_ring_find(const keyframe_ring_t* r, uint64_t target,
+                        uint32_t* slot_out, uint64_t* epoch_out) {
+    if (!r) return false;
+    bool found = false;
+    uint64_t best = 0;
+    uint32_t best_slot = 0;
+    for (uint32_t i = 0; i < r->capacity; i++) {
+        if (!r->slots[i].valid) continue;
+        uint64_t e = r->slots[i].epoch;
+        if (e <= target && (!found || e > best)) {
+            best = e;
+            best_slot = i;
+            found = true;
+        }
+    }
+    if (found) {
+        if (slot_out) *slot_out = best_slot;
+        if (epoch_out) *epoch_out = best;
+    }
+    return found;
+}
+
+bool keyframe_ring_oldest(const keyframe_ring_t* r, uint64_t* epoch_out) {
+    if (!r || r->count == 0) return false;
+    bool found = false;
+    uint64_t best = 0;
+    for (uint32_t i = 0; i < r->capacity; i++) {
+        if (!r->slots[i].valid) continue;
+        if (!found || r->slots[i].epoch < best) { best = r->slots[i].epoch; found = true; }
+    }
+    if (found && epoch_out) *epoch_out = best;
+    return found;
+}
+
+bool keyframe_ring_newest(const keyframe_ring_t* r, uint64_t* epoch_out) {
+    if (!r || r->count == 0) return false;
+    bool found = false;
+    uint64_t best = 0;
+    for (uint32_t i = 0; i < r->capacity; i++) {
+        if (!r->slots[i].valid) continue;
+        if (!found || r->slots[i].epoch > best) { best = r->slots[i].epoch; found = true; }
+    }
+    if (found && epoch_out) *epoch_out = best;
+    return found;
+}
+
+bool keyframe_ring_reclaimed(const keyframe_ring_t* r, uint64_t* epoch_out) {
+    if (!r || !r->reclaimed_valid) return false;
+    if (epoch_out) *epoch_out = r->reclaimed_epoch;
+    return true;
+}
+
+uint32_t keyframe_ring_count(const keyframe_ring_t* r) {
+    return r ? r->count : 0;
+}
+
+/* ---- Persistence: pack the index with a trailing CRC32 ---- */
+
+uint32_t keyframe_ring_packed_size(void) {
+    return (uint32_t)sizeof(keyframe_ring_t) + 4u; /* struct + crc */
+}
+
+static uint8_t* put_bytes(uint8_t* p, const void* src, uint32_t n) {
+    const uint8_t* s = (const uint8_t*)src;
+    for (uint32_t i = 0; i < n; i++) p[i] = s[i];
+    return p + n;
+}
+
+int keyframe_ring_pack(const keyframe_ring_t* r, void* buf, uint32_t buflen) {
+    if (!r || !buf) return KEYFRAME_RING_ERR_PARAM;
+    uint32_t need = keyframe_ring_packed_size();
+    if (buflen < need) return KEYFRAME_RING_ERR_SIZE;
+    uint8_t* p = (uint8_t*)buf;
+    p = put_bytes(p, r, sizeof(*r));
+    uint32_t crc = keyframe_ring_crc32(0, r, sizeof(*r));
+    put_bytes(p, &crc, sizeof(crc));
+    return (int)need;
+}
+
+int keyframe_ring_unpack(keyframe_ring_t* r, const void* buf, uint32_t buflen) {
+    if (!r || !buf) return KEYFRAME_RING_ERR_PARAM;
+    uint32_t need = keyframe_ring_packed_size();
+    if (buflen < need) return KEYFRAME_RING_ERR_SIZE;
+    const uint8_t* p = (const uint8_t*)buf;
+    keyframe_ring_t tmp;
+    uint8_t* d = (uint8_t*)&tmp;
+    for (uint32_t i = 0; i < sizeof(tmp); i++) d[i] = p[i];
+    uint32_t stored;
+    uint8_t* cp = (uint8_t*)&stored;
+    for (uint32_t i = 0; i < sizeof(stored); i++) cp[i] = p[sizeof(tmp) + i];
+    if (keyframe_ring_crc32(0, &tmp, sizeof(tmp)) != stored)
+        return KEYFRAME_RING_ERR_CRC;
+    if (tmp.capacity == 0 || tmp.capacity > KEYFRAME_RING_MAX)
+        return KEYFRAME_RING_ERR_PARAM;
+    *r = tmp;
+    return KEYFRAME_RING_OK;
+}

--- a/tests/test_keyframe_ring.c
+++ b/tests/test_keyframe_ring.c
@@ -1,0 +1,123 @@
+/* Host-side unit test for the keyframe retention ring (#168).
+ *
+ * Verifies:
+ *   1. Configurable retention: the ring holds up to N keyframes.
+ *   2. Old keyframes are reclaimed beyond N (oldest evicted, reported).
+ *   3. find() returns the nearest retained keyframe at or before a target, and
+ *      nothing before the rewind horizon.
+ *   4. pack/unpack round-trips the index and rejects a corrupted buffer.
+ *
+ * Build: gcc -I../include -o test_keyframe_ring \
+ *            test_keyframe_ring.c ../kernel/keyframe_ring.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "keyframe_ring.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+int main(void) {
+    printf("=== Keyframe retention ring (#168) unit test ===\n");
+
+    /* --- 1. Configurable retention, filling below capacity --- */
+    {
+        keyframe_ring_t r;
+        CHECK(keyframe_ring_init(&r, 4) == KEYFRAME_RING_OK, "init with N=4");
+        CHECK(keyframe_ring_init(&r, 0) == KEYFRAME_RING_ERR_PARAM, "N=0 rejected");
+        CHECK(keyframe_ring_init(&r, KEYFRAME_RING_MAX + 1) == KEYFRAME_RING_ERR_PARAM,
+              "N over the max rejected");
+
+        keyframe_ring_init(&r, 4);
+        keyframe_ring_advance(&r, 10);
+        keyframe_ring_advance(&r, 20);
+        keyframe_ring_advance(&r, 30);
+        CHECK(keyframe_ring_count(&r) == 3, "three keyframes retained");
+        CHECK(!keyframe_ring_reclaimed(&r, 0), "nothing reclaimed below capacity");
+        uint64_t oldest, newest;
+        CHECK(keyframe_ring_oldest(&r, &oldest) && oldest == 10, "oldest is 10");
+        CHECK(keyframe_ring_newest(&r, &newest) && newest == 30, "newest is 30");
+    }
+
+    /* --- 2. Reclaim beyond N --- */
+    {
+        keyframe_ring_t r; keyframe_ring_init(&r, 3);
+        keyframe_ring_advance(&r, 10);
+        keyframe_ring_advance(&r, 20);
+        keyframe_ring_advance(&r, 30);   /* full: {10,20,30} */
+        uint64_t evicted;
+        keyframe_ring_advance(&r, 40);   /* evict 10: {40,20,30} */
+        CHECK(keyframe_ring_count(&r) == 3, "count stays at capacity");
+        CHECK(keyframe_ring_reclaimed(&r, &evicted) && evicted == 10,
+              "oldest keyframe (10) reclaimed and reported");
+        uint64_t oldest, newest;
+        keyframe_ring_oldest(&r, &oldest); keyframe_ring_newest(&r, &newest);
+        CHECK(oldest == 20 && newest == 40, "horizon advanced to {20..40}");
+    }
+
+    /* --- 3. find nearest at or before target --- */
+    {
+        keyframe_ring_t r; keyframe_ring_init(&r, 3);
+        keyframe_ring_advance(&r, 20);
+        keyframe_ring_advance(&r, 30);
+        keyframe_ring_advance(&r, 40);   /* retained {20,30,40} */
+        uint32_t slot; uint64_t epoch;
+
+        CHECK(keyframe_ring_find(&r, 40, &slot, &epoch) && epoch == 40, "exact newest");
+        CHECK(keyframe_ring_find(&r, 35, 0, &epoch) && epoch == 30, "between: nearest below is 30");
+        CHECK(keyframe_ring_find(&r, 25, 0, &epoch) && epoch == 20, "between: nearest below is 20");
+        CHECK(keyframe_ring_find(&r, 20, 0, &epoch) && epoch == 20, "exact oldest");
+        CHECK(keyframe_ring_find(&r, 100, 0, &epoch) && epoch == 40, "past newest clamps to newest");
+        CHECK(!keyframe_ring_find(&r, 15, 0, 0), "before the horizon returns nothing");
+    }
+
+    /* --- 4. pack / unpack round-trip and CRC rejection --- */
+    {
+        keyframe_ring_t r; keyframe_ring_init(&r, 5);
+        keyframe_ring_advance(&r, 7);
+        keyframe_ring_advance(&r, 9);
+
+        uint8_t buf[2048];
+        int n = keyframe_ring_pack(&r, buf, sizeof(buf));
+        CHECK(n > 0 && (uint32_t)n == keyframe_ring_packed_size(), "pack reports its size");
+
+        keyframe_ring_t r2;
+        CHECK(keyframe_ring_unpack(&r2, buf, (uint32_t)n) == KEYFRAME_RING_OK, "unpack ok");
+        uint64_t e1, e2;
+        keyframe_ring_newest(&r, &e1); keyframe_ring_newest(&r2, &e2);
+        CHECK(r2.capacity == 5 && r2.count == 2 && e1 == e2, "unpacked ring matches");
+
+        buf[8] ^= 0xFF; /* corrupt a byte inside the struct region */
+        CHECK(keyframe_ring_unpack(&r2, buf, (uint32_t)n) == KEYFRAME_RING_ERR_CRC,
+              "corrupted buffer rejected by CRC");
+
+        uint8_t small[4];
+        CHECK(keyframe_ring_pack(&r, small, sizeof(small)) == KEYFRAME_RING_ERR_SIZE,
+              "pack rejects an undersized buffer");
+    }
+
+    /* --- 5. Degenerate N=1 keeps only the latest (store-like) --- */
+    {
+        keyframe_ring_t r; keyframe_ring_init(&r, 1);
+        keyframe_ring_advance(&r, 100);
+        uint64_t evicted;
+        keyframe_ring_advance(&r, 200);
+        CHECK(keyframe_ring_count(&r) == 1, "N=1 retains a single keyframe");
+        CHECK(keyframe_ring_reclaimed(&r, &evicted) && evicted == 100, "N=1 evicts the prior one");
+        uint64_t only;
+        CHECK(keyframe_ring_newest(&r, &only) && only == 200, "only the latest remains");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: retention ring keeps the last N keyframes and finds rewind targets\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #168

## Summary

Implements #168 (epic #159), opening Milestone C, on its own branch off `main`. The snapshot store keeps only the latest and previous checkpoints, so a rewind (#169) could reach only the most recent moment. This retention ring tracks the last N keyframes: each checkpoint claims the next slot, reclaiming the oldest when full, and a lookup finds the nearest retained keyframe at or before a target epoch (the point a rewind restores from, then replays forward).

Scope is exactly #168 (3 files + CI). Default runtime behavior is unchanged.

## What changed

**`kernel/keyframe_ring.c` + `include/keyframe_ring.h` (new)**

A pure, host-testable ring-index core:
- Configurable retention `N` (1..64).
- `keyframe_ring_advance(epoch)` claims the next slot and reclaims the oldest when full (reporting the evicted epoch).
- `keyframe_ring_find(target)` returns the nearest retained keyframe at or before the target, and nothing before the rewind horizon.
- `oldest` / `newest` report the rewind window.
- `pack` / `unpack` serialize the index with a CRC32 so it can live in a superblock sector.

The **disk-cost trade-off** (AC 3) is documented in the header: the retention window is about `N * checkpoint_interval` and the disk cost about `N * checkpoint_size` worst case; larger `N` buys deeper rewind at linear disk cost, a shorter interval buys finer granularity at more frequent writeback.

**`tests/test_keyframe_ring.c` (new)**

24 checks: retention below capacity, reclaim beyond N with the evicted epoch reported, nearest-at-or-before lookup (exact / between / past-newest / before-horizon), pack/unpack round-trip with CRC rejection and undersized-buffer handling, and the degenerate N=1 (latest-only) case.

**`.github/workflows/persistence.yml`**

Freestanding compile check and unit test.

## Testing

- `test_keyframe_ring`: 24/24 checks pass.
- Freestanding compile clean for `keyframe_ring.c`.
- Branch is exactly #168 and branches from current `main`.

## Notes and dependencies

This is the ring **index** only; per-slot page data stays in the snapshot store. Wiring the store to write across N slots (rather than the two double-buffered ones) lands with the rewind command (#169) that consumes this ring to pick a keyframe.

## Related issues

- Closes #168
- Part of epic #159 (Milestone C); consumed by rewind-to (#169) and the replay engine (#165)