### PR TITLE
Route live entropy through kentropy_fill (#192)

### DIFF
--- a/include/auth_system.h
+++ b/include/auth_system.h
@@ -424,6 +424,10 @@ int auth_generate_salt(char* salt, size_t length);
 
 /* Secure random generation */
 int auth_generate_random(void* buffer, size_t length);
+
+/* Register the auth /dev/urandom source with the deterministic-replay entropy
+ * gate (#192). Called once at boot so auth randomness records and replays. */
+void auth_entropy_gate_init(void);
 int auth_generate_session_id(char* session_id, size_t length);
 
 /* Key derivation */

--- a/kernel/auth_core.c
+++ b/kernel/auth_core.c
@@ -3,6 +3,7 @@
  */
 
 #include "../include/auth_system.h"
+#include "../include/entropy_record.h"   /* kentropy: deterministic-replay entropy gate (#192) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -57,24 +58,37 @@ static int secure_random_init(void) {
     return AUTH_SUCCESS;
 }
 
+/* Live entropy source: fill len bytes from /dev/urandom. This is the real
+ * randomness the deterministic-replay entropy gate (#192) records and replays.
+ * The signature matches entropy_source_fn; returns 0 on success. */
+static int auth_urandom_source(void* ctx, void* buf, uint32_t len) {
+    (void)ctx;
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t bytes_read = read(fd, buf, len);
+    close(fd);
+    return (bytes_read == (ssize_t)len) ? 0 : -1;
+}
+
+/* Register the auth entropy source with the kentropy gate at boot (#192), so
+ * auth_generate_random draws through kentropy_fill(): the real /dev/urandom on a
+ * live run, recorded on a record run, and reproduced identically on replay. */
+void auth_entropy_gate_init(void) {
+    kentropy_init();
+    kentropy_set_source(auth_urandom_source, NULL);
+}
+
 int auth_generate_random(void* buffer, size_t length) {
     if (!buffer || length == 0) {
         return AUTH_ERROR_INVALID;
     }
-    
-    int fd = open("/dev/urandom", O_RDONLY);
-    if (fd < 0) {
-        return AUTH_ERROR_CRYPTO;
-    }
-    
-    ssize_t bytes_read = read(fd, buffer, length);
-    close(fd);
-    
-    if (bytes_read != (ssize_t)length) {
-        return AUTH_ERROR_CRYPTO;
-    }
-    
-    return AUTH_SUCCESS;
+
+    /* Draw through the deterministic-replay entropy gate (#192) rather than
+     * reading /dev/urandom directly, so a recorded run replays identically. */
+    return (kentropy_fill(buffer, (uint32_t)length) == 0)
+               ? AUTH_SUCCESS : AUTH_ERROR_CRYPTO;
 }
 
 int auth_generate_salt(char* salt, size_t length) {

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -33,6 +33,10 @@
 void kernel_init(void);
 void kernel_loop(void);
 void show_help(void);
+
+/* Registers the auth /dev/urandom source with the entropy gate (#192);
+ * forward-declared to avoid pulling auth_system.h (and its libc deps) in. */
+extern void auth_entropy_gate_init(void);
 void show_statistics(void);
 void show_timer_info(void);
 void show_device_info(void);
@@ -82,6 +86,11 @@ void kernel_init(void) {
      * reads the cycle counter, so time reads go through the record/replay wrapper
      * (real RDTSC on a live run) rather than a raw read. Default mode is OFF. */
     ktime_init();
+
+    /* Deterministic-replay entropy gate (#192): register the auth /dev/urandom
+     * source with kentropy at boot, so auth randomness records and replays.
+     * Default mode is OFF (passthrough to /dev/urandom). */
+    auth_entropy_gate_init();
 
     /* Initialize memory management */
     memory_init();


### PR DESCRIPTION
Closes #192

## Summary

Second in-kernel integration step (sibling of #191), on its own branch off `main`. Routes the kernel's real entropy source through the deterministic-replay entropy gate (#164), so auth randomness is captured on a record run and reproduced on replay.

Surgical: 3 files, +40/-13. Default runtime behavior is unchanged (the gate ships in OFF/passthrough mode).

## What changed

**`kernel/auth_core.c`**
- Extract the `/dev/urandom` read into `auth_urandom_source` (matching `entropy_source_fn`).
- Add `auth_entropy_gate_init()` which registers it via `kentropy_init()` + `kentropy_set_source()`.
- Rewrite `auth_generate_random` to draw through `kentropy_fill()` instead of reading `/dev/urandom` directly: live/OFF reads the real device, RECORD logs the bytes, REPLAY returns the recorded bytes.
- The open+close availability probe in `secure_random_init` is left as-is (it reads no bytes, so it does not affect determinism).

**`include/auth_system.h`** — declare `auth_entropy_gate_init()`.

**`kernel/kernel_main.c`** — call `auth_entropy_gate_init()` at boot, next to the time gate (#191, already in `main`).

## Acceptance criteria

- `kentropy_set_source()` registered with the `/dev/urandom` reader at boot — done (`auth_entropy_gate_init()` from `kernel_init`).
- `auth_generate_random` draws through `kentropy_fill()` — done.
- A record run captures the bytes; a replay returns them — verified.

## Testing

A link-test over the real `entropy_record` + `entropy_record_sync` modules, mirroring the new `auth_generate_random`:

```
recorded_bytes=16 replay_matches_record=yes
```

## Honest notes

`auth_core.c` does not host-compile due to a **pre-existing** IKOS-vs-libc `pthread.h` conflict (fails identically on base `main`), unrelated to this change; it is built as part of the kernel. I verified the gate pattern with the link-test above and confirmed `kernel_main.c` parses with no errors referencing the change.

## Related issues

- Closes #192
- Uses the merged #164 (`entropy_record.c`, `entropy_record_sync.c`); sibling of #191; part of the in-kernel integration work (#191-#202)