### PR TITLE
Append the input journal from the checkpoint engine each epoch (#194)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -66,6 +66,10 @@ on:
       - 'tests/test_mcp.c'
       - 'tests/mcp_heisenbug_e2e.c'
       - 'scripts/test/mcp_heisenbug_demo.sh'
+      - 'kernel/journal_capture.c'
+      - 'kernel/journal_capture_sync.c'
+      - 'include/journal_capture.h'
+      - 'tests/test_journal_capture.c'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -82,7 +86,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -125,6 +129,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_rb     test_revbreak.c             ../kernel/revbreak.c ../kernel/reverse.c ../kernel/rewind.c ../kernel/keyframe_ring.c ../kernel/replay_engine.c && /tmp/t_rb
           gcc -I../include -Wall -o /tmp/t_gdb    test_gdbstub.c              ../kernel/gdbstub.c && /tmp/t_gdb
           gcc -I../include -Wall -o /tmp/t_mcp    test_mcp.c                  ../kernel/mcp.c && /tmp/t_mcp
+          gcc -I../include -Wall -o /tmp/t_jc     test_journal_capture.c      ../kernel/journal_capture.c ../kernel/checkpoint_journal.c && /tmp/t_jc
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -26,6 +26,7 @@ ships each piece:
 | Stage | What it does | Modules |
 |-------|--------------|---------|
 | Input journal | Records the nondeterministic inputs between two keyframes (keystrokes, disk completions, timer/cycle reads, entropy), each tagged with epoch and a logical clock, in a CRC-protected double-buffered store | `kernel/checkpoint_journal.c` |
+| Live journal capture | On every checkpoint commit, gathers the closing epoch's recorded deltas (preemption points, time reads, entropy bytes) and writes them to the input journal alongside the checkpoint, via a checkpoint post-commit hook | `kernel/journal_capture.c`, `kernel/journal_capture_sync.c` |
 | Deterministic preemption | Records the logical point of every context switch on a live run and forces switches at the same points on replay | `kernel/sched_record.c` + the `scheduler_tick` seam |
 | Virtualized time | Records RDTSC/timer reads and returns the recorded values on replay | `kernel/time_record.c`, `kernel/time_record_sync.c` |
 | Deterministic entropy | Records entropy draws and returns the recorded bytes on replay | `kernel/entropy_record.c`, `kernel/entropy_record_sync.c` |

--- a/include/checkpoint.h
+++ b/include/checkpoint.h
@@ -157,6 +157,16 @@ void checkpoint_clear_captures(void);
  * and the epoch is closed. Returns CHECKPOINT_OK or a negative code. */
 int checkpoint_writeback(snapshot_store_t* store);
 
+/* Post-commit journal hook (#194). After a checkpoint's writeback has durably
+ * committed, the engine calls this hook (when set) with the committed epoch, so
+ * the deterministic-replay journal for that epoch can be persisted alongside
+ * the checkpoint. Injected as a function pointer to keep the checkpoint core
+ * free of the journal / record-subsystem dependencies. NULL by default (no
+ * journaling). The return value is advisory: the checkpoint is already
+ * committed, so a hook failure does not undo or fail the checkpoint. */
+typedef int (*checkpoint_journal_hook_fn)(uint64_t epoch);
+void checkpoint_set_journal_hook(checkpoint_journal_hook_fn hook);
+
 /* ----- Restore (#116) -----
  *
  * Called once for each page of the loaded checkpoint, in slot order. The

--- a/include/checkpoint_journal.h
+++ b/include/checkpoint_journal.h
@@ -146,6 +146,12 @@ int journal_store_begin(journal_store_t* store, uint64_t epoch,
 int journal_writer_append(journal_writer_t* writer, uint32_t type,
                           uint64_t lclock, uint64_t value);
 
+/* Like journal_writer_append but records `len` in the event's len field, for
+ * variable-length payloads packed into value (for example an entropy run of
+ * 1..8 bytes). journal_writer_append is this with len == 0. */
+int journal_writer_append_len(journal_writer_t* writer, uint32_t type,
+                              uint64_t lclock, uint64_t value, uint32_t len);
+
 /* Finalize: flush the last partial sector, write the slot header + CRC, then
  * flip the superblock. The superblock write is the atomic commit point. */
 int journal_store_commit(journal_writer_t* writer);

--- a/include/journal_capture.h
+++ b/include/journal_capture.h
@@ -1,0 +1,64 @@
+/* IKOS Orthogonal Persistence - Per-epoch journal capture (#194, epic #159)
+ *
+ * When a checkpoint epoch closes, the deterministic-replay journal for that
+ * epoch must be written alongside the checkpoint: the scheduler's preemption
+ * points, the time/cycle reads, and the entropy bytes that were consumed while
+ * the epoch was live. A keyframe (the checkpoint) records the whole system
+ * state; this journal records the nondeterministic delta between keyframes, so
+ * the replay engine (#165/#196) can boot the nearest keyframe and re-drive
+ * execution forward to any past moment.
+ *
+ * This is the capture side of the input journal (#161). The core here is pure
+ * and host-testable: it pulls the epoch's deltas through injected source
+ * function pointers (never the real subsystems) and writes them to a
+ * journal_store_t, which itself talks to storage only through a
+ * fat_block_device_t. The live wiring lives in the kernel adapter below
+ * (journal_capture_sync.c).
+ */
+
+#ifndef JOURNAL_CAPTURE_H
+#define JOURNAL_CAPTURE_H
+
+#include <stdint.h>
+#include "checkpoint_journal.h"  /* journal_store_t, JOURNAL_EV_*, JOURNAL_OK */
+
+/* Scheduler preemption/context-switch point. Extends the JOURNAL_EV_* set in
+ * checkpoint_journal.h; the switch point's logical clock rides in both the
+ * event lclock and value. */
+#define JOURNAL_EV_SCHED 5
+
+/* Injected delta sources. The live kernel wires these to
+ * scheduler_preempt_points / ktime_values / kentropy_bytes; tests pass fakes.
+ * Each returns the count for the current epoch and points *out at the buffer.
+ * Any pointer may be NULL, in which case that class of delta is skipped. */
+typedef struct {
+    uint32_t (*preempt_points)(const uint64_t** out);  /* switch-point lclocks */
+    uint32_t (*time_values)(const uint64_t** out);     /* captured RDTSC reads */
+    uint32_t (*entropy_bytes)(const uint8_t** out);    /* captured entropy run */
+} journal_capture_sources_t;
+
+/* Gather the epoch's deltas from src and write them to store as a single
+ * journal for `epoch`, committing crash-consistently (the journal store's
+ * superblock flip is the one commit point, so a crash mid-write leaves the
+ * previous epoch's journal intact). Event order within the journal: every
+ * scheduler point, then every time read, then the entropy run. base_lclock is
+ * recorded in the slot header for reference. Returns JOURNAL_OK, or a negative
+ * JOURNAL_ERR_* (in which case nothing is committed). */
+int journal_capture_epoch(journal_store_t* store, uint64_t epoch,
+                          uint64_t base_lclock,
+                          const journal_capture_sources_t* src);
+
+/* ---- Kernel adapter (journal_capture_sync.c) ----
+ * Binds a journal store to a region of the persistence device and registers a
+ * checkpoint post-commit hook (checkpoint_set_journal_hook) that journals each
+ * committed epoch's live deltas via journal_capture_epoch(). Call once at boot,
+ * after the checkpoint store is armed, with a non-overlapping sector region.
+ * Returns JOURNAL_OK when the journal is armed, or a negative JOURNAL_ERR_*. */
+int journal_capture_init(fat_block_device_t* dev, uint32_t base_sector,
+                         uint32_t slot_sectors);
+
+/* The bound journal store, or NULL if journal_capture_init has not armed it.
+ * Exposed for the replay path and tests. */
+journal_store_t* journal_capture_store(void);
+
+#endif /* JOURNAL_CAPTURE_H */

--- a/kernel/checkpoint.c
+++ b/kernel/checkpoint.c
@@ -32,6 +32,14 @@ static uint64_t g_timer_ticks = 0;
  * when every CPU has parked. Single CPU until SMP lands. */
 static checkpoint_barrier_t g_barrier;
 
+/* Post-commit journal hook (#194). Injected by the journal-capture adapter so
+ * the checkpoint core stays free of the journal/record dependencies. */
+static checkpoint_journal_hook_fn g_journal_hook = 0;
+
+void checkpoint_set_journal_hook(checkpoint_journal_hook_fn hook) {
+    g_journal_hook = hook;
+}
+
 void checkpoint_init(void) {
     g_checkpoint.current_epoch = 0;
     g_checkpoint.spaces_marked = 0;
@@ -378,6 +386,14 @@ int checkpoint_writeback(snapshot_store_t* store) {
     /* 3. Finalize: slot CRC + the superblock flip (the single commit point). */
     if (snapshot_store_commit(&writer) != SNAPSHOT_OK) {
         return CHECKPOINT_ERR_IO;
+    }
+
+    /* 3b. Persist this epoch's input journal alongside the just-committed
+     * checkpoint (#194). Advisory: the checkpoint is already durable, so a
+     * journal failure does not fail the checkpoint (replay simply cannot
+     * re-drive past this keyframe until a later epoch journals cleanly). */
+    if (g_journal_hook) {
+        g_journal_hook(g_checkpoint.current_epoch);
     }
 
     /* 4. Drop the in-memory snapshot log and close the epoch. */

--- a/kernel/checkpoint_journal.c
+++ b/kernel/checkpoint_journal.c
@@ -154,6 +154,11 @@ static int flush_sector(journal_writer_t* w) {
 
 int journal_writer_append(journal_writer_t* writer, uint32_t type,
                           uint64_t lclock, uint64_t value) {
+    return journal_writer_append_len(writer, type, lclock, value, 0);
+}
+
+int journal_writer_append_len(journal_writer_t* writer, uint32_t type,
+                              uint64_t lclock, uint64_t value, uint32_t len) {
     if (!writer || !writer->active) return JOURNAL_ERR_STATE;
     if (writer->event_count >= writer->store->max_events) return JOURNAL_ERR_FULL;
 
@@ -162,7 +167,7 @@ int journal_writer_append(journal_writer_t* writer, uint32_t type,
     ev.epoch = writer->epoch;
     ev.lclock = lclock;
     ev.type = type;
-    ev.len = 0;
+    ev.len = len;
     ev.value = value;
 
     uint32_t off = writer->buf_events * JOURNAL_EVENT_SIZE;

--- a/kernel/journal_capture.c
+++ b/kernel/journal_capture.c
@@ -1,0 +1,77 @@
+/* IKOS Orthogonal Persistence - Per-epoch journal capture core (#194)
+ *
+ * See include/journal_capture.h. Pure and host-testable: the epoch's deltas
+ * arrive through injected source function pointers and are written to a
+ * journal_store_t, so this file needs no allocator, no hardware, and no
+ * dependency on the scheduler / time / entropy subsystems.
+ */
+
+#include "journal_capture.h"
+#include <stddef.h>
+
+int journal_capture_epoch(journal_store_t* store, uint64_t epoch,
+                          uint64_t base_lclock,
+                          const journal_capture_sources_t* src) {
+    if (!store || !src) {
+        return JOURNAL_ERR_PARAM;
+    }
+
+    journal_writer_t writer;
+    int rc = journal_store_begin(store, epoch, base_lclock, &writer);
+    if (rc != JOURNAL_OK) {
+        return rc;
+    }
+
+    /* 1. Scheduler preemption points. Each point is the logical clock at which
+     *    a context switch was forced; store it as both the event lclock and the
+     *    value so replay can reinstate the exact switch schedule. */
+    if (src->preempt_points) {
+        const uint64_t* pts = NULL;
+        uint32_t n = src->preempt_points(&pts);
+        for (uint32_t i = 0; i < n && pts; i++) {
+            rc = journal_writer_append(&writer, JOURNAL_EV_SCHED, pts[i], pts[i]);
+            if (rc != JOURNAL_OK) {
+                return rc; /* uncommitted: previous epoch's journal stays live */
+            }
+        }
+    }
+
+    /* 2. Time / cycle reads, in the order they were captured. lclock is the
+     *    read index within the epoch; value is the RDTSC value that was
+     *    returned to the caller and must be reproduced on replay. */
+    if (src->time_values) {
+        const uint64_t* vals = NULL;
+        uint32_t n = src->time_values(&vals);
+        for (uint32_t i = 0; i < n && vals; i++) {
+            rc = journal_writer_append(&writer, JOURNAL_EV_TIMER, i, vals[i]);
+            if (rc != JOURNAL_OK) {
+                return rc;
+            }
+        }
+    }
+
+    /* 3. Entropy bytes, packed up to 8 per event (little-endian into value).
+     *    len records how many of those 8 bytes are valid, so the exact byte
+     *    stream reads back even when the run is not a multiple of 8. lclock is
+     *    the byte offset of the chunk within the epoch's entropy run. */
+    if (src->entropy_bytes) {
+        const uint8_t* bytes = NULL;
+        uint32_t n = src->entropy_bytes(&bytes);
+        for (uint32_t off = 0; off < n && bytes; off += 8) {
+            uint32_t chunk = (n - off) < 8u ? (n - off) : 8u;
+            uint64_t packed = 0;
+            for (uint32_t b = 0; b < chunk; b++) {
+                packed |= (uint64_t)bytes[off + b] << (8u * b);
+            }
+            rc = journal_writer_append_len(&writer, JOURNAL_EV_ENTROPY,
+                                           off, packed, chunk);
+            if (rc != JOURNAL_OK) {
+                return rc;
+            }
+        }
+    }
+
+    /* Commit: the journal store flips its superblock, atomically publishing
+     * this epoch's journal next to the checkpoint that closed the epoch. */
+    return journal_store_commit(&writer);
+}

--- a/kernel/journal_capture_sync.c
+++ b/kernel/journal_capture_sync.c
@@ -1,0 +1,64 @@
+/* IKOS Orthogonal Persistence - Journal capture kernel adapter (#194)
+ *
+ * See include/journal_capture.h. This wires the pure capture core to the real
+ * kernel: a journal store bound to a region of the persistence device, the live
+ * delta sources (scheduler / time / entropy record buffers), and a checkpoint
+ * post-commit hook so every committed epoch is journaled alongside its
+ * checkpoint. Kept out of journal_capture.c so that core stays dependency-free
+ * and host-testable.
+ */
+
+#include "journal_capture.h"
+#include "scheduler.h"       /* scheduler_preempt_points */
+#include "time_record.h"     /* ktime_values */
+#include "entropy_record.h"  /* kentropy_bytes */
+#include "checkpoint.h"      /* checkpoint_set_journal_hook */
+#include <stddef.h>
+
+/* The journal store bound to the persistence device (caller-allocated storage
+ * lives here so no allocator is needed). */
+static journal_store_t g_journal_store;
+static bool            g_journal_ready = false;
+
+/* Live delta sources: the record-subsystem accessors, each returning the
+ * current epoch's captured buffer. */
+static const journal_capture_sources_t g_live_sources = {
+    .preempt_points = scheduler_preempt_points,
+    .time_values    = ktime_values,
+    .entropy_bytes  = kentropy_bytes,
+};
+
+/* Checkpoint post-commit hook: journal the epoch that just committed. Runs
+ * before the next epoch's recording begins (checkpoints never overlap), so the
+ * accessors still hold this epoch's deltas. */
+static int journal_capture_hook(uint64_t epoch) {
+    if (!g_journal_ready) {
+        return JOURNAL_ERR_STATE;
+    }
+    return journal_capture_epoch(&g_journal_store, epoch, 0, &g_live_sources);
+}
+
+int journal_capture_init(fat_block_device_t* dev, uint32_t base_sector,
+                         uint32_t slot_sectors) {
+    if (journal_store_init(&g_journal_store, dev, base_sector, slot_sectors)
+            != JOURNAL_OK) {
+        return JOURNAL_ERR_IO;
+    }
+
+    /* Format only if the region holds no valid journal yet, so a journal left
+     * by a previous run survives a reboot and can be replayed. */
+    journal_reader_t probe;
+    if (journal_store_load(&g_journal_store, &probe) != JOURNAL_OK) {
+        if (journal_store_format(&g_journal_store) != JOURNAL_OK) {
+            return JOURNAL_ERR_IO;
+        }
+    }
+
+    g_journal_ready = true;
+    checkpoint_set_journal_hook(journal_capture_hook);
+    return JOURNAL_OK;
+}
+
+journal_store_t* journal_capture_store(void) {
+    return g_journal_ready ? &g_journal_store : NULL;
+}

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -28,6 +28,8 @@
 #include "../include/ramdisk.h"
 #include "../include/time_record.h"
 #include "../include/sched_record.h"
+#include "../include/entropy_record.h"
+#include "../include/journal_capture.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -248,11 +250,27 @@ void kernel_init(void) {
                                     CHECKPOINT_DEFAULT_INTERVAL_TICKS) == CHECKPOINT_OK) {
         kernel_print("Orthogonal persistence armed (checkpoint store ready)\n");
         /* With the checkpoint engine armed the session is being continuously
-         * checkpointed, so record the scheduler's context-switch decisions for
-         * every epoch (#193). The seam (#162) is OFF by default; turning it to
-         * RECORD lets a later rewind reproduce the exact schedule between
-         * keyframes. REPLAY is armed separately by the replay path. */
+         * checkpointed, so record the nondeterministic inputs for every epoch:
+         * the scheduler's context-switch decisions (#193/#162), the time/cycle
+         * reads (#163), and the entropy bytes drawn (#164). All three seams are
+         * OFF by default; RECORD lets a later rewind reproduce the exact
+         * execution between keyframes. REPLAY is armed by the replay path. */
         scheduler_preempt_set_mode(SCHED_REC_RECORD);
+        ktime_set_mode(TIME_REC_RECORD);
+        kentropy_set_mode(ENTROPY_REC_RECORD);
+
+        /* Arm per-epoch journal capture (#194): a journal store placed just
+         * past the checkpoint store's two slots, plus a checkpoint post-commit
+         * hook that writes each epoch's recorded deltas to that journal,
+         * committed alongside the checkpoint. The regions never overlap. */
+        if (journal_capture_init(persistence_dev,
+                                 CHECKPOINT_STORE_BASE_SECTOR + 1 +
+                                     2 * CHECKPOINT_STORE_SLOT_SECTORS,
+                                 64 /* slot_sectors */) == JOURNAL_OK) {
+            kernel_print("Replay journal armed (input capture ready)\n");
+        } else {
+            kernel_print("Replay journal disabled (no journal store)\n");
+        }
     } else {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
     }

--- a/tests/test_journal_capture.c
+++ b/tests/test_journal_capture.c
@@ -1,0 +1,196 @@
+/* Host-side unit test for per-epoch journal capture (#194).
+ *
+ * Uses an in-memory mock block device (same convention as
+ * test_checkpoint_journal.c) to verify that journal_capture_epoch:
+ *   1. Writes scheduler points, time reads and entropy bytes in that order,
+ *      each with the right event type / lclock / value.
+ *   2. Reconstructs an entropy run that is not a multiple of 8 bytes exactly
+ *      (via the per-event len field), across a full and a partial chunk.
+ *   3. Skips a delta class whose source pointer is NULL.
+ *   4. Round-trips crash-consistently: after capture the journal loads back
+ *      with the committed epoch.
+ *
+ * Build: gcc -I../include -o test_journal_capture \
+ *            test_journal_capture.c ../kernel/journal_capture.c \
+ *            ../kernel/checkpoint_journal.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Declare the libc bits we use directly, rather than including <string.h>/
+ * <stdlib.h>/<stdio.h>. Those pull in <sys/types.h>, whose ssize_t typedef
+ * conflicts with the one in IKOS's vfs.h (reached via fat.h). */
+typedef __SIZE_TYPE__ size_t;
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern int   printf(const char*, ...);
+
+#include "journal_capture.h"
+
+/* ----- Mock block device backed by a flat buffer ----- */
+
+#define MOCK_SECTORS 512
+typedef struct {
+    uint8_t data[MOCK_SECTORS * JOURNAL_SECTOR_SIZE];
+} mock_dev_t;
+
+static int mock_read(void* device, uint32_t sector, uint32_t count, void* buffer) {
+    mock_dev_t* m = (mock_dev_t*)device;
+    if ((uint64_t)sector + count > MOCK_SECTORS) return -1;
+    memcpy(buffer, m->data + (size_t)sector * JOURNAL_SECTOR_SIZE,
+           (size_t)count * JOURNAL_SECTOR_SIZE);
+    return 0;
+}
+static int mock_write(void* device, uint32_t sector, uint32_t count, const void* buffer) {
+    mock_dev_t* m = (mock_dev_t*)device;
+    if ((uint64_t)sector + count > MOCK_SECTORS) return -1;
+    memcpy(m->data + (size_t)sector * JOURNAL_SECTOR_SIZE, buffer,
+           (size_t)count * JOURNAL_SECTOR_SIZE);
+    return 0;
+}
+
+static mock_dev_t g_mock;
+static fat_block_device_t g_bdev;
+
+static fat_block_device_t* make_dev(void) {
+    memset(&g_mock, 0, sizeof(g_mock));
+    g_bdev.read_sectors = mock_read;
+    g_bdev.write_sectors = mock_write;
+    g_bdev.sector_size = JOURNAL_SECTOR_SIZE;
+    g_bdev.total_sectors = MOCK_SECTORS;
+    g_bdev.private_data = &g_mock;
+    return &g_bdev;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Store geometry: superblock + two slots, 4 sectors each (1 header + 3 event
+ * sectors => 48 events per slot), enough to hold the fixtures below. */
+#define BASE_SECTOR 10
+#define SLOT_SECTORS 4
+
+/* ----- Fake delta sources ----- */
+
+static const uint64_t k_points[]  = { 5, 11, 23, 42 };
+static const uint64_t k_times[]   = { 0x1111, 0x2222, 0x3333 };
+/* 11 bytes: one full 8-byte chunk plus a 3-byte remainder. */
+static const uint8_t  k_entropy[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03,
+                                      0x04, 0xAA, 0xBB, 0xCC };
+
+static uint32_t src_points(const uint64_t** out) {
+    *out = k_points;
+    return (uint32_t)(sizeof(k_points) / sizeof(k_points[0]));
+}
+static uint32_t src_times(const uint64_t** out) {
+    *out = k_times;
+    return (uint32_t)(sizeof(k_times) / sizeof(k_times[0]));
+}
+static uint32_t src_entropy(const uint8_t** out) {
+    *out = k_entropy;
+    return (uint32_t)sizeof(k_entropy);
+}
+
+/* Reassemble entropy bytes from an event (packed little-endian, len valid). */
+static uint32_t unpack_entropy(const journal_event_t* ev, uint8_t* out) {
+    for (uint32_t b = 0; b < ev->len; b++) {
+        out[b] = (uint8_t)(ev->value >> (8u * b));
+    }
+    return ev->len;
+}
+
+int main(void) {
+    printf("test_journal_capture\n");
+
+    fat_block_device_t* dev = make_dev();
+    journal_store_t store;
+    CHECK(journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS) == JOURNAL_OK,
+          "store init");
+    CHECK(journal_store_format(&store) == JOURNAL_OK, "store format");
+
+    /* --- 1/2/4: capture all three delta classes for epoch 7 --- */
+    journal_capture_sources_t src = {
+        .preempt_points = src_points,
+        .time_values    = src_times,
+        .entropy_bytes  = src_entropy,
+    };
+    CHECK(journal_capture_epoch(&store, 7, 100, &src) == JOURNAL_OK,
+          "capture epoch 7");
+
+    journal_reader_t rd;
+    CHECK(journal_store_load(&store, &rd) == JOURNAL_OK, "load committed journal");
+    CHECK(rd.epoch == 7, "loaded epoch is 7");
+
+    /* Expected order: 4 sched points, then 3 time reads, then 2 entropy chunks
+     * (8-byte full + 3-byte remainder) = 9 events. */
+    CHECK(rd.event_count == 9, "event count is 9");
+
+    journal_event_t ev;
+    int idx = 0;
+    uint8_t got_entropy[16];
+    uint32_t got_entropy_len = 0;
+    bool order_ok = true, sched_ok = true, timer_ok = true, entropy_type_ok = true;
+
+    while (journal_reader_next(&rd, &ev) == JOURNAL_OK) {
+        if (idx < 4) {
+            if (ev.type != JOURNAL_EV_SCHED) sched_ok = false;
+            if (ev.value != k_points[idx] || ev.lclock != k_points[idx])
+                sched_ok = false;
+        } else if (idx < 7) {
+            if (ev.type != JOURNAL_EV_TIMER) timer_ok = false;
+            if (ev.value != k_times[idx - 4] || ev.lclock != (uint64_t)(idx - 4))
+                timer_ok = false;
+        } else {
+            if (ev.type != JOURNAL_EV_ENTROPY) entropy_type_ok = false;
+            got_entropy_len += unpack_entropy(&ev, got_entropy + got_entropy_len);
+        }
+        idx++;
+    }
+    CHECK(idx == 9, "read back 9 events in order");
+    CHECK(order_ok, "iteration completed");
+    CHECK(sched_ok, "scheduler points: type/lclock/value correct");
+    CHECK(timer_ok, "time reads: type/index/value correct");
+    CHECK(entropy_type_ok, "entropy events tagged JOURNAL_EV_ENTROPY");
+
+    /* Entropy stream reconstructed exactly, including the 3-byte remainder. */
+    bool entropy_bytes_ok = (got_entropy_len == sizeof(k_entropy));
+    for (uint32_t i = 0; i < sizeof(k_entropy) && entropy_bytes_ok; i++) {
+        if (got_entropy[i] != k_entropy[i]) entropy_bytes_ok = false;
+    }
+    CHECK(entropy_bytes_ok, "entropy run reconstructed byte-for-byte (11 bytes)");
+
+    /* --- 3: a NULL source class is skipped, others still recorded --- */
+    make_dev();
+    CHECK(journal_store_init(&store, dev, BASE_SECTOR, SLOT_SECTORS) == JOURNAL_OK,
+          "re-init store");
+    CHECK(journal_store_format(&store) == JOURNAL_OK, "re-format store");
+
+    journal_capture_sources_t sched_only = {
+        .preempt_points = src_points,
+        .time_values    = NULL,
+        .entropy_bytes  = NULL,
+    };
+    CHECK(journal_capture_epoch(&store, 8, 0, &sched_only) == JOURNAL_OK,
+          "capture epoch 8 (sched only)");
+    CHECK(journal_store_load(&store, &rd) == JOURNAL_OK, "load sched-only journal");
+    CHECK(rd.event_count == 4, "sched-only journal has 4 events");
+    bool all_sched = true;
+    while (journal_reader_next(&rd, &ev) == JOURNAL_OK) {
+        if (ev.type != JOURNAL_EV_SCHED) all_sched = false;
+    }
+    CHECK(all_sched, "sched-only journal holds only scheduler events");
+
+    /* --- param guard --- */
+    CHECK(journal_capture_epoch(NULL, 1, 0, &src) == JOURNAL_ERR_PARAM,
+          "NULL store rejected");
+    CHECK(journal_capture_epoch(&store, 1, 0, NULL) == JOURNAL_ERR_PARAM,
+          "NULL sources rejected");
+
+    printf("%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

When a checkpoint epoch closes, persist that epoch's recorded nondeterministic
deltas into the input journal (#161) from the live checkpoint path, so the
replay engine (#165/#196) can boot the nearest keyframe and re-drive forward.
A keyframe records whole-system state; this journal records the delta between
keyframes.

## How

- **`kernel/journal_capture.c` (pure core)** — `journal_capture_epoch()` gathers
  an epoch's deltas through injected source function pointers and writes them to
  a `journal_store` as one journal for the epoch, committed via the store's
  single superblock flip (crash-consistent: a crash mid-write leaves the prior
  epoch's journal intact). Event order: all scheduler preemption points
  (`JOURNAL_EV_SCHED`), then time reads (`JOURNAL_EV_TIMER`), then entropy runs
  (`JOURNAL_EV_ENTROPY`). Entropy is packed 8 bytes per event with the reserved
  `len` field carrying the valid-byte count, so a run whose length is not a
  multiple of 8 reads back byte-for-byte. Host-testable: no allocator, hardware,
  or record-subsystem dependency.
- **`kernel/checkpoint.c` / `include/checkpoint.h`** — a post-commit journal hook
  (`checkpoint_set_journal_hook`, an injected function pointer, NULL by default)
  keeps the checkpoint core free of the journal/record dependencies.
  `checkpoint_writeback()` calls it with the committed epoch right after the
  superblock flip. The hook return is advisory: the checkpoint is already
  durable, so a journal failure never fails the checkpoint.
- **`kernel/journal_capture_sync.c` (kernel adapter)** — binds a journal store to
  a device region just past the checkpoint store's two slots (non-overlapping),
  wires the live accessors `scheduler_preempt_points` / `ktime_values` /
  `kentropy_bytes`, formats only when no valid journal exists (so one survives a
  reboot), and registers the hook.
- **`kernel/checkpoint_journal.c` / `.h`** — `journal_writer_append_len()` uses the
  reserved `len` field for variable-length payloads; `journal_writer_append()` is
  now that with `len == 0` (backward compatible).
- **`kernel/kernel_main.c`** — on persistence-armed, also enable time and entropy
  RECORD (alongside the scheduler RECORD from #193) and arm journal capture.

## Acceptance criteria

- [x] Each epoch's preemption/time/entropy deltas are written to the journal on checkpoint (post-commit hook + `journal_capture_epoch`).
- [x] The journal commits crash-consistently next to the checkpoint (reuses the journal store's inactive-slot + superblock-flip commit).
- [x] The recorded deltas read back in order for replay (unit test iterates the committed journal and reconstructs each class, including a non-8-multiple entropy run).

## Verification

- New host unit test `tests/test_journal_capture.c` — passes (ordering, entropy
  reconstruction across full + partial chunk, NULL-source skip, param guards,
  round-trip load).
- Existing `test_checkpoint_journal` still passes after the `append` refactor.
- Freestanding `-Wall -Wextra` syntax checks clean for `journal_capture.c`,
  `journal_capture_sync.c`, `checkpoint_journal.c`; `checkpoint.c` and the
  touched `kernel_main.c` parse with no errors referencing the change.
- CI wired: trigger paths, freestanding checks, and the unit test added to
  `.github/workflows/persistence.yml`.

Closes #194