### PR TITLE
Reverse breakpoints / watchpoints (#171)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -48,6 +48,10 @@ on:
       - 'kernel/reverse_sync.c'
       - 'include/reverse.h'
       - 'tests/test_reverse.c'
+      - 'kernel/revbreak.c'
+      - 'kernel/revbreak_sync.c'
+      - 'include/revbreak.h'
+      - 'tests/test_revbreak.c'
       - 'tests/timetravel_e2e.c'
       - 'scripts/test/timetravel_demo.sh'
       - '.github/workflows/persistence.yml'
@@ -66,7 +70,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -106,6 +110,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_kfr    test_keyframe_ring.c        ../kernel/keyframe_ring.c && /tmp/t_kfr
           gcc -I../include -Wall -o /tmp/t_rw     test_rewind.c               ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rw
           gcc -I../include -Wall -o /tmp/t_rev    test_reverse.c              ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rev
+          gcc -I../include -Wall -o /tmp/t_rb     test_revbreak.c             ../kernel/revbreak.c ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rb
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/include/revbreak.h
+++ b/include/revbreak.h
@@ -1,0 +1,65 @@
+/* IKOS Orthogonal Persistence - Reverse Breakpoints and Watchpoints (#171)
+ *
+ * Answers "where did this last happen?" by scanning backward through the
+ * retained history. Both plug a predicate into the reverse-continue seam (#170):
+ *
+ *   - Reverse breakpoint: step backward to the most recent position before the
+ *     current point where a condition holds (for example a PC or state check).
+ *   - Reverse watchpoint: step backward to the most recent position at or before
+ *     the current point where a watched value changed, i.e. the last write to
+ *     it, answering "where did this value last change?".
+ *
+ * The search is bounded by the retained keyframe ring (#168): reverse-step stops
+ * at the oldest retained moment, so a miss returns REVBREAK_NOT_FOUND rather than
+ * running off the end.
+ *
+ * Pure and host-testable: the condition and the watched-value probe are
+ * injected, reading the system state restored at each candidate position. The
+ * kernel adapter (revbreak_sync.c) binds a reverse context for a debugger front
+ * end.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef REVBREAK_H
+#define REVBREAK_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "reverse.h"
+
+#define REVBREAK_OK          0
+#define REVBREAK_NOT_FOUND  -1   /* no hit within the retained window */
+#define REVBREAK_ERR_PARAM  -2
+#define REVBREAK_ERR        -3   /* an underlying rewind/replay failed */
+
+/* Breakpoint condition, evaluated on the system state restored at the current
+ * position. Return true to stop. */
+typedef bool (*revbreak_cond_fn)(void* ctx);
+
+/* Reads the watched value from the system state restored at the current
+ * position (for a watchpoint). */
+typedef uint64_t (*revbreak_probe_fn)(void* ctx);
+
+/* Step backward to the most recent position strictly before the current point
+ * where cond() holds. Leaves the system there and, if hit != NULL, writes the
+ * position. Returns REVBREAK_NOT_FOUND if none within the retained ring. */
+int reverse_breakpoint(reverse_ctx_t* rv, revbreak_cond_fn cond, void* ctx,
+                       reverse_pos_t* hit);
+
+/* Step backward to the most recent position at or before the current point where
+ * the probed value changed (the last write to it). Leaves the system at that
+ * write and, if hit != NULL, writes the position. Returns REVBREAK_NOT_FOUND if
+ * the value never changed within the retained ring. */
+int reverse_watchpoint(reverse_ctx_t* rv, revbreak_probe_fn probe, void* ctx,
+                       reverse_pos_t* hit);
+
+/* ---- Kernel adapter (revbreak_sync.c) ----
+ * Reverse breakpoint / watchpoint bound to a reverse context, for the debugger
+ * front end (the GDB bridge in #172). */
+void krevbreak_bind(reverse_ctx_t* rv);
+int  krevbreak_breakpoint(revbreak_cond_fn cond, void* ctx, reverse_pos_t* hit);
+int  krevbreak_watchpoint(revbreak_probe_fn probe, void* ctx, reverse_pos_t* hit);
+
+#endif /* REVBREAK_H */

--- a/kernel/revbreak.c
+++ b/kernel/revbreak.c
@@ -1,0 +1,68 @@
+/* IKOS Orthogonal Persistence - Reverse Breakpoints and Watchpoints (#171)
+ *
+ * See include/revbreak.h and docs/architecture/time-travel.md.
+ *
+ * Pure layer over reverse execution (#170): no allocator, no hardware, no I/O
+ * of its own. Both operations scan backward via reverse_step / reverse_continue,
+ * which restore the nearest keyframe and replay to each candidate position, so
+ * the injected predicate reads the real system state there.
+ */
+
+#include "revbreak.h"
+
+typedef struct {
+    revbreak_cond_fn cond;
+    void*            ctx;
+} bp_pack_t;
+
+/* Adapt a breakpoint condition to the reverse-continue stop predicate. The
+ * position is ignored: the condition reads the state restored at it. */
+static bool bp_adapter(void* c, reverse_pos_t pos) {
+    (void)pos;
+    bp_pack_t* b = (bp_pack_t*)c;
+    return b->cond(b->ctx);
+}
+
+int reverse_breakpoint(reverse_ctx_t* rv, revbreak_cond_fn cond, void* ctx,
+                       reverse_pos_t* hit) {
+    if (!rv || !cond) return REVBREAK_ERR_PARAM;
+    bp_pack_t pack = { cond, ctx };
+    int rc = reverse_continue(rv, bp_adapter, &pack);
+    if (rc == REVERSE_OK) {
+        if (hit) *hit = reverse_position(rv);
+        return REVBREAK_OK;
+    }
+    if (rc == REVERSE_AT_START) return REVBREAK_NOT_FOUND;
+    return REVBREAK_ERR;
+}
+
+int reverse_watchpoint(reverse_ctx_t* rv, revbreak_probe_fn probe, void* ctx,
+                       reverse_pos_t* hit) {
+    if (!rv || !rv->rw || !probe) return REVBREAK_ERR_PARAM;
+
+    /* Land at the current position so the probe reads its value. */
+    reverse_pos_t cur = reverse_position(rv);
+    if (rewind_to(rv->rw, cur.epoch, cur.offset) != REWIND_OK) return REVBREAK_ERR;
+    uint64_t newer = probe(ctx);
+
+    /* Walk backward, comparing each position's value to the one after it. The
+     * first difference (going backward) is the most recent write. */
+    for (;;) {
+        reverse_pos_t before = reverse_position(rv);  /* position holding `newer` */
+        int rc = reverse_step(rv);
+        if (rc == REVERSE_AT_START) return REVBREAK_NOT_FOUND;
+        if (rc != REVERSE_OK) return REVBREAK_ERR;
+
+        uint64_t older = probe(ctx);                  /* value one step earlier */
+        if (older != newer) {
+            /* The value changed between here and `before`: the write is at
+             * `before`. Land there. */
+            if (rewind_to(rv->rw, before.epoch, before.offset) != REWIND_OK)
+                return REVBREAK_ERR;
+            reverse_set_position(rv, before.epoch, before.offset);
+            if (hit) *hit = before;
+            return REVBREAK_OK;
+        }
+        newer = older;
+    }
+}

--- a/kernel/revbreak_sync.c
+++ b/kernel/revbreak_sync.c
@@ -1,0 +1,23 @@
+/* IKOS Orthogonal Persistence - Reverse Breakpoints/Watchpoints adapter (#171)
+ *
+ * Binds the reverse breakpoint / watchpoint operations (revbreak.c) to a reverse
+ * context for the debugger front end (the GDB bridge in #172).
+ */
+
+#include "revbreak.h"
+
+static reverse_ctx_t* g_rv;
+
+void krevbreak_bind(reverse_ctx_t* rv) {
+    g_rv = rv;
+}
+
+int krevbreak_breakpoint(revbreak_cond_fn cond, void* ctx, reverse_pos_t* hit) {
+    if (!g_rv) return REVBREAK_ERR_PARAM;
+    return reverse_breakpoint(g_rv, cond, ctx, hit);
+}
+
+int krevbreak_watchpoint(revbreak_probe_fn probe, void* ctx, reverse_pos_t* hit) {
+    if (!g_rv) return REVBREAK_ERR_PARAM;
+    return reverse_watchpoint(g_rv, probe, ctx, hit);
+}

--- a/tests/test_revbreak.c
+++ b/tests/test_revbreak.c
@@ -1,0 +1,148 @@
+/* Host-side unit test for reverse breakpoints and watchpoints (#171).
+ *
+ * Drives the REAL reverse / rewind / keyframe-ring / replay-engine stack. The
+ * "system state" is modeled as a watched value that is written at two known
+ * positions; the injected condition and probe read that value at whatever
+ * position the stack restored. Verifies:
+ *   1. A reverse breakpoint stops at the most recent earlier position where the
+ *      condition holds.
+ *   2. A reverse watchpoint lands on the last write to the value.
+ *   3. The search is bounded by the retained ring: a miss reports NOT_FOUND at
+ *      the oldest retained moment.
+ *
+ * Build: gcc -I../include -o test_revbreak test_revbreak.c ../kernel/revbreak.c \
+ *          ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c \
+ *          ../kernel/replay_engine.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "revbreak.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Mock engine hooks (positions are driven by rewind; state is modeled below). */
+typedef struct { uint64_t restored; } sim_t;
+static int sim_restore(void* c, uint64_t e) { ((sim_t*)c)->restored = e; return 0; }
+static int sim_load(void* c, uint64_t e) { (void)c; (void)e; return 0; }
+static int sim_run(void* c, uint64_t e, uint64_t l) { (void)c; (void)e; (void)l; return 0; }
+
+static uint64_t elen(void* c, uint64_t e) {
+    (void)c;
+    if (e == 20) return 3;
+    if (e == 30) return 4;
+    if (e == 40) return 5;
+    return 0;
+}
+
+/* Total order on positions, and the watched value = number of writes at or
+ * before a position. Writes at W1 = (30,2) and W2 = (40,1). */
+static bool pos_le(uint64_t ae, uint64_t ao, uint64_t be, uint64_t bo) {
+    return ae < be || (ae == be && ao <= bo);
+}
+static uint64_t value_at(reverse_pos_t p) {
+    uint64_t v = 0;
+    if (pos_le(30, 2, p.epoch, p.offset)) v++;  /* W1 */
+    if (pos_le(40, 1, p.epoch, p.offset)) v++;  /* W2 */
+    return v;
+}
+
+/* Condition / probe read the value at the reverse context's current position. */
+static bool cond_value_is_1(void* c) {
+    return value_at(reverse_position((reverse_ctx_t*)c)) == 1;
+}
+static bool cond_never(void* c) { (void)c; return false; }
+static uint64_t probe_value(void* c) {
+    return value_at(reverse_position((reverse_ctx_t*)c));
+}
+
+static bool pos_is(reverse_pos_t p, uint64_t e, uint64_t o) {
+    return p.epoch == e && p.offset == o;
+}
+
+static void fixture(keyframe_ring_t* ring, sim_t* s, replay_engine_t* re,
+                    rewind_ctx_t* rw, reverse_ctx_t* rv,
+                    uint64_t start_epoch, uint64_t start_offset) {
+    keyframe_ring_init(ring, 4);
+    keyframe_ring_advance(ring, 20);
+    keyframe_ring_advance(ring, 30);
+    keyframe_ring_advance(ring, 40);
+    s->restored = 0;
+    replay_hooks_t h = { sim_restore, sim_load, sim_run, s };
+    replay_init(re, &h);
+    rewind_init(rw, ring, re);
+    reverse_init(rv, rw, elen, 0);
+    reverse_set_position(rv, start_epoch, start_offset);
+}
+
+int main(void) {
+    printf("=== Reverse breakpoints and watchpoints (#171) unit test ===\n");
+
+    /* --- 1. Reverse breakpoint: last earlier position where value == 1 --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv, 40, 3);   /* value there is 2 */
+        reverse_pos_t hit;
+        CHECK(reverse_breakpoint(&rv, cond_value_is_1, &rv, &hit) == REVBREAK_OK,
+              "reverse breakpoint finds an earlier hit");
+        CHECK(pos_is(hit, 40, 0), "stopped at the most recent earlier position with value 1 (40,0)");
+        CHECK(pos_is(reverse_position(&rv), 40, 0), "system left at the breakpoint hit");
+    }
+
+    /* --- 2. Reverse watchpoint: last write to the value --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv, 40, 3);
+        reverse_pos_t hit;
+        CHECK(reverse_watchpoint(&rv, probe_value, &rv, &hit) == REVBREAK_OK,
+              "reverse watchpoint finds a write");
+        CHECK(pos_is(hit, 40, 1), "landed on the last write to the value (40,1)");
+        CHECK(pos_is(reverse_position(&rv), 40, 1), "system left at the write");
+    }
+
+    /* --- 2b. Watchpoint from an earlier point finds the earlier write --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv, 40, 0);   /* value there is 1 */
+        reverse_pos_t hit;
+        CHECK(reverse_watchpoint(&rv, probe_value, &rv, &hit) == REVBREAK_OK &&
+              pos_is(hit, 30, 2),
+              "from (40,0) the last write is the earlier one (30,2)");
+    }
+
+    /* --- 3. Bounded by the ring: misses report NOT_FOUND at the start --- */
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv, 40, 3);
+        CHECK(reverse_breakpoint(&rv, cond_never, &rv, 0) == REVBREAK_NOT_FOUND,
+              "a breakpoint that never holds reports NOT_FOUND");
+        CHECK(pos_is(reverse_position(&rv), 20, 0), "and the scan stopped at the oldest retained moment");
+    }
+    {
+        keyframe_ring_t ring; sim_t s; replay_engine_t re; rewind_ctx_t rw; reverse_ctx_t rv;
+        fixture(&ring, &s, &re, &rw, &rv, 20, 2);   /* before any write: value 0 throughout */
+        reverse_pos_t hit;
+        CHECK(reverse_watchpoint(&rv, probe_value, &rv, &hit) == REVBREAK_NOT_FOUND,
+              "a value that never changed in the window reports NOT_FOUND");
+    }
+
+    /* --- 4. Bad params --- */
+    {
+        reverse_ctx_t rv;
+        CHECK(reverse_breakpoint(0, cond_never, 0, 0) == REVBREAK_ERR_PARAM, "breakpoint rejects NULL ctx");
+        CHECK(reverse_watchpoint(&rv, 0, 0, 0) == REVBREAK_ERR_PARAM, "watchpoint rejects NULL probe");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: reverse breakpoints and watchpoints find the last hit, bounded by the ring\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #171

## Summary

Implements #171 (epic #159, Milestone C) on its own branch off `main`. Answers "where did this last happen?" by scanning backward through the retained history, plugging a predicate into the reverse-continue seam (#170). This completes Milestone C.

Scope is exactly #171 (4 files + CI). Default runtime behavior is unchanged.

## What changed

**`kernel/revbreak.c` + `include/revbreak.h` (new)**

A pure layer over reverse execution:
- `reverse_breakpoint(cond)` steps backward to the most recent position **before** the current point where the condition holds (adapts the condition to `reverse_continue`).
- `reverse_watchpoint(probe)` steps backward, comparing the probed value at consecutive positions, and lands on the most recent position where it changed — the **last write** to it.

Both are bounded by the retained keyframe ring (#168): a miss returns `REVBREAK_NOT_FOUND` at the oldest retained moment rather than running off the end.

**`kernel/revbreak_sync.c` (new)**

Kernel adapter binding a reverse context for the debugger front end (the GDB bridge, #172).

**`tests/test_revbreak.c` (new)**

12 checks over the **real** reverse / rewind / keyframe-ring / replay-engine stack, modeling a watched value written at two known positions:
- breakpoint stops at the last earlier position where the condition holds;
- watchpoint lands on the last write, and from an earlier point finds the earlier write;
- both report `NOT_FOUND` at the horizon (search bounded by the ring);
- bad params.

**`.github/workflows/persistence.yml`**

Freestanding compile checks and unit test.

## Testing

- `test_revbreak`: 12/12 checks pass (links the real reverse / rewind / ring / engine).
- Freestanding compile clean for `revbreak.c` and `revbreak_sync.c`.
- Branch is exactly #171 and branches from current `main`.

## Related issues

- Closes #171
- Part of epic #159 (Milestone C); built on reverse execution (#170); consumed by the GDB bridge (#175)