### PR TITLE
rewind-to &lt;epoch&gt; control command (#169)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -40,6 +40,10 @@ on:
       - 'kernel/keyframe_ring.c'
       - 'include/keyframe_ring.h'
       - 'tests/test_keyframe_ring.c'
+      - 'kernel/rewind.c'
+      - 'kernel/rewind_sync.c'
+      - 'include/rewind.h'
+      - 'tests/test_rewind.c'
       - 'tests/timetravel_e2e.c'
       - 'scripts/test/timetravel_demo.sh'
       - '.github/workflows/persistence.yml'
@@ -58,7 +62,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -96,6 +100,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_replay test_replay_engine.c        ../kernel/replay_engine.c && /tmp/t_replay
           gcc -I../include -Wall -o /tmp/t_div    test_divergence.c           ../kernel/divergence.c && /tmp/t_div
           gcc -I../include -Wall -o /tmp/t_kfr    test_keyframe_ring.c        ../kernel/keyframe_ring.c && /tmp/t_kfr
+          gcc -I../include -Wall -o /tmp/t_rw     test_rewind.c               ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rw
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/rewind.h
+++ b/include/rewind.h
@@ -1,0 +1,64 @@
+/* IKOS Orthogonal Persistence - Rewind Command (#169, epic #159)
+ *
+ * The core time-travel verb: "rewind to epoch E". It composes the keyframe
+ * retention ring (#168) and the replay engine (#165): find the nearest retained
+ * keyframe at or before the target, restore it, then replay forward to the exact
+ * target (an epoch plus an offset into that epoch's journal), leaving the system
+ * runnable at that past moment.
+ *
+ * A target outside the retained window is rejected with a clear error: before
+ * the oldest keyframe (fell off the ring, #168) or after the newest (there is
+ * no such future to rewind to).
+ *
+ * The core is pure and host-testable: it drives a real keyframe_ring and a real
+ * replay_engine, whose restore/load/run steps are the engine's injected hooks.
+ * The kernel adapter (rewind_sync.c) binds the global ring and engine and
+ * exposes krewind_to() as the command entry point.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef REWIND_H
+#define REWIND_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "keyframe_ring.h"
+#include "replay_engine.h"
+
+#define REWIND_OK             0
+#define REWIND_ERR_PARAM     -1
+#define REWIND_ERR_OUT_OF_RANGE -2   /* target before the oldest / after the newest keyframe */
+#define REWIND_ERR_REPLAY    -3      /* the replay engine failed en route to the target */
+
+typedef struct {
+    const keyframe_ring_t* ring;    /* keyframe selection */
+    replay_engine_t*       engine;  /* drives restore + re-drive */
+
+    /* Result of the last rewind_to. */
+    uint64_t landed_keyframe;  /* keyframe epoch restored from */
+    uint64_t landed_epoch;     /* target epoch reached */
+    uint64_t landed_offset;    /* offset into the target epoch */
+    bool     runnable;         /* true once the system sits at the target */
+} rewind_ctx_t;
+
+/* Bind the rewind verb to a keyframe ring and a (hook-initialized) engine. */
+int rewind_init(rewind_ctx_t* rw, const keyframe_ring_t* ring, replay_engine_t* engine);
+
+/* Rewind to (target_epoch, target_offset): restore the nearest retained
+ * keyframe at or before target_epoch, then replay forward to the target. An
+ * offset of 0 lands exactly at the target epoch's keyframe boundary. Returns
+ * REWIND_ERR_OUT_OF_RANGE if the target is outside the retained window. */
+int rewind_to(rewind_ctx_t* rw, uint64_t target_epoch, uint64_t target_offset);
+
+/* ---- Kernel adapter (rewind_sync.c) ----
+ * A global rewind verb bound to the kernel's keyframe ring and replay engine.
+ * krewind_to() is the "rewind-to <epoch>" command entry point; a CLI wrapper
+ * parses the argument and calls it. */
+void     krewind_bind(const keyframe_ring_t* ring, replay_engine_t* engine);
+int      krewind_to(uint64_t target_epoch, uint64_t target_offset);
+bool     krewind_runnable(void);
+uint64_t krewind_landed_keyframe(void);
+
+#endif /* REWIND_H */

--- a/kernel/rewind.c
+++ b/kernel/rewind.c
@@ -1,0 +1,50 @@
+/* IKOS Orthogonal Persistence - Rewind Command (#169, epic #159)
+ *
+ * See include/rewind.h and docs/architecture/time-travel.md.
+ *
+ * Pure composition of the keyframe ring (#168) and the replay engine (#165):
+ * no allocator, no hardware, no I/O of its own.
+ */
+
+#include "rewind.h"
+
+int rewind_init(rewind_ctx_t* rw, const keyframe_ring_t* ring,
+                replay_engine_t* engine) {
+    if (!rw || !ring || !engine) return REWIND_ERR_PARAM;
+    rw->ring = ring;
+    rw->engine = engine;
+    rw->landed_keyframe = 0;
+    rw->landed_epoch = 0;
+    rw->landed_offset = 0;
+    rw->runnable = false;
+    return REWIND_OK;
+}
+
+int rewind_to(rewind_ctx_t* rw, uint64_t target_epoch, uint64_t target_offset) {
+    if (!rw || !rw->ring || !rw->engine) return REWIND_ERR_PARAM;
+
+    rw->runnable = false;
+
+    /* Reject a rewind to the future: past the newest retained keyframe there is
+     * nothing recorded to replay to. An empty ring has no newest, so this also
+     * rejects rewinding before anything has been checkpointed. */
+    uint64_t newest;
+    if (!keyframe_ring_newest(rw->ring, &newest) || target_epoch > newest)
+        return REWIND_ERR_OUT_OF_RANGE;
+
+    /* Find the nearest retained keyframe at or before the target. A target that
+     * predates the oldest retained keyframe has fallen off the ring. */
+    uint64_t keyframe;
+    if (!keyframe_ring_find(rw->ring, target_epoch, 0, &keyframe))
+        return REWIND_ERR_OUT_OF_RANGE;
+
+    /* Restore that keyframe and replay forward to the exact target. */
+    if (replay_run(rw->engine, keyframe, target_epoch, target_offset) != REPLAY_OK)
+        return REWIND_ERR_REPLAY;
+
+    rw->landed_keyframe = keyframe;
+    rw->landed_epoch = target_epoch;
+    rw->landed_offset = target_offset;
+    rw->runnable = rw->engine->done;
+    return REWIND_OK;
+}

--- a/kernel/rewind_sync.c
+++ b/kernel/rewind_sync.c
@@ -1,0 +1,29 @@
+/* IKOS Orthogonal Persistence - Rewind Command, kernel adapter (#169)
+ *
+ * Binds the pure rewind verb (rewind.c) to the kernel's global keyframe ring
+ * (#168) and replay engine (#165), and exposes krewind_to() as the
+ * "rewind-to <epoch>" command entry point. A CLI wrapper parses the epoch (and
+ * an optional offset) and calls krewind_to().
+ */
+
+#include "rewind.h"
+
+static rewind_ctx_t g_rewind;
+static bool         g_rewind_bound;
+
+void krewind_bind(const keyframe_ring_t* ring, replay_engine_t* engine) {
+    g_rewind_bound = (rewind_init(&g_rewind, ring, engine) == REWIND_OK);
+}
+
+int krewind_to(uint64_t target_epoch, uint64_t target_offset) {
+    if (!g_rewind_bound) return REWIND_ERR_PARAM;
+    return rewind_to(&g_rewind, target_epoch, target_offset);
+}
+
+bool krewind_runnable(void) {
+    return g_rewind_bound && g_rewind.runnable;
+}
+
+uint64_t krewind_landed_keyframe(void) {
+    return g_rewind_bound ? g_rewind.landed_keyframe : 0;
+}

--- a/tests/test_rewind.c
+++ b/tests/test_rewind.c
@@ -1,0 +1,142 @@
+/* Host-side unit test for the rewind command (#169).
+ *
+ * Drives a REAL keyframe ring (#168) and a REAL replay engine (#165), with mock
+ * engine hooks that record what the engine was asked to do. Verifies:
+ *   1. rewind_to restores the nearest keyframe at or before the target and
+ *      replays forward to it, landing runnable.
+ *   2. Targets outside the retained ring are rejected with a clear error
+ *      (before the oldest keyframe, or after the newest).
+ *   3. A replay failure en route is surfaced.
+ *
+ * Build: gcc -I../include -o test_rewind test_rewind.c \
+ *            ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "rewind.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock engine hooks: record the keyframe restored and the target reached. */
+typedef struct {
+    uint64_t restored_keyframe;
+    uint64_t last_run_epoch;
+    uint32_t epochs_run;
+    int      fail_restore;
+} sim_t;
+
+static int sim_restore(void* c, uint64_t epoch) {
+    sim_t* s = (sim_t*)c;
+    if (s->fail_restore) return -1;
+    s->restored_keyframe = epoch;
+    return 0;
+}
+static int sim_load(void* c, uint64_t epoch) { (void)c; (void)epoch; return 0; }
+static int sim_run(void* c, uint64_t epoch, uint64_t limit) {
+    sim_t* s = (sim_t*)c; (void)limit;
+    s->last_run_epoch = epoch;
+    s->epochs_run++;
+    return 0;
+}
+
+static void engine_with(replay_engine_t* re, sim_t* s) {
+    replay_hooks_t h;
+    h.restore_keyframe = sim_restore;
+    h.load_epoch = sim_load;
+    h.run_epoch = sim_run;
+    h.ctx = s;
+    replay_init(re, &h);
+}
+
+/* A ring retaining keyframes {20, 30, 40}. */
+static void ring_20_30_40(keyframe_ring_t* r) {
+    keyframe_ring_init(r, 4);
+    keyframe_ring_advance(r, 20);
+    keyframe_ring_advance(r, 30);
+    keyframe_ring_advance(r, 40);
+}
+
+int main(void) {
+    printf("=== Rewind command (#169) unit test ===\n");
+
+    /* --- 1. Rewind to a point between keyframes --- */
+    {
+        keyframe_ring_t ring; ring_20_30_40(&ring);
+        sim_t s = {0}; replay_engine_t re; engine_with(&re, &s);
+        rewind_ctx_t rw; CHECK(rewind_init(&rw, &ring, &re) == REWIND_OK, "init");
+
+        CHECK(rewind_to(&rw, 35, 3) == REWIND_OK, "rewind to (35, +3) succeeds");
+        CHECK(s.restored_keyframe == 30, "restored the nearest keyframe at or before 35 (=30)");
+        CHECK(rw.landed_keyframe == 30 && rw.landed_epoch == 35 && rw.landed_offset == 3,
+              "landed at the requested target");
+        CHECK(rw.runnable, "system is runnable at the target");
+        /* engine re-drove epochs 30..34 whole, then 35 partial */
+        CHECK(s.epochs_run == 6 && s.last_run_epoch == 35, "replayed forward through the target epoch");
+    }
+
+    /* --- 2. Exact-keyframe target --- */
+    {
+        keyframe_ring_t ring; ring_20_30_40(&ring);
+        sim_t s = {0}; replay_engine_t re; engine_with(&re, &s);
+        rewind_ctx_t rw; rewind_init(&rw, &ring, &re);
+        CHECK(rewind_to(&rw, 40, 0) == REWIND_OK && s.restored_keyframe == 40,
+              "rewind to an exact keyframe restores it directly");
+        CHECK(rw.runnable, "runnable at the exact keyframe");
+    }
+
+    /* --- 3. Out-of-range targets are rejected clearly --- */
+    {
+        keyframe_ring_t ring; ring_20_30_40(&ring);
+        sim_t s = {0}; replay_engine_t re; engine_with(&re, &s);
+        rewind_ctx_t rw; rewind_init(&rw, &ring, &re);
+
+        CHECK(rewind_to(&rw, 15, 0) == REWIND_ERR_OUT_OF_RANGE,
+              "target before the oldest keyframe is rejected");
+        CHECK(rewind_to(&rw, 100, 0) == REWIND_ERR_OUT_OF_RANGE,
+              "target after the newest keyframe is rejected");
+        CHECK(!rw.runnable, "a rejected rewind leaves the system not-runnable");
+        CHECK(s.restored_keyframe == 0, "a rejected rewind never restored anything");
+    }
+
+    /* --- 4. Empty ring rejects any rewind --- */
+    {
+        keyframe_ring_t ring; keyframe_ring_init(&ring, 4);
+        sim_t s = {0}; replay_engine_t re; engine_with(&re, &s);
+        rewind_ctx_t rw; rewind_init(&rw, &ring, &re);
+        CHECK(rewind_to(&rw, 10, 0) == REWIND_ERR_OUT_OF_RANGE,
+              "an empty ring has no keyframe to rewind to");
+    }
+
+    /* --- 5. A replay failure en route is surfaced --- */
+    {
+        keyframe_ring_t ring; ring_20_30_40(&ring);
+        sim_t s = {0}; s.fail_restore = 1;
+        replay_engine_t re; engine_with(&re, &s);
+        rewind_ctx_t rw; rewind_init(&rw, &ring, &re);
+        CHECK(rewind_to(&rw, 30, 0) == REWIND_ERR_REPLAY, "replay failure surfaced as REWIND_ERR_REPLAY");
+        CHECK(!rw.runnable, "not runnable after a failed replay");
+    }
+
+    /* --- 6. Bad params --- */
+    {
+        rewind_ctx_t rw;
+        keyframe_ring_t ring; ring_20_30_40(&ring);
+        replay_engine_t re; sim_t s = {0}; engine_with(&re, &s);
+        CHECK(rewind_init(&rw, 0, &re) == REWIND_ERR_PARAM, "init rejects a NULL ring");
+        CHECK(rewind_init(&rw, &ring, 0) == REWIND_ERR_PARAM, "init rejects a NULL engine");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: rewind restores the nearest keyframe and replays to the target\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #169

## Summary

Implements #169 (epic #159, Milestone C) on its own branch off `main`. The core time-travel verb: "rewind to epoch E". It composes the keyframe retention ring (#168) and the replay engine (#165) — find the nearest retained keyframe at or before the target, restore it, then replay forward to the exact target (an epoch plus an offset into that epoch's journal), leaving the system runnable at that past moment.

Both dependencies (#168 ring, #165 engine) are now in `main`, so this builds on them directly.

Scope is exactly #169 (4 files + CI). Default runtime behavior is unchanged.

## What changed

**`kernel/rewind.c` + `include/rewind.h` (new)**

A pure composition core:
- `rewind_to(target_epoch, target_offset)` selects the keyframe via `keyframe_ring_find`, restores it, and drives `replay_run` forward to the target.
- Targets outside the retained window are rejected with a clear `REWIND_ERR_OUT_OF_RANGE`: before the oldest keyframe (fell off the ring) or after the newest (no such future).
- Reports the landed keyframe / epoch / offset and whether the system is runnable at the target.

**`kernel/rewind_sync.c` (new)**

Kernel adapter binding the global keyframe ring and replay engine, exposing `krewind_to()` as the "rewind-to <epoch>" command entry point (a CLI wrapper parses the epoch and optional offset and calls it).

**`tests/test_rewind.c` (new)**

17 checks driving a **real** keyframe ring and **real** replay engine (with mock engine hooks that record what the engine did): rewind to a point between keyframes restores the nearest and replays through the target epoch; exact-keyframe target; before-oldest / after-newest / empty-ring rejection; replay-failure surfacing; and bad params.

**`.github/workflows/persistence.yml`**

Freestanding compile checks and unit test.

## Testing

- `test_rewind`: 17/17 checks pass (links the real `keyframe_ring` and `replay_engine`).
- Freestanding compile clean for `rewind.c` and `rewind_sync.c`.
- Branch is exactly #169 and branches from current `main`.

## Related issues

- Closes #169
- Part of epic #159 (Milestone C); composes #168 (keyframe ring) and #165 (replay engine); the foundation for reverse execution (#170, #171)