### PR TITLE
Reverse-continue / reverse-step (#170)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -44,6 +44,10 @@ on:
       - 'kernel/rewind_sync.c'
       - 'include/rewind.h'
       - 'tests/test_rewind.c'
+      - 'kernel/reverse.c'
+      - 'kernel/reverse_sync.c'
+      - 'include/reverse.h'
+      - 'tests/test_reverse.c'
       - 'tests/timetravel_e2e.c'
       - 'scripts/test/timetravel_demo.sh'
       - '.github/workflows/persistence.yml'
@@ -62,7 +66,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -101,6 +105,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_div    test_divergence.c           ../kernel/divergence.c && /tmp/t_div
           gcc -I../include -Wall -o /tmp/t_kfr    test_keyframe_ring.c        ../kernel/keyframe_ring.c && /tmp/t_kfr
           gcc -I../include -Wall -o /tmp/t_rw     test_rewind.c               ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rw
+          gcc -I../include -Wall -o /tmp/t_rev    test_reverse.c              ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rev
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/reverse.h
+++ b/include/reverse.h
@@ -1,0 +1,79 @@
+/* IKOS Orthogonal Persistence - Reverse Execution (#170, epic #159)
+ *
+ * Classic reverse debugging on top of the rewind verb (#169): to step backward,
+ * restore the prior keyframe and replay forward to just before the current
+ * point. Because every reverse step recomputes from a keyframe via deterministic
+ * replay, repeated reverse-steps are stable and never drift.
+ *
+ * A position is (keyframe epoch, offset), where offset indexes the steps of that
+ * keyframe's journal up to the next keyframe. reverse-step moves one step
+ * earlier: within an epoch it decrements the offset; at a keyframe boundary
+ * (offset 0) it crosses to the previous keyframe's last step. reverse-continue
+ * steps backward until an injected stop condition holds (breakpoints arrive in
+ * #171) or the oldest retained keyframe is reached.
+ *
+ * The core is pure and host-testable: it drives a real rewind_ctx, and the
+ * per-epoch step count comes from an injected epoch_len (the journal's event
+ * count for that epoch). The kernel adapter (reverse_sync.c) binds the globals.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef REVERSE_H
+#define REVERSE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "rewind.h"
+
+#define REVERSE_OK          0
+#define REVERSE_ERR_PARAM  -1
+#define REVERSE_AT_START   -2   /* already at the oldest retained moment */
+#define REVERSE_ERR_REWIND -3   /* the underlying rewind failed */
+
+typedef struct {
+    uint64_t epoch;    /* keyframe epoch this position is anchored at */
+    uint64_t offset;   /* steps replayed into that keyframe's journal */
+} reverse_pos_t;
+
+/* Number of steps in keyframe `epoch`'s journal (up to the next keyframe). */
+typedef uint64_t (*reverse_epoch_len_fn)(void* ctx, uint64_t epoch);
+
+/* Stop predicate for reverse-continue: return true to stop at `pos`. */
+typedef bool (*reverse_stop_fn)(void* ctx, reverse_pos_t pos);
+
+typedef struct {
+    rewind_ctx_t*        rw;         /* the rewind verb (drives restore+replay) */
+    reverse_epoch_len_fn epoch_len;  /* per-epoch step count (from the journal) */
+    void*                ctx;
+    reverse_pos_t        cur;        /* current position */
+} reverse_ctx_t;
+
+/* Bind reverse execution to a rewind verb and an epoch-length source. */
+int  reverse_init(reverse_ctx_t* rc, rewind_ctx_t* rw,
+                  reverse_epoch_len_fn epoch_len, void* ctx);
+
+/* Set the current position (where execution is "now"). */
+void reverse_set_position(reverse_ctx_t* rc, uint64_t epoch, uint64_t offset);
+reverse_pos_t reverse_position(const reverse_ctx_t* rc);
+
+/* Step one unit backward. Lands at the previous step and updates the current
+ * position. Returns REVERSE_AT_START if already at the oldest retained moment. */
+int reverse_step(reverse_ctx_t* rc);
+
+/* Step backward until `should_stop(pos)` holds, or the oldest retained moment is
+ * reached. Returns REVERSE_OK if a stop was hit (position left there), or
+ * REVERSE_AT_START if it ran back to the beginning without stopping. */
+int reverse_continue(reverse_ctx_t* rc, reverse_stop_fn should_stop, void* pctx);
+
+/* ---- Kernel adapter (reverse_sync.c) ----
+ * A global reverse-execution context bound to the kernel's rewind verb, exposing
+ * the reverse-step / reverse-continue commands for a debugger front end. */
+void          kreverse_bind(rewind_ctx_t* rw, reverse_epoch_len_fn epoch_len, void* ctx);
+void          kreverse_set_position(uint64_t epoch, uint64_t offset);
+reverse_pos_t kreverse_position(void);
+int           kreverse_step(void);
+int           kreverse_continue(reverse_stop_fn should_stop, void* pctx);
+
+#endif /* REVERSE_H */

--- a/kernel/reverse.c
+++ b/kernel/reverse.c
@@ -1,0 +1,80 @@
+/* IKOS Orthogonal Persistence - Reverse Execution (#170, epic #159)
+ *
+ * See include/reverse.h and docs/architecture/time-travel.md.
+ *
+ * Pure composition over the rewind verb (#169): no allocator, no hardware, no
+ * I/O of its own.
+ */
+
+#include "reverse.h"
+
+int reverse_init(reverse_ctx_t* rc, rewind_ctx_t* rw,
+                 reverse_epoch_len_fn epoch_len, void* ctx) {
+    if (!rc || !rw || !epoch_len) return REVERSE_ERR_PARAM;
+    rc->rw = rw;
+    rc->epoch_len = epoch_len;
+    rc->ctx = ctx;
+    rc->cur.epoch = 0;
+    rc->cur.offset = 0;
+    return REVERSE_OK;
+}
+
+void reverse_set_position(reverse_ctx_t* rc, uint64_t epoch, uint64_t offset) {
+    if (!rc) return;
+    rc->cur.epoch = epoch;
+    rc->cur.offset = offset;
+}
+
+reverse_pos_t reverse_position(const reverse_ctx_t* rc) {
+    if (rc) return rc->cur;
+    reverse_pos_t z = { 0, 0 };
+    return z;
+}
+
+/* Compute the step one unit before `cur`. Within an epoch, decrement the offset.
+ * At a keyframe boundary (offset 0), cross to the previous retained keyframe's
+ * last step, skipping any empty epochs. Returns false at the oldest moment. */
+static bool prev_pos(reverse_ctx_t* rc, reverse_pos_t cur, reverse_pos_t* out) {
+    if (cur.offset > 0) {
+        out->epoch = cur.epoch;
+        out->offset = cur.offset - 1;
+        return true;
+    }
+    /* At a boundary: find the keyframe strictly before this one. */
+    uint64_t epoch = cur.epoch;
+    while (epoch > 0) {
+        uint64_t prev_kf;
+        if (!keyframe_ring_find(rc->rw->ring, epoch - 1, 0, &prev_kf))
+            return false; /* no earlier retained keyframe */
+        uint64_t len = rc->epoch_len(rc->ctx, prev_kf);
+        if (len > 0) {
+            out->epoch = prev_kf;
+            out->offset = len - 1;
+            return true;
+        }
+        epoch = prev_kf; /* empty epoch: keep walking back */
+    }
+    return false;
+}
+
+int reverse_step(reverse_ctx_t* rc) {
+    if (!rc || !rc->rw) return REVERSE_ERR_PARAM;
+    reverse_pos_t prev;
+    if (!prev_pos(rc, rc->cur, &prev)) return REVERSE_AT_START;
+    if (rewind_to(rc->rw, prev.epoch, prev.offset) != REWIND_OK)
+        return REVERSE_ERR_REWIND;
+    rc->cur = prev;
+    return REVERSE_OK;
+}
+
+int reverse_continue(reverse_ctx_t* rc, reverse_stop_fn should_stop, void* pctx) {
+    if (!rc || !rc->rw) return REVERSE_ERR_PARAM;
+    for (;;) {
+        reverse_pos_t prev;
+        if (!prev_pos(rc, rc->cur, &prev)) return REVERSE_AT_START;
+        if (rewind_to(rc->rw, prev.epoch, prev.offset) != REWIND_OK)
+            return REVERSE_ERR_REWIND;
+        rc->cur = prev;
+        if (should_stop && should_stop(pctx, prev)) return REVERSE_OK;
+    }
+}

--- a/kernel/reverse_sync.c
+++ b/kernel/reverse_sync.c
@@ -1,0 +1,36 @@
+/* IKOS Orthogonal Persistence - Reverse Execution, kernel adapter (#170)
+ *
+ * Binds the pure reverse-execution core (reverse.c) to the kernel's rewind verb
+ * (#169) and exposes reverse-step / reverse-continue for a debugger front end
+ * (the GDB bridge in #172). The per-epoch step count comes from the input
+ * journal (#161); the kernel registers an epoch_len reader when it wires this up.
+ */
+
+#include "reverse.h"
+
+static reverse_ctx_t g_reverse;
+static bool          g_reverse_bound;
+
+void kreverse_bind(rewind_ctx_t* rw, reverse_epoch_len_fn epoch_len, void* ctx) {
+    g_reverse_bound = (reverse_init(&g_reverse, rw, epoch_len, ctx) == REVERSE_OK);
+}
+
+void kreverse_set_position(uint64_t epoch, uint64_t offset) {
+    reverse_set_position(&g_reverse, epoch, offset);
+}
+
+reverse_pos_t kreverse_position(void) {
+    if (g_reverse_bound) return reverse_position(&g_reverse);
+    reverse_pos_t z = { 0, 0 };
+    return z;
+}
+
+int kreverse_step(void) {
+    if (!g_reverse_bound) return REVERSE_ERR_PARAM;
+    return reverse_step(&g_reverse);
+}
+
+int kreverse_continue(reverse_stop_fn should_stop, void* pctx) {
+    if (!g_reverse_bound) return REVERSE_ERR_PARAM;
+    return reverse_continue(&g_reverse, should_stop, pctx);
+}

--- a/tests/test_reverse.c
+++ b/tests/test_reverse.c
@@ -1,0 +1,140 @@
+/* Host-side unit test for reverse execution (#170).
+ *
+ * Drives a REAL rewind verb (#169) over a REAL keyframe ring (#168) and replay
+ * engine (#165), with mock engine hooks that record which keyframe was restored.
+ * Verifies:
+ *   1. reverse-step lands one step before the current point, within an epoch.
+ *   2. At a keyframe boundary, reverse-step crosses to the previous keyframe's
+ *      last step (and the rewind restores that keyframe).
+ *   3. Repeated reverse-steps are stable: the position sequence is exact and
+ *      each step restores the correct keyframe (no drift).
+ *   4. reverse-continue stops at an injected condition; with no stop it runs
+ *      back to the oldest retained moment and reports REVERSE_AT_START.
+ *
+ * Build: gcc -I../include -o test_reverse test_reverse.c ../kernel/reverse.c \
+ *          ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "reverse.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock engine hooks: record which keyframe was restored. */
+typedef struct { uint64_t restored_keyframe; } sim_t;
+static int sim_restore(void* c, uint64_t epoch) { ((sim_t*)c)->restored_keyframe = epoch; return 0; }
+static int sim_load(void* c, uint64_t e) { (void)c; (void)e; return 0; }
+static int sim_run(void* c, uint64_t e, uint64_t l) { (void)c; (void)e; (void)l; return 0; }
+
+/* Per-keyframe journal lengths (steps until the next keyframe). */
+static uint64_t elen(void* c, uint64_t e) {
+    (void)c;
+    if (e == 20) return 3;
+    if (e == 30) return 4;
+    if (e == 40) return 5;
+    return 0;
+}
+
+static reverse_pos_t g_stop_at;
+static bool stop_at(void* c, reverse_pos_t p) {
+    (void)c;
+    return p.epoch == g_stop_at.epoch && p.offset == g_stop_at.offset;
+}
+
+static bool pos_is(reverse_pos_t p, uint64_t e, uint64_t o) {
+    return p.epoch == e && p.offset == o;
+}
+
+/* Build the fixture: ring {20,30,40}, engine(sim), rewind, reverse@(40,2). */
+static void fixture(keyframe_ring_t* ring, sim_t* s, replay_engine_t* re,
+                    rewind_ctx_t* rw, reverse_ctx_t* rv) {
+    keyframe_ring_init(ring, 4);
+    keyframe_ring_advance(ring, 20);
+    keyframe_ring_advance(ring, 30);
+    keyframe_ring_advance(ring, 40);
+    s->restored_keyframe = 0;
+    replay_hooks_t h = { sim_restore, sim_load, sim_run, s };
+    replay_init(re, &h);
+    rewind_init(rw, ring, re);
+    reverse_init(rv, rw, elen, 0);
+    reverse_set_position(rv, 40, 2);
+}
+
+int main(void) {
+    printf("=== Reverse execution (#170) unit test ===\n");
+
+    /* --- 1. reverse-step within an epoch --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv);
+        CHECK(reverse_step(&rv) == REVERSE_OK && pos_is(reverse_position(&rv), 40, 1),
+              "reverse-step (40,2) -> (40,1)");
+        CHECK(s.restored_keyframe == 40, "restored keyframe 40 for a within-epoch step");
+        CHECK(reverse_step(&rv) == REVERSE_OK && pos_is(reverse_position(&rv), 40, 0),
+              "reverse-step (40,1) -> (40,0)");
+    }
+
+    /* --- 2. reverse-step across a keyframe boundary --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv);
+        reverse_set_position(&rv, 40, 0);
+        CHECK(reverse_step(&rv) == REVERSE_OK && pos_is(reverse_position(&rv), 30, 3),
+              "reverse-step (40,0) -> (30,3): previous keyframe's last step");
+        CHECK(s.restored_keyframe == 30, "rewind restored keyframe 30 across the boundary");
+    }
+
+    /* --- 3. Repeated reverse-steps are stable, no drift --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv);
+        /* Expected exact sequence from (40,2) down to the start. */
+        const uint64_t exp[][2] = {
+            {40,1},{40,0},{30,3},{30,2},{30,1},{30,0},{20,2},{20,1},{20,0}
+        };
+        const uint64_t kf[]   = { 40, 40, 30, 30, 30, 30, 20, 20, 20 };
+        int ok = 1;
+        for (unsigned i = 0; i < 9; i++) {
+            if (reverse_step(&rv) != REVERSE_OK) { ok = 0; break; }
+            if (!pos_is(reverse_position(&rv), exp[i][0], exp[i][1])) ok = 0;
+            if (s.restored_keyframe != kf[i]) ok = 0;
+        }
+        CHECK(ok, "nine reverse-steps follow the exact position sequence, right keyframe each time");
+        CHECK(reverse_step(&rv) == REVERSE_AT_START, "reverse-step at the oldest moment reports AT_START");
+        CHECK(pos_is(reverse_position(&rv), 20, 0), "position unchanged once at the start");
+    }
+
+    /* --- 4a. reverse-continue stops at an injected condition --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv);
+        g_stop_at.epoch = 30; g_stop_at.offset = 1;
+        CHECK(reverse_continue(&rv, stop_at, 0) == REVERSE_OK, "reverse-continue hits the stop");
+        CHECK(pos_is(reverse_position(&rv), 30, 1), "reverse-continue landed exactly at the stop");
+        CHECK(s.restored_keyframe == 30, "stopped with keyframe 30 restored");
+    }
+
+    /* --- 4b. reverse-continue with no stop runs back to the start --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv);
+        g_stop_at.epoch = 999; g_stop_at.offset = 999; /* never matches */
+        CHECK(reverse_continue(&rv, stop_at, 0) == REVERSE_AT_START,
+              "reverse-continue with no stop reports AT_START");
+        CHECK(pos_is(reverse_position(&rv), 20, 0), "and lands at the oldest retained moment");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: reverse execution steps backward stably via keyframe + replay\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #170

## Summary

Implements #170 (epic #159, Milestone C) on its own branch off `main`. Classic reverse debugging on top of the rewind verb (#169): to step backward, restore the prior keyframe and replay forward to just before the current point. Because every reverse step recomputes from a keyframe via deterministic replay, repeated reverse-steps are stable and never drift.

Both dependencies (#169 rewind, #168 ring, #165 engine) are in `main`, so this builds on them directly.

Scope is exactly #170 (4 files + CI). Default runtime behavior is unchanged.

## What changed

**`kernel/reverse.c` + `include/reverse.h` (new)**

A pure composition core. A position is `(keyframe epoch, offset)`:
- `reverse_step` decrements the offset within an epoch, and at a keyframe boundary (offset 0) crosses to the previous keyframe's last step (skipping empty epochs), driving `rewind_to` for each.
- `reverse_continue` steps backward until an injected stop condition holds (breakpoints arrive in #171) or the oldest retained keyframe is reached.

**`kernel/reverse_sync.c` (new)**

Kernel adapter binding the global rewind verb and exposing reverse-step / reverse-continue for a debugger front end (the GDB bridge, #172). The per-epoch step count comes from the journal via an injected reader.

**`tests/test_reverse.c` (new)**

13 checks driving a **real** rewind verb over a **real** keyframe ring and replay engine: within-epoch step; boundary crossing to the prior keyframe (restoring the right keyframe); an exact nine-step sequence with the correct keyframe restored each time (proving no drift); `reverse_continue` stopping at a condition; and running back to the oldest moment reporting `REVERSE_AT_START`.

**`.github/workflows/persistence.yml`**

Freestanding compile checks and unit test.

## Testing

- `test_reverse`: 13/13 checks pass (links the real `rewind`, `keyframe_ring`, `replay_engine`).
- Freestanding compile clean for `reverse.c` and `reverse_sync.c`.
- Branch is exactly #170 and branches from current `main`.

## Related issues

- Closes #170
- Part of epic #159 (Milestone C); built on rewind-to (#169); the injected stop condition is where reverse breakpoints (#171) plug in