### PR TITLE
MCP interface: expose record/rewind/reverse as agent tools (#188)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -60,6 +60,12 @@ on:
       - 'scripts/test/timetravel_demo.sh'
       - 'tests/scrub_e2e.c'
       - 'scripts/test/scrub_demo.sh'
+      - 'kernel/mcp.c'
+      - 'kernel/mcp_sync.c'
+      - 'include/mcp.h'
+      - 'tests/test_mcp.c'
+      - 'tests/mcp_heisenbug_e2e.c'
+      - 'scripts/test/mcp_heisenbug_demo.sh'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -76,7 +82,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -118,6 +124,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_rev    test_reverse.c              ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rev
           gcc -I../include -Wall -o /tmp/t_rb     test_revbreak.c             ../kernel/revbreak.c ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rb
           gcc -I../include -Wall -o /tmp/t_gdb    test_gdbstub.c              ../kernel/gdbstub.c && /tmp/t_gdb
+          gcc -I../include -Wall -o /tmp/t_mcp    test_mcp.c                  ../kernel/mcp.c && /tmp/t_mcp
 
   e2e-demo:
     runs-on: ubuntu-latest
@@ -130,5 +137,7 @@ jobs:
         run: bash scripts/test/timetravel_demo.sh
       - name: Time-travel "scrub the machine backwards" demo
         run: bash scripts/test/scrub_demo.sh
+      - name: MCP heisenbug demo (agent rewinds to find the bug)
+        run: bash scripts/test/mcp_heisenbug_demo.sh
       - name: In-QEMU boot demo (skips gracefully if QEMU is unavailable)
         run: bash scripts/test/qemu_persistence_demo.sh

--- a/README.md
+++ b/README.md
@@ -354,9 +354,9 @@ Status:
 - Time-travel UX (keyframe retention, rewind-to, reverse execution, reverse
   breakpoints/watchpoints): implemented, unit-tested, with a headless scrub-backwards demo
 - Tooling: a GDB reverse-execution bridge (implemented, unit-tested)
-- MCP interface (planned): expose record, rewind, and reverse execution as tools an AI
-  agent can call, with a demo where an agent debugs a planted heisenbug by rewinding the
-  machine
+- MCP interface: expose record, rewind, and reverse execution as JSON-RPC tools an AI
+  agent can call (implemented, unit-tested), with a headless demo where an agent debugs a
+  planted heisenbug by rewinding the machine
 
 ### Systems Roadmap
 

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -36,6 +36,7 @@ ships each piece:
 | Reverse execution | reverse-step / reverse-continue as restore-prior-keyframe-and-replay | `kernel/reverse.c`, `kernel/reverse_sync.c` |
 | Reverse breakpoints/watchpoints | Scan backward to the last hit or the last write to a value, bounded by the ring | `kernel/revbreak.c`, `kernel/revbreak_sync.c` |
 | GDB bridge | Maps gdb `reverse-stepi` / `reverse-continue` (RSP bs/bc) onto the reverse engine | `kernel/gdbstub.c`, `kernel/gdbstub_sync.c` |
+| MCP interface | Exposes record / rewind / reverse execution as JSON-RPC tools an AI agent can call | `kernel/mcp.c`, `kernel/mcp_sync.c` |
 
 Each stage has a host-side unit test under `tests/` and a freestanding compile check in CI.
 Two end-to-end demos tie them together, both headless: `scripts/test/timetravel_demo.sh`
@@ -167,6 +168,13 @@ final state is byte-identical. This gates the milestone and guards against regre
 
 Goal: expose record, rewind, and reverse execution as Model Context Protocol tools so an
 AI agent can drive a time-traveling debugger over a well-defined interface.
+
+This is implemented: `kernel/mcp.c` is a pure JSON-RPC dispatch core that handles
+`tools/list` and `tools/call`, mapping the tool names below onto the rewind (#169), reverse
+(#170), and reverse-watchpoint (#171) engines; `kernel/mcp_sync.c` wires the operations to
+the kernel entry points. `scripts/test/mcp_heisenbug_demo.sh` runs the agent flow below
+headlessly: an agent debugs a planted heisenbug by calling `watch_last_write` and
+`rewind_to`, with the stdio JSON-RPC server loop the only remaining transport wiring.
 
 The interface changes who the customer is. Instead of a human who must adopt a new OS, the
 consumer is an agent that calls tools. Agents are poor at exactly what this engine is good

--- a/include/mcp.h
+++ b/include/mcp.h
@@ -1,0 +1,66 @@
+/* IKOS Orthogonal Persistence - MCP Time-Travel Interface (#159 Milestone E)
+ *
+ * Exposes IKOS's time-travel primitives as Model Context Protocol tools, so an
+ * AI agent can drive record / rewind / reverse execution over JSON-RPC. Agents
+ * are poor at exactly what this stack is good at: reproducing a non-deterministic
+ * bug, stepping backward, and keeping the world stable between runs. Giving the
+ * agent rewind_to / reverse_step / watch_last_write as callable tools turns it
+ * into a time-traveling debugger.
+ *
+ * The tool surface:
+ *   - list_checkpoints : the retained keyframe window (rewind horizon)
+ *   - rewind_to        : restore the nearest keyframe and replay to (epoch,offset)
+ *   - reverse_step     : step one unit backward
+ *   - watch_last_write : find where a watched value last changed
+ *
+ * The core is pure and host-testable: it parses a JSON-RPC request, dispatches
+ * to injected operations (backed by the rewind #169 / reverse #170 / reverse
+ * watchpoint #171 engines), and formats the JSON-RPC response. The kernel
+ * adapter (mcp_sync.c) wires the operations to the k* time-travel entry points;
+ * the stdio JSON-RPC server loop is the thin transport documented alongside it.
+ *
+ * See docs/architecture/time-travel.md (Plan 2).
+ */
+
+#ifndef MCP_H
+#define MCP_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Time-travel operations the tools drive. Each returns 0 on success. Position
+ * results are written to *out_epoch / *out_offset. */
+typedef struct {
+    int (*list_checkpoints)(void* ctx, uint64_t* oldest, uint64_t* newest, uint32_t* count);
+    int (*rewind_to)(void* ctx, uint64_t epoch, uint64_t offset);
+    int (*reverse_step)(void* ctx, uint64_t* out_epoch, uint64_t* out_offset);
+    int (*watch_last_write)(void* ctx, uint64_t* out_epoch, uint64_t* out_offset);
+    void* ctx;
+} mcp_ops_t;
+
+/* ---- JSON helpers (exposed for tests) ---- */
+
+/* Find integer field "key": <digits> in a JSON object. Returns true if found. */
+bool mcp_json_int(const char* json, uint32_t len, const char* key, uint64_t* out);
+
+/* Find string field "key": "value"; copies value into out. Returns true. */
+bool mcp_json_str(const char* json, uint32_t len, const char* key,
+                  char* out, uint32_t outcap);
+
+/* Handle one JSON-RPC request and write the JSON-RPC response into out.
+ * Recognizes the "tools/list" method (returns the tool schema) and "tools/call"
+ * (dispatches params.name to the matching operation). Returns the response
+ * length, or -1 if it does not fit in out. */
+int mcp_handle(const mcp_ops_t* ops, const char* request, uint32_t reqlen,
+               char* out, uint32_t outcap);
+
+/* ---- Kernel adapter (mcp_sync.c) ----
+ * Build an mcp_ops_t wired to the kernel's time-travel entry points. The
+ * watchpoint needs a probe for the watched value, registered separately. */
+typedef uint64_t (*mcp_probe_fn)(void* ctx);
+void          mcp_bind(void);
+void          mcp_set_ring(const void* keyframe_ring);   /* for list_checkpoints */
+void          mcp_set_watch_probe(mcp_probe_fn probe, void* ctx);
+const mcp_ops_t* mcp_kernel_ops(void);
+
+#endif /* MCP_H */

--- a/kernel/mcp.c
+++ b/kernel/mcp.c
@@ -1,0 +1,204 @@
+/* IKOS Orthogonal Persistence - MCP Time-Travel Interface (#159 Milestone E)
+ *
+ * See include/mcp.h and docs/architecture/time-travel.md (Plan 2).
+ *
+ * Pure JSON-RPC dispatch core: focused scanners for the known tool schema (not a
+ * general JSON parser, in the spirit of the gdb RSP stub), plus a small string
+ * builder for the response. No allocator, no I/O; the operations and the stdio
+ * transport are injected/wired by the adapter.
+ */
+
+#include "mcp.h"
+
+/* ---------------- small string builder ---------------- */
+
+typedef struct { char* buf; uint32_t cap; uint32_t len; bool ovf; } sb_t;
+
+static void sb_init(sb_t* s, char* buf, uint32_t cap) {
+    s->buf = buf; s->cap = cap; s->len = 0; s->ovf = false;
+}
+static void sb_putc(sb_t* s, char c) {
+    if (s->len < s->cap) s->buf[s->len++] = c; else s->ovf = true;
+}
+static void sb_put(sb_t* s, const char* str) {
+    while (*str) sb_putc(s, *str++);
+}
+static void sb_put_u64(sb_t* s, uint64_t v) {
+    char tmp[20]; int n = 0;
+    if (v == 0) { sb_putc(s, '0'); return; }
+    while (v) { tmp[n++] = (char)('0' + (v % 10)); v /= 10; }
+    while (n--) sb_putc(s, tmp[n]);
+}
+
+/* ---------------- focused JSON scanners ---------------- */
+
+static bool str_eq(const char* a, const char* b, uint32_t n) {
+    for (uint32_t i = 0; i < n; i++) if (a[i] != b[i]) return false;
+    return true;
+}
+static uint32_t lit_len(const char* s) { uint32_t n = 0; while (s[n]) n++; return n; }
+
+/* Locate `"key"` in json; returns the index just past the closing quote, or -1. */
+static int find_key(const char* json, uint32_t len, const char* key) {
+    uint32_t klen = lit_len(key);
+    if (klen + 2 > len) return -1;
+    for (uint32_t i = 0; i + klen + 2 <= len; i++) {
+        if (json[i] == '"' && str_eq(json + i + 1, key, klen) && json[i + 1 + klen] == '"')
+            return (int)(i + 1 + klen + 1);
+    }
+    return -1;
+}
+
+/* Skip spaces and a single ':'. */
+static uint32_t skip_colon(const char* json, uint32_t len, uint32_t i) {
+    while (i < len && (json[i] == ' ' || json[i] == ':' || json[i] == '\t')) i++;
+    return i;
+}
+
+bool mcp_json_int(const char* json, uint32_t len, const char* key, uint64_t* out) {
+    int k = find_key(json, len, key);
+    if (k < 0) return false;
+    uint32_t i = skip_colon(json, len, (uint32_t)k);
+    if (i >= len || json[i] < '0' || json[i] > '9') return false;
+    uint64_t v = 0;
+    while (i < len && json[i] >= '0' && json[i] <= '9') { v = v * 10 + (uint64_t)(json[i] - '0'); i++; }
+    if (out) *out = v;
+    return true;
+}
+
+bool mcp_json_str(const char* json, uint32_t len, const char* key,
+                  char* out, uint32_t outcap) {
+    int k = find_key(json, len, key);
+    if (k < 0) return false;
+    uint32_t i = skip_colon(json, len, (uint32_t)k);
+    if (i >= len || json[i] != '"') return false;
+    i++;
+    uint32_t o = 0;
+    while (i < len && json[i] != '"') {
+        if (o + 1 < outcap) out[o++] = json[i];
+        i++;
+    }
+    if (o < outcap) out[o] = 0;
+    return true;
+}
+
+/* ---------------- response helpers ---------------- */
+
+/* Open a JSON-RPC result envelope with the echoed id and a text content item. */
+static void begin_text_result(sb_t* s, uint64_t id) {
+    sb_put(s, "{\"jsonrpc\":\"2.0\",\"id\":");
+    sb_put_u64(s, id);
+    sb_put(s, ",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"");
+}
+static void end_text_result(sb_t* s, bool is_error) {
+    sb_put(s, "\"}]");
+    if (is_error) sb_put(s, ",\"isError\":true");
+    sb_put(s, "}}");
+}
+
+/* ---------------- dispatch ---------------- */
+
+static int finish(sb_t* s) { return s->ovf ? -1 : (int)s->len; }
+
+int mcp_handle(const mcp_ops_t* ops, const char* request, uint32_t reqlen,
+               char* out, uint32_t outcap) {
+    uint64_t id = 0;
+    mcp_json_int(request, reqlen, "id", &id);
+
+    char method[32];
+    if (!mcp_json_str(request, reqlen, "method", method, sizeof(method)))
+        return -1;
+
+    sb_t s; sb_init(&s, out, outcap);
+
+    /* tools/list: advertise the time-travel tools. */
+    if (str_eq(method, "tools/list", lit_len("tools/list")) &&
+        lit_len(method) == lit_len("tools/list")) {
+        sb_put(&s, "{\"jsonrpc\":\"2.0\",\"id\":");
+        sb_put_u64(&s, id);
+        sb_put(&s, ",\"result\":{\"tools\":[");
+        sb_put(&s, "{\"name\":\"list_checkpoints\",\"description\":\"Retained keyframe window (rewind horizon).\"},");
+        sb_put(&s, "{\"name\":\"rewind_to\",\"description\":\"Restore the nearest keyframe and replay to (epoch, offset).\"},");
+        sb_put(&s, "{\"name\":\"reverse_step\",\"description\":\"Step one unit backward through recorded history.\"},");
+        sb_put(&s, "{\"name\":\"watch_last_write\",\"description\":\"Find where a watched value last changed.\"}");
+        sb_put(&s, "]}}");
+        return finish(&s);
+    }
+
+    /* tools/call: dispatch on the tool name. */
+    if (str_eq(method, "tools/call", lit_len("tools/call")) &&
+        lit_len(method) == lit_len("tools/call")) {
+        char name[32];
+        if (!mcp_json_str(request, reqlen, "name", name, sizeof(name))) {
+            begin_text_result(&s, id);
+            sb_put(&s, "missing tool name");
+            end_text_result(&s, true);
+            return finish(&s);
+        }
+        uint32_t nlen = lit_len(name);
+
+        if (nlen == lit_len("list_checkpoints") && str_eq(name, "list_checkpoints", nlen)) {
+            uint64_t oldest = 0, newest = 0; uint32_t count = 0;
+            int rc = ops && ops->list_checkpoints
+                     ? ops->list_checkpoints(ops->ctx, &oldest, &newest, &count) : -1;
+            begin_text_result(&s, id);
+            if (rc == 0) {
+                sb_put(&s, "checkpoints: count="); sb_put_u64(&s, count);
+                sb_put(&s, " oldest="); sb_put_u64(&s, oldest);
+                sb_put(&s, " newest="); sb_put_u64(&s, newest);
+                end_text_result(&s, false);
+            } else { sb_put(&s, "no checkpoints"); end_text_result(&s, true); }
+            return finish(&s);
+        }
+
+        if (nlen == lit_len("rewind_to") && str_eq(name, "rewind_to", nlen)) {
+            uint64_t epoch = 0, offset = 0;
+            bool have = mcp_json_int(request, reqlen, "epoch", &epoch);
+            mcp_json_int(request, reqlen, "offset", &offset);
+            int rc = (have && ops && ops->rewind_to)
+                     ? ops->rewind_to(ops->ctx, epoch, offset) : -1;
+            begin_text_result(&s, id);
+            if (rc == 0) {
+                sb_put(&s, "rewound to epoch="); sb_put_u64(&s, epoch);
+                sb_put(&s, " offset="); sb_put_u64(&s, offset);
+                end_text_result(&s, false);
+            } else { sb_put(&s, "rewind out of range"); end_text_result(&s, true); }
+            return finish(&s);
+        }
+
+        if (nlen == lit_len("reverse_step") && str_eq(name, "reverse_step", nlen)) {
+            uint64_t e = 0, o = 0;
+            int rc = ops && ops->reverse_step ? ops->reverse_step(ops->ctx, &e, &o) : -1;
+            begin_text_result(&s, id);
+            if (rc == 0) {
+                sb_put(&s, "stepped back to epoch="); sb_put_u64(&s, e);
+                sb_put(&s, " offset="); sb_put_u64(&s, o);
+                end_text_result(&s, false);
+            } else { sb_put(&s, "at start of history"); end_text_result(&s, true); }
+            return finish(&s);
+        }
+
+        if (nlen == lit_len("watch_last_write") && str_eq(name, "watch_last_write", nlen)) {
+            uint64_t e = 0, o = 0;
+            int rc = ops && ops->watch_last_write ? ops->watch_last_write(ops->ctx, &e, &o) : -1;
+            begin_text_result(&s, id);
+            if (rc == 0) {
+                sb_put(&s, "last write at epoch="); sb_put_u64(&s, e);
+                sb_put(&s, " offset="); sb_put_u64(&s, o);
+                end_text_result(&s, false);
+            } else { sb_put(&s, "no write within the retained window"); end_text_result(&s, true); }
+            return finish(&s);
+        }
+
+        begin_text_result(&s, id);
+        sb_put(&s, "unknown tool");
+        end_text_result(&s, true);
+        return finish(&s);
+    }
+
+    /* Unknown method: JSON-RPC method-not-found error. */
+    sb_put(&s, "{\"jsonrpc\":\"2.0\",\"id\":");
+    sb_put_u64(&s, id);
+    sb_put(&s, ",\"error\":{\"code\":-32601,\"message\":\"method not found\"}}");
+    return finish(&s);
+}

--- a/kernel/mcp_sync.c
+++ b/kernel/mcp_sync.c
@@ -1,0 +1,78 @@
+/* IKOS Orthogonal Persistence - MCP Time-Travel Interface, kernel adapter
+ * (#159 Milestone E)
+ *
+ * Wires the MCP tool operations (mcp.c) to the kernel's time-travel entry
+ * points: list_checkpoints reads the keyframe ring (#168), rewind_to calls
+ * krewind_to (#169), reverse_step calls kreverse_step (#170), and
+ * watch_last_write calls krevbreak_watchpoint (#171) with a registered probe.
+ *
+ * A stdio JSON-RPC server loop reads a request, calls mcp_handle() with these
+ * ops, and writes the response; that transport is the only remaining wiring to
+ * expose the tools to a real MCP client.
+ */
+
+#include "mcp.h"
+#include "keyframe_ring.h"
+#include "rewind.h"
+#include "reverse.h"
+#include "revbreak.h"
+
+static const keyframe_ring_t* g_ring;
+static mcp_probe_fn           g_probe;
+static void*                  g_probe_ctx;
+
+static int op_list(void* c, uint64_t* oldest, uint64_t* newest, uint32_t* count) {
+    (void)c;
+    if (!g_ring) return -1;
+    if (!keyframe_ring_oldest(g_ring, oldest)) return -1;
+    keyframe_ring_newest(g_ring, newest);
+    *count = keyframe_ring_count(g_ring);
+    return 0;
+}
+
+static int op_rewind(void* c, uint64_t epoch, uint64_t offset) {
+    (void)c;
+    return krewind_to(epoch, offset) == REWIND_OK ? 0 : -1;
+}
+
+static int op_reverse_step(void* c, uint64_t* out_epoch, uint64_t* out_offset) {
+    (void)c;
+    int rc = kreverse_step();
+    reverse_pos_t p = kreverse_position();
+    if (out_epoch) *out_epoch = p.epoch;
+    if (out_offset) *out_offset = p.offset;
+    return rc == REVERSE_OK ? 0 : -1;
+}
+
+static int op_watch(void* c, uint64_t* out_epoch, uint64_t* out_offset) {
+    (void)c;
+    if (!g_probe) return -1;
+    reverse_pos_t hit;
+    if (krevbreak_watchpoint(g_probe, g_probe_ctx, &hit) != REVBREAK_OK) return -1;
+    if (out_epoch) *out_epoch = hit.epoch;
+    if (out_offset) *out_offset = hit.offset;
+    return 0;
+}
+
+static mcp_ops_t g_ops;
+
+void mcp_bind(void) {
+    g_ops.list_checkpoints = op_list;
+    g_ops.rewind_to = op_rewind;
+    g_ops.reverse_step = op_reverse_step;
+    g_ops.watch_last_write = op_watch;
+    g_ops.ctx = 0;
+}
+
+void mcp_set_ring(const void* keyframe_ring) {
+    g_ring = (const keyframe_ring_t*)keyframe_ring;
+}
+
+void mcp_set_watch_probe(mcp_probe_fn probe, void* ctx) {
+    g_probe = probe;
+    g_probe_ctx = ctx;
+}
+
+const mcp_ops_t* mcp_kernel_ops(void) {
+    return &g_ops;
+}

--- a/scripts/test/mcp_heisenbug_demo.sh
+++ b/scripts/test/mcp_heisenbug_demo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# MCP heisenbug demo / test (#159 Milestone E).
+#
+# A scripted agent debugs a planted heisenbug using the MCP time-travel tools.
+# The tool calls are real JSON-RPC requests handled by the MCP dispatch core,
+# backed by the real rewind (#169) / reverse (#170) / reverse-watchpoint (#171)
+# stack. A watched value is good throughout the run except for one bad write; the
+# agent finds it by asking watch_last_write and rewinding, without knowing where
+# the bug is.
+#
+# Headless (no emulator). Exits non-zero if the agent fails to localize the bug,
+# so it gates CI.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CC="${CC:-gcc}"
+WORK="$(mktemp -d)"
+BIN="$WORK/mcp_heisenbug"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "==> building MCP heisenbug demo"
+"$CC" -I"$ROOT/include" -O2 -Wall -o "$BIN" \
+    "$ROOT/tests/mcp_heisenbug_e2e.c" \
+    "$ROOT/kernel/mcp.c" \
+    "$ROOT/kernel/revbreak.c" \
+    "$ROOT/kernel/reverse.c" \
+    "$ROOT/kernel/rewind.c" \
+    "$ROOT/kernel/keyframe_ring.c" \
+    "$ROOT/kernel/replay_engine.c"
+
+echo
+"$BIN"
+
+echo
+echo "PASSED: the agent used the MCP tools to rewind and localize the bug"

--- a/tests/mcp_heisenbug_e2e.c
+++ b/tests/mcp_heisenbug_e2e.c
@@ -1,0 +1,182 @@
+/* MCP heisenbug demo (#159 Milestone E).
+ *
+ * A scripted agent debugs a planted heisenbug using the MCP time-travel tools.
+ * The tool calls are real JSON-RPC requests handled by mcp_handle(); the
+ * operations are backed by the real rewind (#169) / reverse (#170) / reverse
+ * watchpoint (#171) stack over a keyframe ring (#168). A watched value is 0
+ * throughout the run except that a bug flips it to 0xBAD at one position; the
+ * agent finds that write by rewinding, without knowing where it was.
+ *
+ * The agent's steps:
+ *   1. tools/list  : discover the tools.
+ *   2. list_checkpoints : learn the retained rewind window.
+ *   3. watch_last_write : find where the watched value last changed (the bug).
+ *   4. rewind_to   : land just before the write and confirm the value was good.
+ *
+ * Exits non-zero if the agent fails to localize the bug, so it gates CI.
+ *
+ * Build: gcc -Iinclude -o mcp_heisenbug mcp_heisenbug_e2e.c kernel/mcp.c \
+ *          kernel/reverse.c kernel/rewind.c kernel/keyframe_ring.c \
+ *          kernel/replay_engine.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "mcp.h"
+#include "revbreak.h"  /* reverse_watchpoint; pulls reverse.h, rewind.h, ... */
+
+#define STEPS 4
+/* The planted bug: the watched value flips to 0xBAD at this position. */
+#define BUG_EPOCH  2
+#define BUG_OFFSET 1
+
+/* Mock engine hooks (positions are driven by rewind; the watched value is a
+ * pure function of position, below). */
+typedef struct { uint64_t restored; } sim_t;
+static int sim_restore(void* c, uint64_t e) { ((sim_t*)c)->restored = e; return 0; }
+static int sim_load(void* c, uint64_t e) { (void)c; (void)e; return 0; }
+static int sim_run(void* c, uint64_t e, uint64_t l) { (void)c; (void)e; (void)l; return 0; }
+static uint64_t elen(void* c, uint64_t e) { (void)c; (void)e; return STEPS; }
+
+/* The watched value: 0 everywhere until the bug write at (BUG_EPOCH,BUG_OFFSET),
+ * 0xBAD at or after it. */
+static uint64_t watched_at(reverse_pos_t p) {
+    bool at_or_after = p.epoch > BUG_EPOCH ||
+                       (p.epoch == BUG_EPOCH && p.offset >= BUG_OFFSET);
+    return at_or_after ? 0xBADull : 0ull;
+}
+static uint64_t probe(void* c) { return watched_at(reverse_position((reverse_ctx_t*)c)); }
+
+/* MCP ops backed by the real stack. */
+typedef struct { keyframe_ring_t* ring; rewind_ctx_t* rw; reverse_ctx_t* rv; } td_t;
+static int op_list(void* c, uint64_t* o, uint64_t* n, uint32_t* cnt) {
+    td_t* t = (td_t*)c;
+    if (!keyframe_ring_oldest(t->ring, o)) return -1;
+    keyframe_ring_newest(t->ring, n);
+    *cnt = keyframe_ring_count(t->ring);
+    return 0;
+}
+static int op_rewind(void* c, uint64_t e, uint64_t off) {
+    td_t* t = (td_t*)c;
+    if (rewind_to(t->rw, e, off) != REWIND_OK) return -1;
+    reverse_set_position(t->rv, e, off);
+    return 0;
+}
+static int op_step(void* c, uint64_t* e, uint64_t* o) {
+    td_t* t = (td_t*)c;
+    int rc = reverse_step(t->rv);
+    reverse_pos_t p = reverse_position(t->rv);
+    *e = p.epoch; *o = p.offset;
+    return rc == REVERSE_OK ? 0 : -1;
+}
+static int op_watch(void* c, uint64_t* e, uint64_t* o) {
+    td_t* t = (td_t*)c;
+    reverse_pos_t hit;
+    if (reverse_watchpoint(t->rv, probe, t->rv, &hit) != REVBREAK_OK) return -1;
+    *e = hit.epoch; *o = hit.offset;
+    return 0;
+}
+
+/* Parse "key=<digits>" out of a response text (what the agent reads back). */
+static bool read_after(const char* s, uint32_t n, const char* key, uint64_t* out) {
+    uint32_t klen = 0; while (key[klen]) klen++;
+    for (uint32_t i = 0; i + klen <= n; i++) {
+        bool m = true;
+        for (uint32_t j = 0; j < klen; j++) if (s[i + j] != key[j]) { m = false; break; }
+        if (!m) continue;
+        uint32_t p = i + klen; uint64_t v = 0; bool any = false;
+        while (p < n && s[p] >= '0' && s[p] <= '9') { v = v * 10 + (uint64_t)(s[p] - '0'); p++; any = true; }
+        if (any) { *out = v; return true; }
+    }
+    return false;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+int main(void) {
+    printf("=== MCP heisenbug demo: an agent rewinds to find the bug ===\n");
+
+    /* Set up the recorded run: keyframes 0..3, the stack, and the bad end state. */
+    keyframe_ring_t ring; keyframe_ring_init(&ring, 4);
+    for (uint64_t e = 0; e < 4; e++) keyframe_ring_advance(&ring, e);
+    sim_t s = {0};
+    replay_hooks_t h = { sim_restore, sim_load, sim_run, &s };
+    replay_engine_t re; replay_init(&re, &h);
+    rewind_ctx_t rw; rewind_init(&rw, &ring, &re);
+    reverse_ctx_t rv; reverse_init(&rv, &rw, elen, 0);
+    reverse_set_position(&rv, 3, STEPS - 1);   /* the run ended here, value = 0xBAD */
+
+    td_t td = { &ring, &rw, &rv };
+    mcp_ops_t ops = { op_list, op_rewind, op_step, op_watch, &td };
+    char out[512];
+
+    /* 1. Discover the tools. */
+    {
+        const char* req = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}";
+        int n = mcp_handle(&ops, req, (uint32_t)0 + __builtin_strlen(req), out, sizeof(out));
+        printf("  agent -> tools/list\n");
+        CHECK(n > 0, "tools/list returned a schema");
+    }
+
+    /* 2. Learn the rewind window. */
+    {
+        const char* req = "{\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"list_checkpoints\"}}";
+        int n = mcp_handle(&ops, req, (uint32_t)__builtin_strlen(req), out, sizeof(out));
+        out[n < (int)sizeof(out) ? n : (int)sizeof(out) - 1] = 0;
+        printf("  agent -> list_checkpoints : %s\n", out);
+    }
+
+    /* 3. The run ended badly: find where the watched value was last written. */
+    uint64_t bug_epoch = 0, bug_offset = 0;
+    {
+        const char* req = "{\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"watch_last_write\"}}";
+        int n = mcp_handle(&ops, req, (uint32_t)__builtin_strlen(req), out, sizeof(out));
+        printf("  agent -> watch_last_write : ");
+        for (int i = 0; i < n; i++) printf("%c", out[i]);
+        printf("\n");
+        bool a = read_after(out, (uint32_t)n, "epoch=", &bug_epoch);
+        bool b = read_after(out, (uint32_t)n, "offset=", &bug_offset);
+        CHECK(a && b && bug_epoch == BUG_EPOCH && bug_offset == BUG_OFFSET,
+              "agent localized the last write to the bug position (2,1)");
+    }
+
+    /* 4. Rewind to just before the bad write and confirm the value was good. */
+    {
+        char req[160];
+        /* build rewind_to {epoch: bug_epoch, offset: bug_offset-1 (or 0)} */
+        uint64_t insp_off = bug_offset > 0 ? bug_offset - 1 : 0;
+        /* the agent inspects the moment before the write */
+        int m = 0;
+        const char* pre = "{\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"rewind_to\",\"arguments\":{\"epoch\":";
+        for (const char* p = pre; *p; p++) req[m++] = *p;
+        req[m++] = (char)('0' + (bug_epoch % 10));
+        const char* mid = ",\"offset\":";
+        for (const char* p = mid; *p; p++) req[m++] = *p;
+        req[m++] = (char)('0' + (insp_off % 10));
+        const char* end = "}}}";
+        for (const char* p = end; *p; p++) req[m++] = *p;
+        req[m] = 0;
+        int n = mcp_handle(&ops, req, (uint32_t)m, out, sizeof(out));
+        printf("  agent -> rewind_to (before the write) : ");
+        for (int i = 0; i < n; i++) printf("%c", out[i]);
+        printf("\n");
+
+        reverse_pos_t before = { bug_epoch, insp_off };
+        reverse_pos_t at     = { bug_epoch, bug_offset };
+        CHECK(watched_at(before) == 0 && watched_at(at) == 0xBAD,
+              "the watched value is good just before the write and 0xBAD at it");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: the agent rewound to localize the planted heisenbug\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}

--- a/tests/test_mcp.c
+++ b/tests/test_mcp.c
@@ -1,0 +1,139 @@
+/* Host-side unit test for the MCP time-travel interface (#159 Milestone E).
+ *
+ * Verifies:
+ *   1. The JSON scanners extract integer and string fields.
+ *   2. tools/list advertises the time-travel tools.
+ *   3. tools/call dispatches rewind_to / reverse_step / watch_last_write /
+ *      list_checkpoints to the injected ops, echoes the request id, and reports
+ *      tool errors as isError.
+ *
+ * Build: gcc -I../include -o test_mcp test_mcp.c ../kernel/mcp.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+extern int printf(const char*, ...);
+
+#include "mcp.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+static uint32_t slen(const char* s) { uint32_t n = 0; while (s[n]) n++; return n; }
+static bool contains(const char* hay, uint32_t hlen, const char* needle) {
+    uint32_t n = slen(needle);
+    if (n == 0 || hlen < n) return false;
+    for (uint32_t i = 0; i + n <= hlen; i++) {
+        bool m = true;
+        for (uint32_t j = 0; j < n; j++) if (hay[i + j] != needle[j]) { m = false; break; }
+        if (m) return true;
+    }
+    return false;
+}
+
+/* Mock ops recording what the agent drove. */
+typedef struct {
+    uint64_t rewind_epoch, rewind_offset; int rewinds;
+    int steps;
+    int watches;
+} mock_t;
+static int m_list(void* c, uint64_t* o, uint64_t* n, uint32_t* cnt) {
+    (void)c; *o = 20; *n = 40; *cnt = 3; return 0;
+}
+static int m_rewind(void* c, uint64_t e, uint64_t off) {
+    mock_t* m = (mock_t*)c; m->rewind_epoch = e; m->rewind_offset = off; m->rewinds++;
+    return (e <= 40) ? 0 : -1;
+}
+static int m_step(void* c, uint64_t* e, uint64_t* o) {
+    mock_t* m = (mock_t*)c; m->steps++; *e = 30; *o = 3; return 0;
+}
+static int m_watch(void* c, uint64_t* e, uint64_t* o) {
+    mock_t* m = (mock_t*)c; m->watches++; *e = 40; *o = 1; return 0;
+}
+
+int main(void) {
+    printf("=== MCP time-travel interface unit test ===\n");
+
+    /* --- 1. JSON scanners --- */
+    {
+        const char* j = "{\"id\":7,\"params\":{\"name\":\"rewind_to\",\"arguments\":{\"epoch\":30,\"offset\":2}}}";
+        uint32_t n = slen(j);
+        uint64_t v = 0; char s[32];
+        CHECK(mcp_json_int(j, n, "epoch", &v) && v == 30, "int field epoch=30");
+        CHECK(mcp_json_int(j, n, "offset", &v) && v == 2, "int field offset=2");
+        CHECK(mcp_json_int(j, n, "id", &v) && v == 7, "int field id=7");
+        CHECK(mcp_json_str(j, n, "name", s, sizeof(s)) && contains(s, slen(s), "rewind_to"),
+              "string field name=rewind_to");
+    }
+
+    mock_t mock = {0};
+    mcp_ops_t ops = { m_list, m_rewind, m_step, m_watch, &mock };
+    char out[512];
+
+    /* --- 2. tools/list --- */
+    {
+        const char* req = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(n > 0 && contains(out, (uint32_t)n, "rewind_to") &&
+              contains(out, (uint32_t)n, "watch_last_write") &&
+              contains(out, (uint32_t)n, "reverse_step") &&
+              contains(out, (uint32_t)n, "list_checkpoints"),
+              "tools/list advertises the four time-travel tools");
+        CHECK(contains(out, (uint32_t)n, "\"id\":1"), "tools/list echoes the request id");
+    }
+
+    /* --- 3. tools/call dispatch --- */
+    {
+        const char* req = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"rewind_to\",\"arguments\":{\"epoch\":35,\"offset\":2}}}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(mock.rewinds == 1 && mock.rewind_epoch == 35 && mock.rewind_offset == 2,
+              "rewind_to dispatched with epoch=35 offset=2");
+        CHECK(contains(out, (uint32_t)n, "rewound to epoch=35 offset=2") &&
+              contains(out, (uint32_t)n, "\"id\":2"),
+              "rewind_to result text and id echoed");
+    }
+    {
+        const char* req = "{\"id\":3,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"watch_last_write\",\"arguments\":{}}}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(mock.watches == 1 && contains(out, (uint32_t)n, "last write at epoch=40 offset=1"),
+              "watch_last_write returns the write position");
+    }
+    {
+        const char* req = "{\"id\":4,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"reverse_step\",\"arguments\":{}}}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(mock.steps == 1 && contains(out, (uint32_t)n, "stepped back to epoch=30 offset=3"),
+              "reverse_step returns the new position");
+    }
+    {
+        const char* req = "{\"id\":5,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"list_checkpoints\",\"arguments\":{}}}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(contains(out, (uint32_t)n, "count=3 oldest=20 newest=40"),
+              "list_checkpoints returns the retained window");
+    }
+    {
+        const char* req = "{\"id\":6,\"method\":\"tools/call\","
+                          "\"params\":{\"name\":\"no_such_tool\",\"arguments\":{}}}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(contains(out, (uint32_t)n, "unknown tool") && contains(out, (uint32_t)n, "isError"),
+              "an unknown tool is reported as an error");
+    }
+    {
+        const char* req = "{\"id\":8,\"method\":\"nope\"}";
+        int n = mcp_handle(&ops, req, slen(req), out, sizeof(out));
+        CHECK(contains(out, (uint32_t)n, "-32601"), "an unknown method returns method-not-found");
+    }
+
+    if (failures == 0) {
+        printf("PASSED: MCP tools dispatch record/rewind/reverse over JSON-RPC\n");
+        return 0;
+    }
+    printf("FAILED: %d check(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
Closes #188

## Summary

Implements #188 (epic #159, Milestone E) on its own branch off `main`. This is the finale of the time-travel epic: expose the time-travel primitives as Model Context Protocol tools so an AI agent can drive record / rewind / reverse execution over JSON-RPC. Agents are poor at exactly what this stack is good at (reproducing a non-deterministic bug, stepping backward, keeping the world stable between runs); callable tools turn an agent into a time-traveling debugger.

Scope is exactly #188 (code + demo + docs + CI).

## What changed

**`kernel/mcp.c` + `include/mcp.h` (new)**

A pure, host-testable JSON-RPC dispatch core: focused JSON scanners (in the spirit of the gdb RSP stub, not a general parser) plus a small response builder. Handles `tools/list` (advertising the tools) and `tools/call` (dispatching `params.name` to injected operations), echoes the request id, and reports unknown tools as `isError` / unknown methods as method-not-found. Tool surface:

| tool | maps to |
|---|---|
| `list_checkpoints` | keyframe ring window (#168) |
| `rewind_to(epoch, offset)` | rewind (#169) |
| `reverse_step` | reverse execution (#170) |
| `watch_last_write` | reverse watchpoint (#171) |

**`kernel/mcp_sync.c` (new)**

Kernel adapter wiring the operations to the `k*` entry points. The stdio JSON-RPC server loop is the only remaining transport wiring.

**`tests/mcp_heisenbug_e2e.c` + `scripts/test/mcp_heisenbug_demo.sh` (new)**

The flagship demo: a scripted agent debugs a **planted heisenbug** using real JSON-RPC tool calls backed by the **real** reverse stack. A watched value is good throughout the run except one bad write; the agent calls `watch_last_write` to find the write and `rewind_to` to inspect just before it, localizing the bug without knowing where it was. Sample:

```
  agent -> watch_last_write : {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"last write at epoch=2 offset=1"}]}}
  ok:   agent localized the last write to the bug position (2,1)
  agent -> rewind_to (before the write) : {... "text":"rewound to epoch=2 offset=0"}
PASSED: the agent rewound to localize the planted heisenbug
```

**`tests/test_mcp.c` (new)** — 13 checks: JSON scanners, `tools/list`, and `tools/call` dispatch for each tool with id echo and error handling.

**`docs/architecture/time-travel.md`, `README.md`** — mark the MCP interface implemented and add it to the module map.

**`.github/workflows/persistence.yml`** — freestanding checks, unit test, and the heisenbug demo in the `e2e-demo` job.

## Testing

- `test_mcp`: 13/13 checks pass.
- `scripts/test/mcp_heisenbug_demo.sh`: passes (agent localizes the bug).
- Freestanding compile clean for `mcp.c` and `mcp_sync.c`; docs glyph-clean.
- Branch is exactly #188 and branches from current `main`.

## Related issues

- Closes #188 (completes epic #159, Milestone E)
- Front end for rewind (#169), reverse (#170), and reverse watchpoint (#171)