### PR TITLE
Wire the keyframe retention ring into the snapshot store (#195)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -70,6 +70,10 @@ on:
       - 'kernel/journal_capture_sync.c'
       - 'include/journal_capture.h'
       - 'tests/test_journal_capture.c'
+      - 'kernel/keyframe_store.c'
+      - 'kernel/keyframe_store_sync.c'
+      - 'include/keyframe_store.h'
+      - 'tests/test_keyframe_store.c'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -86,7 +90,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -130,6 +134,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_gdb    test_gdbstub.c              ../kernel/gdbstub.c && /tmp/t_gdb
           gcc -I../include -Wall -o /tmp/t_mcp    test_mcp.c                  ../kernel/mcp.c && /tmp/t_mcp
           gcc -I../include -Wall -o /tmp/t_jc     test_journal_capture.c      ../kernel/journal_capture.c ../kernel/checkpoint_journal.c && /tmp/t_jc
+          gcc -I../include -Wall -o /tmp/t_ks     test_keyframe_store.c       ../kernel/keyframe_store.c ../kernel/snapshot_store.c ../kernel/keyframe_ring.c && /tmp/t_ks
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -33,6 +33,7 @@ ships each piece:
 | Replay engine | Restores the nearest keyframe and re-drives forward to a target epoch plus offset | `kernel/replay_engine.c`, `kernel/replay_engine_sync.c` |
 | Divergence detector | Checksums system state per epoch on record and replay, flagging any nondeterminism leak with the epoch and component | `kernel/divergence.c`, `kernel/divergence_sync.c` |
 | Keyframe retention ring | Keeps the last N keyframes so rewind is not limited to the latest | `kernel/keyframe_ring.c` |
+| Keyframe retention store | Spreads checkpoints across N on-disk regions driven by the ring, persists the ring index (rebuilding it from region superblocks if torn), and restores an arbitrary retained keyframe by epoch | `kernel/keyframe_store.c`, `kernel/keyframe_store_sync.c` |
 | Rewind-to | The core verb: nearest keyframe at or before the target, then replay to the target | `kernel/rewind.c`, `kernel/rewind_sync.c` |
 | Reverse execution | reverse-step / reverse-continue as restore-prior-keyframe-and-replay | `kernel/reverse.c`, `kernel/reverse_sync.c` |
 | Reverse breakpoints/watchpoints | Scan backward to the last hit or the last write to a value, bounded by the ring | `kernel/revbreak.c`, `kernel/revbreak_sync.c` |

--- a/include/checkpoint.h
+++ b/include/checkpoint.h
@@ -157,6 +157,18 @@ void checkpoint_clear_captures(void);
  * and the epoch is closed. Returns CHECKPOINT_OK or a negative code. */
 int checkpoint_writeback(snapshot_store_t* store);
 
+/* Stream the current epoch's pages (captured images + still-clean pages) into
+ * an already-open snapshot writer. Shared by checkpoint_writeback and the
+ * keyframe-ring writeback path (#195), which open the writer on a ring-selected
+ * region rather than the two-slot store. Returns CHECKPOINT_OK or a negative
+ * code; does not commit. */
+int checkpoint_stream_pages(snapshot_writer_t* writer);
+
+/* Finish an epoch once its checkpoint has durably committed: run the post-commit
+ * journal hook, drop the in-memory capture log, and close the epoch. Called by
+ * both writeback paths after their respective commit. */
+void checkpoint_after_commit(uint64_t epoch);
+
 /* Post-commit journal hook (#194). After a checkpoint's writeback has durably
  * committed, the engine calls this hook (when set) with the committed epoch, so
  * the deterministic-replay journal for that epoch can be persisted alongside

--- a/include/keyframe_store.h
+++ b/include/keyframe_store.h
@@ -1,0 +1,132 @@
+/* IKOS Orthogonal Persistence - Keyframe retention store (#195, epic #159)
+ *
+ * The snapshot store (snapshot_store.h) keeps two double-buffered slots: the
+ * latest checkpoint and the previous one, which is enough to resume on boot but
+ * not to rewind to any of the last N moments. This layer spreads checkpoints
+ * across N independent store regions, driven by the keyframe retention ring
+ * (#168): each checkpoint claims the ring's next slot and is written into that
+ * region, the ring index is persisted (its CRC-protected pack) so the retained
+ * window survives a reboot, and restore can select any retained keyframe by
+ * epoch rather than only the latest.
+ *
+ * Each region is an ordinary snapshot_store, so all page-record read/write/CRC
+ * and per-region crash-consistency (inactive-slot write + superblock flip) are
+ * reused unchanged. The one added commit point is the ring index: a checkpoint
+ * is folded into the in-memory ring and the index is rewritten only after its
+ * region has durably committed, so a crash mid-write leaves the previously
+ * retained window intact. The index is a cache: if it is torn or absent at
+ * boot, the ring is rebuilt by scanning the region superblocks (each is
+ * self-describing with its epoch), so the retained window is never lost to a
+ * torn index.
+ *
+ * Pure and host-testable: it talks to storage only through a
+ * fat_block_device_t (for the index sectors) and through snapshot_store /
+ * keyframe_ring, and carries its own buffers, so it needs no allocator.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef KEYFRAME_STORE_H
+#define KEYFRAME_STORE_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "fat.h"             /* fat_block_device_t */
+#include "snapshot_store.h"  /* snapshot_store_t, writer/reader */
+#include "keyframe_ring.h"   /* keyframe_ring_t */
+
+/* The packed ring index never exceeds this many sectors (keyframe_ring_pack is
+ * about 1060 bytes => 3 sectors; 4 leaves headroom and bounds the I/O buffer). */
+#define KEYFRAME_STORE_INDEX_MAX_SECTORS 4
+
+/* Error codes (distinct from SNAPSHOT_* / KEYFRAME_RING_*). */
+#define KEYFRAME_STORE_OK            0
+#define KEYFRAME_STORE_ERR_PARAM    -1
+#define KEYFRAME_STORE_ERR_IO       -2
+#define KEYFRAME_STORE_ERR_CRC      -3   /* index/region epoch disagree */
+#define KEYFRAME_STORE_ERR_NO_KEYFRAME -4 /* target predates the retained window */
+#define KEYFRAME_STORE_ERR_STATE    -5
+
+typedef struct {
+    fat_block_device_t* dev;
+    uint32_t base_sector;         /* first index sector */
+    uint32_t index_sectors;       /* sectors reserved for the packed ring index */
+    uint32_t capacity;            /* N retained keyframes */
+    uint32_t region_slot_sectors; /* per-slot sectors inside each region store */
+    uint32_t region_sectors;      /* derived: 1 + 2 * region_slot_sectors */
+    uint32_t kernel_version;      /* stamped into every region store (#139) */
+    keyframe_ring_t ring;         /* in-memory index, persisted to the index sectors */
+    snapshot_store_t region;      /* scratch store, re-pointed per region */
+    bool     initialized;
+} keyframe_store_t;
+
+/* Sectors a keyframe store of `capacity` regions (each region_slot_sectors per
+ * slot) occupies from base_sector, including index_sectors. Callers use this to
+ * lay the store out without overlapping neighbours. */
+uint32_t keyframe_store_total_sectors(uint32_t index_sectors, uint32_t capacity,
+                                      uint32_t region_slot_sectors);
+
+/* Bind a keyframe store to a device region. index_sectors must be at least the
+ * packed-index size (see KEYFRAME_STORE_INDEX_MAX_SECTORS) and no larger than
+ * that bound; capacity is 1..KEYFRAME_RING_MAX; region_slot_sectors sizes each
+ * region's snapshot store (>= 1 + 9 so a page record fits). Writes nothing. */
+int keyframe_store_init(keyframe_store_t* ks, fat_block_device_t* dev,
+                        uint32_t base_sector, uint32_t index_sectors,
+                        uint32_t capacity, uint32_t region_slot_sectors);
+
+/* Stamp every region store with the kernel build version (#139). */
+void keyframe_store_set_version(keyframe_store_t* ks, uint32_t kernel_version);
+
+/* Provision a brand-new store: an empty ring, a formatted (empty) superblock in
+ * every region, and a fresh persisted index. */
+int keyframe_store_format(keyframe_store_t* ks);
+
+/* Reload the retained window at boot. Unpacks the persisted index when it is
+ * intact; otherwise rebuilds the ring by scanning the region superblocks (and
+ * rewrites the index cache). Returns KEYFRAME_STORE_OK, or a negative code. */
+int keyframe_store_load_index(keyframe_store_t* ks);
+
+/* Begin a checkpoint at `epoch`: claim the ring's next region and open a
+ * snapshot writer on it. Add pages with snapshot_writer_add_page, then finish
+ * with keyframe_store_commit. */
+int keyframe_store_begin(keyframe_store_t* ks, uint64_t epoch,
+                         snapshot_writer_t* writer);
+
+/* Commit the checkpoint opened by keyframe_store_begin: durably commit the
+ * region (superblock flip), then fold the epoch into the ring and rewrite the
+ * persisted index. A region-commit failure leaves the ring and index untouched
+ * so the previous window survives. */
+int keyframe_store_commit(keyframe_store_t* ks, snapshot_writer_t* writer,
+                          uint64_t epoch);
+
+/* Open the nearest retained keyframe at or before `target` for reading, filling
+ * *epoch_out (may be NULL) with the epoch actually selected. Returns
+ * KEYFRAME_STORE_ERR_NO_KEYFRAME when target predates the retained window. */
+int keyframe_store_load_epoch(keyframe_store_t* ks, uint64_t target,
+                              snapshot_reader_t* reader, uint64_t* epoch_out);
+
+/* Open the newest retained keyframe (boot resume). */
+int keyframe_store_load_latest(keyframe_store_t* ks, snapshot_reader_t* reader,
+                               uint64_t* epoch_out);
+
+/* The in-memory ring index (retained epochs, horizon), for logging and tests. */
+const keyframe_ring_t* keyframe_store_ring(const keyframe_store_t* ks);
+
+/* ---- Kernel adapter (keyframe_store_sync.c) ----
+ * Binds a process-wide keyframe store to a device region and reloads (or
+ * formats) its retained window. Call once at boot with a non-overlapping
+ * region. */
+int keyframe_store_arm(fat_block_device_t* dev, uint32_t base_sector,
+                       uint32_t index_sectors, uint32_t capacity,
+                       uint32_t region_slot_sectors);
+
+/* The armed keyframe store, or NULL if keyframe_store_arm has not run. */
+keyframe_store_t* keyframe_store_get(void);
+
+/* Run a full checkpoint writeback through the retention ring: claim the next
+ * region, stream the current epoch's pages into it, commit the region, and
+ * republish the ring index. Returns CHECKPOINT_OK or a negative CHECKPOINT_ERR_*
+ * (see checkpoint.h). */
+int checkpoint_writeback_keyframe(void);
+
+#endif /* KEYFRAME_STORE_H */

--- a/kernel/checkpoint.c
+++ b/kernel/checkpoint.c
@@ -359,6 +359,37 @@ static int writeback_clean_pages(snapshot_writer_t* writer) {
     return CHECKPOINT_OK;
 }
 
+int checkpoint_stream_pages(snapshot_writer_t* writer) {
+    if (!writer) {
+        return CHECKPOINT_ERR_PARAM;
+    }
+
+    /* 1. Modified pages: the captured pre-checkpoint images. */
+    for (checkpoint_capture_t* c = g_captures; c; c = c->next) {
+        if (snapshot_writer_add_page(writer, c->pid, c->virt_addr, c->flags,
+                                     c->data) != SNAPSHOT_OK) {
+            return CHECKPOINT_ERR_IO;
+        }
+    }
+
+    /* 2. Still-clean pages: live content (== checkpoint-time content). */
+    return writeback_clean_pages(writer);
+}
+
+void checkpoint_after_commit(uint64_t epoch) {
+    /* Persist this epoch's input journal alongside the just-committed
+     * checkpoint (#194). Advisory: the checkpoint is already durable, so a
+     * journal failure does not fail the checkpoint (replay simply cannot
+     * re-drive past this keyframe until a later epoch journals cleanly). */
+    if (g_journal_hook) {
+        g_journal_hook(epoch);
+    }
+
+    /* Drop the in-memory snapshot log and close the epoch. */
+    checkpoint_clear_captures();
+    g_checkpoint.epoch_open = false;
+}
+
 int checkpoint_writeback(snapshot_store_t* store) {
     if (!store) {
         return CHECKPOINT_ERR_PARAM;
@@ -369,36 +400,17 @@ int checkpoint_writeback(snapshot_store_t* store) {
         return CHECKPOINT_ERR_IO;
     }
 
-    /* 1. Modified pages: the captured pre-checkpoint images. */
-    for (checkpoint_capture_t* c = g_captures; c; c = c->next) {
-        if (snapshot_writer_add_page(&writer, c->pid, c->virt_addr, c->flags,
-                                     c->data) != SNAPSHOT_OK) {
-            return CHECKPOINT_ERR_IO;
-        }
-    }
-
-    /* 2. Still-clean pages: live content (== checkpoint-time content). */
-    int rc = writeback_clean_pages(&writer);
+    int rc = checkpoint_stream_pages(&writer);
     if (rc != CHECKPOINT_OK) {
         return rc;
     }
 
-    /* 3. Finalize: slot CRC + the superblock flip (the single commit point). */
+    /* Finalize: slot CRC + the superblock flip (the single commit point). */
     if (snapshot_store_commit(&writer) != SNAPSHOT_OK) {
         return CHECKPOINT_ERR_IO;
     }
 
-    /* 3b. Persist this epoch's input journal alongside the just-committed
-     * checkpoint (#194). Advisory: the checkpoint is already durable, so a
-     * journal failure does not fail the checkpoint (replay simply cannot
-     * re-drive past this keyframe until a later epoch journals cleanly). */
-    if (g_journal_hook) {
-        g_journal_hook(g_checkpoint.current_epoch);
-    }
-
-    /* 4. Drop the in-memory snapshot log and close the epoch. */
-    checkpoint_clear_captures();
-    g_checkpoint.epoch_open = false;
+    checkpoint_after_commit(g_checkpoint.current_epoch);
     return CHECKPOINT_OK;
 }
 

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -30,6 +30,7 @@
 #include "../include/sched_record.h"
 #include "../include/entropy_record.h"
 #include "../include/journal_capture.h"
+#include "../include/keyframe_store.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -270,6 +271,22 @@ void kernel_init(void) {
             kernel_print("Replay journal armed (input capture ready)\n");
         } else {
             kernel_print("Replay journal disabled (no journal store)\n");
+        }
+
+        /* Arm the keyframe retention store (#195): keep the last N checkpoints
+         * across N regions (driven by the retention ring), placed on the device
+         * past the checkpoint store and the journal so nothing overlaps. This
+         * lets a rewind restore any of the last N moments, not only the latest;
+         * the ring index is persisted so the retained window survives a reboot. */
+        uint32_t keyframe_base = CHECKPOINT_STORE_BASE_SECTOR
+                               + 1 + 2 * CHECKPOINT_STORE_SLOT_SECTORS /* checkpoint store */
+                               + 1 + 2 * 64;                           /* journal store */
+        if (keyframe_store_arm(persistence_dev, keyframe_base,
+                               3 /* index sectors */, 8 /* retained keyframes */,
+                               64 /* region slot sectors */) == KEYFRAME_STORE_OK) {
+            kernel_print("Keyframe retention armed (last N checkpoints retained)\n");
+        } else {
+            kernel_print("Keyframe retention disabled (no keyframe store)\n");
         }
     } else {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");

--- a/kernel/keyframe_store.c
+++ b/kernel/keyframe_store.c
@@ -1,0 +1,222 @@
+/* IKOS Orthogonal Persistence - Keyframe retention store core (#195)
+ *
+ * See include/keyframe_store.h. Pure and host-testable: reuses snapshot_store
+ * for the per-region page data and keyframe_ring for the index; the only extra
+ * commit point is the persisted ring index. No allocator, no hardware.
+ */
+
+#include "keyframe_store.h"
+#include <stddef.h>
+
+/* Freestanding helper provided by the kernel. */
+extern void* memset(void* dest, int value, size_t size);
+
+/* ---- Sector I/O for the index ---- */
+
+static int idx_read(keyframe_store_t* ks, uint32_t sector, void* buf) {
+    fat_block_device_t* d = ks->dev;
+    if (!d || !d->read_sectors) return KEYFRAME_STORE_ERR_IO;
+    return d->read_sectors(d->private_data, sector, 1, buf) == 0
+               ? KEYFRAME_STORE_OK : KEYFRAME_STORE_ERR_IO;
+}
+
+static int idx_write(keyframe_store_t* ks, uint32_t sector, const void* buf) {
+    fat_block_device_t* d = ks->dev;
+    if (!d || !d->write_sectors) return KEYFRAME_STORE_ERR_IO;
+    return d->write_sectors(d->private_data, sector, 1, buf) == 0
+               ? KEYFRAME_STORE_OK : KEYFRAME_STORE_ERR_IO;
+}
+
+/* First sector of region `slot`, past the index. */
+static uint32_t region_base(const keyframe_store_t* ks, uint32_t slot) {
+    return ks->base_sector + ks->index_sectors + slot * ks->region_sectors;
+}
+
+/* Re-point the scratch snapshot store at region `slot`. */
+static int region_open(keyframe_store_t* ks, uint32_t slot) {
+    if (snapshot_store_init(&ks->region, ks->dev, region_base(ks, slot),
+                            ks->region_slot_sectors) != SNAPSHOT_OK) {
+        return KEYFRAME_STORE_ERR_PARAM;
+    }
+    snapshot_store_set_version(&ks->region, ks->kernel_version);
+    return KEYFRAME_STORE_OK;
+}
+
+/* ---- Persisted index (a cache; the regions are the source of truth) ---- */
+
+static int write_index(keyframe_store_t* ks) {
+    uint8_t buf[KEYFRAME_STORE_INDEX_MAX_SECTORS * SNAPSHOT_SECTOR_SIZE];
+    memset(buf, 0, sizeof(buf));
+    if (keyframe_ring_pack(&ks->ring, buf, sizeof(buf)) < 0) {
+        return KEYFRAME_STORE_ERR_PARAM;
+    }
+    for (uint32_t i = 0; i < ks->index_sectors; i++) {
+        int rc = idx_write(ks, ks->base_sector + i, buf + i * SNAPSHOT_SECTOR_SIZE);
+        if (rc != KEYFRAME_STORE_OK) return rc;
+    }
+    return KEYFRAME_STORE_OK;
+}
+
+/* Try to reload the persisted index. KEYFRAME_STORE_OK if it unpacks and its
+ * capacity matches this store's geometry; otherwise a negative code so the
+ * caller falls back to a rebuild. */
+static int read_index(keyframe_store_t* ks) {
+    uint8_t buf[KEYFRAME_STORE_INDEX_MAX_SECTORS * SNAPSHOT_SECTOR_SIZE];
+    memset(buf, 0, sizeof(buf));
+    for (uint32_t i = 0; i < ks->index_sectors; i++) {
+        int rc = idx_read(ks, ks->base_sector + i, buf + i * SNAPSHOT_SECTOR_SIZE);
+        if (rc != KEYFRAME_STORE_OK) return rc;
+    }
+    keyframe_ring_t tmp;
+    if (keyframe_ring_unpack(&tmp, buf, sizeof(buf)) != KEYFRAME_RING_OK) {
+        return KEYFRAME_STORE_ERR_CRC;
+    }
+    if (tmp.capacity != ks->capacity) {
+        return KEYFRAME_STORE_ERR_PARAM; /* geometry changed: rebuild instead */
+    }
+    ks->ring = tmp;
+    return KEYFRAME_STORE_OK;
+}
+
+/* Rebuild the ring by probing each region's superblock (self-describing with
+ * its epoch), then persist the rebuilt cache. */
+static int rebuild_ring(keyframe_store_t* ks) {
+    keyframe_ring_init(&ks->ring, ks->capacity);
+
+    uint32_t first_empty = ks->capacity; /* none */
+    bool have_empty = false;
+    uint64_t oldest = 0;
+    uint32_t oldest_slot = 0;
+    bool any = false;
+
+    for (uint32_t i = 0; i < ks->capacity; i++) {
+        if (region_open(ks, i) != KEYFRAME_STORE_OK) return KEYFRAME_STORE_ERR_IO;
+        snapshot_reader_t rd;
+        if (snapshot_store_load(&ks->region, &rd) == SNAPSHOT_OK) {
+            ks->ring.slots[i].epoch = rd.epoch;
+            ks->ring.slots[i].valid = 1;
+            ks->ring.count++;
+            if (!any || rd.epoch < oldest) { oldest = rd.epoch; oldest_slot = i; any = true; }
+        } else if (!have_empty) {
+            first_empty = i;
+            have_empty = true;
+        }
+    }
+
+    /* Next region to claim: the first empty slot, or (when full) the one holding
+     * the oldest epoch, matching the ring's evict-oldest order. */
+    ks->ring.head = have_empty ? first_empty : (any ? oldest_slot : 0);
+    return write_index(ks);
+}
+
+/* ---- Public API ---- */
+
+uint32_t keyframe_store_total_sectors(uint32_t index_sectors, uint32_t capacity,
+                                      uint32_t region_slot_sectors) {
+    uint32_t region_sectors = 1 + 2 * region_slot_sectors;
+    return index_sectors + capacity * region_sectors;
+}
+
+int keyframe_store_init(keyframe_store_t* ks, fat_block_device_t* dev,
+                        uint32_t base_sector, uint32_t index_sectors,
+                        uint32_t capacity, uint32_t region_slot_sectors) {
+    if (!ks || !dev) return KEYFRAME_STORE_ERR_PARAM;
+    if (capacity == 0 || capacity > KEYFRAME_RING_MAX) return KEYFRAME_STORE_ERR_PARAM;
+    if (region_slot_sectors < SNAPSHOT_SECTORS_PER_RECORD + 1) {
+        return KEYFRAME_STORE_ERR_PARAM; /* need room for the header + a record */
+    }
+    /* The index must hold the packed ring and stay within the I/O buffer bound. */
+    uint32_t need = (keyframe_ring_packed_size() + SNAPSHOT_SECTOR_SIZE - 1)
+                    / SNAPSHOT_SECTOR_SIZE;
+    if (index_sectors < need || index_sectors > KEYFRAME_STORE_INDEX_MAX_SECTORS) {
+        return KEYFRAME_STORE_ERR_PARAM;
+    }
+
+    memset(ks, 0, sizeof(*ks));
+    ks->dev = dev;
+    ks->base_sector = base_sector;
+    ks->index_sectors = index_sectors;
+    ks->capacity = capacity;
+    ks->region_slot_sectors = region_slot_sectors;
+    ks->region_sectors = 1 + 2 * region_slot_sectors;
+    ks->kernel_version = 0;
+    keyframe_ring_init(&ks->ring, capacity);
+    ks->initialized = true;
+    return KEYFRAME_STORE_OK;
+}
+
+void keyframe_store_set_version(keyframe_store_t* ks, uint32_t kernel_version) {
+    if (ks) ks->kernel_version = kernel_version;
+}
+
+int keyframe_store_format(keyframe_store_t* ks) {
+    if (!ks || !ks->initialized) return KEYFRAME_STORE_ERR_STATE;
+    keyframe_ring_init(&ks->ring, ks->capacity);
+    for (uint32_t i = 0; i < ks->capacity; i++) {
+        if (region_open(ks, i) != KEYFRAME_STORE_OK) return KEYFRAME_STORE_ERR_IO;
+        if (snapshot_store_format(&ks->region) != SNAPSHOT_OK) return KEYFRAME_STORE_ERR_IO;
+    }
+    return write_index(ks);
+}
+
+int keyframe_store_load_index(keyframe_store_t* ks) {
+    if (!ks || !ks->initialized) return KEYFRAME_STORE_ERR_STATE;
+    if (read_index(ks) == KEYFRAME_STORE_OK) return KEYFRAME_STORE_OK;
+    return rebuild_ring(ks);
+}
+
+int keyframe_store_begin(keyframe_store_t* ks, uint64_t epoch,
+                         snapshot_writer_t* writer) {
+    if (!ks || !ks->initialized || !writer) return KEYFRAME_STORE_ERR_PARAM;
+    /* Peek the slot the next advance will claim; do not mutate the ring until
+     * the region has committed (so a failed write keeps the old window). */
+    uint32_t slot = ks->ring.head;
+    if (region_open(ks, slot) != KEYFRAME_STORE_OK) return KEYFRAME_STORE_ERR_PARAM;
+    if (snapshot_store_begin(&ks->region, epoch, writer) != SNAPSHOT_OK) {
+        return KEYFRAME_STORE_ERR_IO;
+    }
+    return KEYFRAME_STORE_OK;
+}
+
+int keyframe_store_commit(keyframe_store_t* ks, snapshot_writer_t* writer,
+                          uint64_t epoch) {
+    if (!ks || !ks->initialized || !writer) return KEYFRAME_STORE_ERR_PARAM;
+    if (snapshot_store_commit(writer) != SNAPSHOT_OK) {
+        return KEYFRAME_STORE_ERR_IO; /* ring/index untouched: old window survives */
+    }
+    /* Region durably committed: fold the epoch into the ring (claims ring.head,
+     * the region we just wrote) and republish the index. */
+    keyframe_ring_advance(&ks->ring, epoch);
+    return write_index(ks);
+}
+
+int keyframe_store_load_epoch(keyframe_store_t* ks, uint64_t target,
+                              snapshot_reader_t* reader, uint64_t* epoch_out) {
+    if (!ks || !ks->initialized || !reader) return KEYFRAME_STORE_ERR_PARAM;
+    uint32_t slot = 0;
+    uint64_t e = 0;
+    if (!keyframe_ring_find(&ks->ring, target, &slot, &e)) {
+        return KEYFRAME_STORE_ERR_NO_KEYFRAME;
+    }
+    if (region_open(ks, slot) != KEYFRAME_STORE_OK) return KEYFRAME_STORE_ERR_PARAM;
+    if (snapshot_store_load(&ks->region, reader) != SNAPSHOT_OK) {
+        return KEYFRAME_STORE_ERR_IO;
+    }
+    if (reader->epoch != e) return KEYFRAME_STORE_ERR_CRC; /* index/region disagree */
+    if (epoch_out) *epoch_out = e;
+    return KEYFRAME_STORE_OK;
+}
+
+int keyframe_store_load_latest(keyframe_store_t* ks, snapshot_reader_t* reader,
+                               uint64_t* epoch_out) {
+    if (!ks || !ks->initialized || !reader) return KEYFRAME_STORE_ERR_PARAM;
+    uint64_t newest = 0;
+    if (!keyframe_ring_newest(&ks->ring, &newest)) {
+        return KEYFRAME_STORE_ERR_NO_KEYFRAME;
+    }
+    return keyframe_store_load_epoch(ks, newest, reader, epoch_out);
+}
+
+const keyframe_ring_t* keyframe_store_ring(const keyframe_store_t* ks) {
+    return ks ? &ks->ring : NULL;
+}

--- a/kernel/keyframe_store_sync.c
+++ b/kernel/keyframe_store_sync.c
@@ -1,0 +1,67 @@
+/* IKOS Orthogonal Persistence - Keyframe store kernel adapter (#195)
+ *
+ * See include/keyframe_store.h. Binds a keyframe retention store to a region of
+ * the persistence device and drives a full checkpoint writeback through the
+ * ring: claim the next region, stream the epoch's pages into it (reusing the
+ * checkpoint engine's page walk), commit the region, and republish the ring
+ * index. Kept out of keyframe_store.c so that core stays dependency-free and
+ * host-testable.
+ */
+
+#include "keyframe_store.h"
+#include "checkpoint.h"   /* checkpoint_current_epoch, stream_pages, after_commit */
+#include <stddef.h>
+
+/* Caller-allocated storage lives here so no allocator is needed. */
+static keyframe_store_t g_keyframe_store;
+static bool             g_keyframe_ready = false;
+
+int keyframe_store_arm(fat_block_device_t* dev, uint32_t base_sector,
+                       uint32_t index_sectors, uint32_t capacity,
+                       uint32_t region_slot_sectors) {
+    if (keyframe_store_init(&g_keyframe_store, dev, base_sector, index_sectors,
+                            capacity, region_slot_sectors) != KEYFRAME_STORE_OK) {
+        return KEYFRAME_STORE_ERR_PARAM;
+    }
+    /* Reload the retained window if one is present; otherwise provision a fresh
+     * store. keyframe_store_load_index reads the persisted index (rebuilding
+     * from region superblocks if it is torn). A brand-new device has neither,
+     * so format when the reload comes back empty. */
+    if (keyframe_store_load_index(&g_keyframe_store) != KEYFRAME_STORE_OK ||
+        keyframe_ring_count(keyframe_store_ring(&g_keyframe_store)) == 0) {
+        if (keyframe_store_format(&g_keyframe_store) != KEYFRAME_STORE_OK) {
+            return KEYFRAME_STORE_ERR_IO;
+        }
+    }
+    g_keyframe_ready = true;
+    return KEYFRAME_STORE_OK;
+}
+
+keyframe_store_t* keyframe_store_get(void) {
+    return g_keyframe_ready ? &g_keyframe_store : NULL;
+}
+
+int checkpoint_writeback_keyframe(void) {
+    if (!g_keyframe_ready) return CHECKPOINT_ERR_PARAM;
+
+    uint64_t epoch = checkpoint_current_epoch();
+
+    snapshot_writer_t writer;
+    if (keyframe_store_begin(&g_keyframe_store, epoch, &writer) != KEYFRAME_STORE_OK) {
+        return CHECKPOINT_ERR_IO;
+    }
+
+    int rc = checkpoint_stream_pages(&writer);
+    if (rc != CHECKPOINT_OK) {
+        return rc; /* writer un-committed: the retained window is untouched */
+    }
+
+    if (keyframe_store_commit(&g_keyframe_store, &writer, epoch) != KEYFRAME_STORE_OK) {
+        return CHECKPOINT_ERR_IO;
+    }
+
+    /* Region committed and the ring index republished: finish the epoch
+     * (journal hook + drop captures + close). */
+    checkpoint_after_commit(epoch);
+    return CHECKPOINT_OK;
+}

--- a/tests/test_keyframe_store.c
+++ b/tests/test_keyframe_store.c
@@ -1,0 +1,201 @@
+/* Host-side unit test for the keyframe retention store (#195).
+ *
+ * Uses an in-memory mock block device to verify the three acceptance criteria:
+ *   1. Checkpoints write across N store regions per the ring (retain the last N,
+ *      evicting the oldest), each region loadable with its own epoch.
+ *   2. The ring index is persisted and reloaded on boot (a fresh store bound to
+ *      the same device sees the same retained window), including a rebuild from
+ *      the region superblocks when the persisted index is torn.
+ *   3. Restore can select an arbitrary retained keyframe by epoch, and a target
+ *      before the horizon is rejected.
+ *
+ * Build: gcc -I../include -o test_keyframe_store \
+ *            test_keyframe_store.c ../kernel/keyframe_store.c \
+ *            ../kernel/snapshot_store.c ../kernel/keyframe_ring.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Declare the libc bits we use directly, rather than including <string.h> etc.,
+ * whose <sys/types.h> ssize_t collides with IKOS's vfs.h (reached via fat.h). */
+typedef __SIZE_TYPE__ size_t;
+extern void* memcpy(void*, const void*, size_t);
+extern void* memset(void*, int, size_t);
+extern void* malloc(size_t);
+extern void  free(void*);
+extern int   printf(const char*, ...);
+
+/* snapshot_store.c calls these as freestanding kernel helpers; map to libc. */
+void* kmalloc(size_t size) { return malloc(size); }
+void  kfree(void* ptr) { free(ptr); }
+
+#include "keyframe_store.h"
+
+/* ----- Mock block device backed by a flat buffer ----- */
+
+#define MOCK_SECTORS 4096
+typedef struct {
+    uint8_t data[MOCK_SECTORS * SNAPSHOT_SECTOR_SIZE];
+} mock_dev_t;
+
+static int mock_read(void* device, uint32_t sector, uint32_t count, void* buffer) {
+    mock_dev_t* m = (mock_dev_t*)device;
+    if ((uint64_t)sector + count > MOCK_SECTORS) return -1;
+    memcpy(buffer, m->data + (size_t)sector * SNAPSHOT_SECTOR_SIZE,
+           (size_t)count * SNAPSHOT_SECTOR_SIZE);
+    return 0;
+}
+static int mock_write(void* device, uint32_t sector, uint32_t count, const void* buffer) {
+    mock_dev_t* m = (mock_dev_t*)device;
+    if ((uint64_t)sector + count > MOCK_SECTORS) return -1;
+    memcpy(m->data + (size_t)sector * SNAPSHOT_SECTOR_SIZE, buffer,
+           (size_t)count * SNAPSHOT_SECTOR_SIZE);
+    return 0;
+}
+
+static mock_dev_t g_mock;
+static fat_block_device_t g_bdev;
+
+static fat_block_device_t* make_dev(void) {
+    memset(&g_mock, 0, sizeof(g_mock));
+    g_bdev.read_sectors = mock_read;
+    g_bdev.write_sectors = mock_write;
+    g_bdev.sector_size = SNAPSHOT_SECTOR_SIZE;
+    g_bdev.total_sectors = MOCK_SECTORS;
+    g_bdev.private_data = &g_mock;
+    return &g_bdev;
+}
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Store geometry: a 3-sector index plus N regions, each a snapshot store of
+ * 2 slots of 10 sectors (1 header + one 9-sector page record). */
+#define BASE_SECTOR   20
+#define INDEX_SECTORS 3
+#define CAPACITY      4
+#define REGION_SLOT   10
+
+/* Write one checkpoint holding a single page whose first bytes encode `epoch`,
+ * so a later load can prove it read back the right keyframe. */
+static int put_checkpoint(keyframe_store_t* ks, uint64_t epoch) {
+    static uint8_t page[SNAPSHOT_PAGE_SIZE];
+    memset(page, 0, sizeof(page));
+    memcpy(page, &epoch, sizeof(epoch));
+
+    snapshot_writer_t w;
+    if (keyframe_store_begin(ks, epoch, &w) != KEYFRAME_STORE_OK) return -1;
+    if (snapshot_writer_add_page(&w, 1 /*pid*/, 0x1000, 0, page) != SNAPSHOT_OK) return -1;
+    return keyframe_store_commit(ks, &w, epoch);
+}
+
+/* Load the keyframe nearest to `target` and return the epoch tag stored in its
+ * page, or 0 on failure. Also asserts the reader's epoch matches selected. */
+static uint64_t get_checkpoint_tag(keyframe_store_t* ks, uint64_t target,
+                                   uint64_t* selected_out) {
+    static uint8_t page[SNAPSHOT_PAGE_SIZE];
+    snapshot_reader_t rd;
+    uint64_t selected = 0;
+    if (keyframe_store_load_epoch(ks, target, &rd, &selected) != KEYFRAME_STORE_OK) {
+        return 0;
+    }
+    if (selected_out) *selected_out = selected;
+    snapshot_page_record_t rec;
+    rec.page_data = page;
+    if (snapshot_reader_next(&rd, &rec) != SNAPSHOT_OK) return 0;
+    uint64_t tag = 0;
+    memcpy(&tag, page, sizeof(tag));
+    return tag;
+}
+
+int main(void) {
+    printf("test_keyframe_store\n");
+
+    fat_block_device_t* dev = make_dev();
+    keyframe_store_t ks;
+    CHECK(keyframe_store_init(&ks, dev, BASE_SECTOR, INDEX_SECTORS, CAPACITY,
+                              REGION_SLOT) == KEYFRAME_STORE_OK, "store init");
+    CHECK(keyframe_store_format(&ks) == KEYFRAME_STORE_OK, "store format");
+
+    /* --- AC1: write more checkpoints than the ring holds (epochs 1..6) --- */
+    for (uint64_t e = 1; e <= 6; e++) {
+        CHECK(put_checkpoint(&ks, e) == KEYFRAME_STORE_OK, "checkpoint written");
+    }
+    const keyframe_ring_t* ring = keyframe_store_ring(&ks);
+    CHECK(keyframe_ring_count(ring) == CAPACITY, "ring retains exactly N=4");
+    uint64_t oldest = 0, newest = 0;
+    keyframe_ring_oldest(ring, &oldest);
+    keyframe_ring_newest(ring, &newest);
+    CHECK(oldest == 3 && newest == 6, "retained window is epochs 3..6");
+
+    /* --- AC3: select arbitrary retained keyframes by epoch --- */
+    uint64_t sel = 0;
+    CHECK(get_checkpoint_tag(&ks, 5, &sel) == 5 && sel == 5,
+          "exact select: epoch 5 reads back epoch 5's page");
+    CHECK(get_checkpoint_tag(&ks, 4, &sel) == 4 && sel == 4,
+          "exact select: epoch 4");
+    /* A target between keyframes picks the nearest at or before it. */
+    CHECK(get_checkpoint_tag(&ks, 100, &sel) == 6 && sel == 6,
+          "future target selects newest (epoch 6)");
+    /* A target before the horizon (epochs 1,2 were evicted) is rejected. */
+    snapshot_reader_t rd;
+    CHECK(keyframe_store_load_epoch(&ks, 2, &rd, NULL)
+              == KEYFRAME_STORE_ERR_NO_KEYFRAME, "pre-horizon target rejected");
+
+    /* --- AC2: index persists and reloads on a fresh store over same device --- */
+    keyframe_store_t ks2;
+    CHECK(keyframe_store_init(&ks2, dev, BASE_SECTOR, INDEX_SECTORS, CAPACITY,
+                              REGION_SLOT) == KEYFRAME_STORE_OK, "reopen init");
+    CHECK(keyframe_store_load_index(&ks2) == KEYFRAME_STORE_OK, "reload index");
+    const keyframe_ring_t* ring2 = keyframe_store_ring(&ks2);
+    CHECK(keyframe_ring_count(ring2) == CAPACITY, "reloaded window still N=4");
+    keyframe_ring_oldest(ring2, &oldest);
+    keyframe_ring_newest(ring2, &newest);
+    CHECK(oldest == 3 && newest == 6, "reloaded window is epochs 3..6");
+    CHECK(get_checkpoint_tag(&ks2, 5, NULL) == 5,
+          "reloaded store selects epoch 5 correctly");
+    /* Appending on the reloaded store keeps rolling the window forward. */
+    CHECK(put_checkpoint(&ks2, 7) == KEYFRAME_STORE_OK, "append epoch 7 after reload");
+    keyframe_ring_oldest(keyframe_store_ring(&ks2), &oldest);
+    keyframe_ring_newest(keyframe_store_ring(&ks2), &newest);
+    CHECK(oldest == 4 && newest == 7, "window rolled to epochs 4..7");
+
+    /* --- AC2 (robustness): torn index rebuilds from region superblocks --- */
+    /* Corrupt the persisted index sectors, then reopen: load_index must fall
+     * back to scanning regions and recover the same retained window. */
+    memset(g_mock.data + (size_t)BASE_SECTOR * SNAPSHOT_SECTOR_SIZE, 0xFF,
+           (size_t)INDEX_SECTORS * SNAPSHOT_SECTOR_SIZE);
+    keyframe_store_t ks3;
+    CHECK(keyframe_store_init(&ks3, dev, BASE_SECTOR, INDEX_SECTORS, CAPACITY,
+                              REGION_SLOT) == KEYFRAME_STORE_OK, "reopen for rebuild");
+    CHECK(keyframe_store_load_index(&ks3) == KEYFRAME_STORE_OK,
+          "load_index rebuilds from regions");
+    const keyframe_ring_t* ring3 = keyframe_store_ring(&ks3);
+    CHECK(keyframe_ring_count(ring3) == CAPACITY, "rebuilt window has N=4");
+    keyframe_ring_oldest(ring3, &oldest);
+    keyframe_ring_newest(ring3, &newest);
+    CHECK(oldest == 4 && newest == 7, "rebuilt window is epochs 4..7");
+    CHECK(get_checkpoint_tag(&ks3, 6, NULL) == 6,
+          "rebuilt store selects epoch 6 correctly");
+    /* After a rebuild the next checkpoint must evict the oldest (epoch 4). */
+    CHECK(put_checkpoint(&ks3, 8) == KEYFRAME_STORE_OK, "append epoch 8 after rebuild");
+    keyframe_ring_oldest(keyframe_store_ring(&ks3), &oldest);
+    keyframe_ring_newest(keyframe_store_ring(&ks3), &newest);
+    CHECK(oldest == 5 && newest == 8, "post-rebuild window rolled to epochs 5..8");
+
+    /* --- param guards --- */
+    CHECK(keyframe_store_init(&ks, dev, BASE_SECTOR, 1 /*too small*/, CAPACITY,
+                              REGION_SLOT) == KEYFRAME_STORE_ERR_PARAM,
+          "undersized index rejected");
+    CHECK(keyframe_store_init(&ks, dev, BASE_SECTOR, INDEX_SECTORS, 0 /*bad N*/,
+                              REGION_SLOT) == KEYFRAME_STORE_ERR_PARAM,
+          "zero capacity rejected");
+
+    printf("%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Make the snapshot store keep the last N checkpoints instead of only its two
double-buffered slots, driven by the keyframe retention ring (#168), so a rewind
can restore any of the last N moments rather than only the latest.

## How

- **`kernel/keyframe_store.c` / `include/keyframe_store.h` (pure core)** — a retention
  store layered over `snapshot_store` and `keyframe_ring`:
  - **N regions.** Each retained keyframe lives in its own region, an ordinary
    `snapshot_store`, so all page-record read/write/CRC and per-region
    crash-consistency (inactive-slot write + superblock flip) are reused
    unchanged.
  - **Ring-driven.** A checkpoint claims the ring's next region
    (`keyframe_store_begin` → `snapshot_store_begin` on that region). Only after
    the region **durably commits** is the epoch folded into the ring and the
    CRC-protected ring index rewritten (`keyframe_store_commit`), so the ring
    index is the one added commit point and a crash mid-write leaves the
    previous retained window intact.
  - **Index is a cache.** `keyframe_store_load_index` unpacks the persisted index
    when intact; if it is torn or absent it **rebuilds the ring by scanning the
    region superblocks** (each is self-describing with its epoch) and rewrites
    the cache — the window is never lost to a torn index.
  - **Select by epoch.** `keyframe_store_load_epoch` opens the nearest retained
    keyframe at or before a target, rejecting a target before the horizon;
    `keyframe_store_load_latest` opens the newest (boot resume).
  - Host-testable: talks to storage only through `fat_block_device_t`,
    `snapshot_store`, and `keyframe_ring`; no allocator.
- **`kernel/checkpoint.c` / `include/checkpoint.h`** — factor `checkpoint_writeback`
  into `checkpoint_stream_pages()` (the epoch page walk) and
  `checkpoint_after_commit()` (journal hook + drop captures + close epoch), so a
  ring-backed writeback can open the writer on a ring-selected region and reuse
  the same logic. `checkpoint_writeback` keeps identical behavior for the
  two-slot path.
- **`kernel/keyframe_store_sync.c` (kernel adapter)** — binds a process-wide
  keyframe store, reloads-or-formats the retained window at boot, and provides
  `checkpoint_writeback_keyframe()` driving a full writeback through the ring.
- **`kernel/kernel_main.c`** — arm the keyframe store at boot on a non-overlapping
  device region past the checkpoint store and the journal.

## Acceptance criteria

- [x] Checkpoints write across N store regions per the ring (test writes epochs 1..6 into a 4-region store; retains 3..6, evicting the oldest).
- [x] The ring index is persisted and reloaded on boot (a fresh store over the same device sees the same window; plus a torn-index rebuild from region superblocks recovers it).
- [x] Restore can select an arbitrary retained keyframe by epoch (exact select, nearest-at-or-before, newest for a future target, pre-horizon rejected).

## Verification

- New host unit test `tests/test_keyframe_store.c` — 30 checks pass, covering all
  three ACs, the torn-index rebuild, window-roll-forward after reload/rebuild,
  and param guards.
- `test_checkpoint_writeback` still passes after the `checkpoint_writeback`
  refactor.
- Freestanding `-Wall -Wextra` syntax checks clean for `keyframe_store.c`,
  `keyframe_store_sync.c`, `checkpoint.c`; `kernel_main.c` parses with no errors
  referencing the change.
- CI wired: trigger paths, freestanding checks, and the unit test added to
  `.github/workflows/persistence.yml`; architecture module map updated.

Closes #195