### PR TITLE
Enable deterministic-preemption recording in the live scheduler (#193)

### DIFF
--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -27,6 +27,7 @@
 #include "../include/checkpoint.h"
 #include "../include/ramdisk.h"
 #include "../include/time_record.h"
+#include "../include/sched_record.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -37,6 +38,9 @@ void show_help(void);
 /* Registers the auth /dev/urandom source with the entropy gate (#192);
  * forward-declared to avoid pulling auth_system.h (and its libc deps) in. */
 extern void auth_entropy_gate_init(void);
+/* Arms deterministic-preemption recording in the live scheduler (#193);
+ * forward-declared to avoid pulling scheduler.h in here. */
+extern void scheduler_preempt_set_mode(sched_rec_mode_t mode);
 void show_statistics(void);
 void show_timer_info(void);
 void show_device_info(void);
@@ -243,6 +247,12 @@ void kernel_init(void) {
                                     CHECKPOINT_STORE_SLOT_SECTORS,
                                     CHECKPOINT_DEFAULT_INTERVAL_TICKS) == CHECKPOINT_OK) {
         kernel_print("Orthogonal persistence armed (checkpoint store ready)\n");
+        /* With the checkpoint engine armed the session is being continuously
+         * checkpointed, so record the scheduler's context-switch decisions for
+         * every epoch (#193). The seam (#162) is OFF by default; turning it to
+         * RECORD lets a later rewind reproduce the exact schedule between
+         * keyframes. REPLAY is armed separately by the replay path. */
+        scheduler_preempt_set_mode(SCHED_REC_RECORD);
     } else {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
     }


### PR DESCRIPTION
## What

Arms the scheduler's deterministic-preemption seam (`sched_record`, #162) in
the live kernel. Until now the seam existed but defaulted to `SCHED_REC_OFF`
and nothing ever switched it on, so context-switch decisions were never
logged and a rewind could not reproduce the exact schedule between keyframes.

## How

In `kernel_init()`, once `checkpoint_persistence_init()` reports the
checkpoint store is armed, call `scheduler_preempt_set_mode(SCHED_REC_RECORD)`.
Rationale: with the checkpoint engine armed the machine is being continuously
checkpointed, i.e. a session is being recorded, so the schedule between
keyframes must be captured to make that session deterministically replayable.

- `kernel/kernel_main.c`:
  - `#include "../include/sched_record.h"` for `sched_rec_mode_t` / `SCHED_REC_RECORD`.
  - `extern void scheduler_preempt_set_mode(sched_rec_mode_t mode);` forward decl (avoids pulling `scheduler.h` in here).
  - `scheduler_preempt_set_mode(SCHED_REC_RECORD);` right after the "persistence armed" message.

REPLAY is intentionally not armed here; the replay path (`replay_engine_sync.c`)
sets REPLAY mode when reconstructing a past moment. When the store is absent
the seam stays OFF, so behavior is unchanged for non-persistent boots.

## Verification

- Freestanding syntax check of `kernel/kernel_main.c` reports no errors
  referencing the change (`sched_record` / `scheduler_preempt` / `SCHED_REC`).
- The per-epoch reset and OFF default from #162 are unchanged, so AC2/AC3
  (no behavior change when OFF, per-epoch clock reset) still hold.

Closes #193