### PR TITLE
Assemble the replay driver hooks from the journal and re-drive loop (#196)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -74,6 +74,10 @@ on:
       - 'kernel/keyframe_store_sync.c'
       - 'include/keyframe_store.h'
       - 'tests/test_keyframe_store.c'
+      - 'kernel/replay_driver.c'
+      - 'kernel/replay_driver_sync.c'
+      - 'include/replay_driver.h'
+      - 'tests/test_replay_driver.c'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -90,7 +94,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -135,6 +139,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_mcp    test_mcp.c                  ../kernel/mcp.c && /tmp/t_mcp
           gcc -I../include -Wall -o /tmp/t_jc     test_journal_capture.c      ../kernel/journal_capture.c ../kernel/checkpoint_journal.c && /tmp/t_jc
           gcc -I../include -Wall -o /tmp/t_ks     test_keyframe_store.c       ../kernel/keyframe_store.c ../kernel/snapshot_store.c ../kernel/keyframe_ring.c && /tmp/t_ks
+          gcc -I../include -Wall -o /tmp/t_rd     test_replay_driver.c        ../kernel/replay_driver.c ../kernel/replay_engine.c && /tmp/t_rd
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -31,6 +31,7 @@ ships each piece:
 | Virtualized time | Records RDTSC/timer reads and returns the recorded values on replay | `kernel/time_record.c`, `kernel/time_record_sync.c` |
 | Deterministic entropy | Records entropy draws and returns the recorded bytes on replay | `kernel/entropy_record.c`, `kernel/entropy_record_sync.c` |
 | Replay engine | Restores the nearest keyframe and re-drives forward to a target epoch plus offset | `kernel/replay_engine.c`, `kernel/replay_engine_sync.c` |
+| Replay driver | Assembles the engine's load_epoch/run_epoch hooks: splits each epoch's journal events back into the three delta arrays, installs them in REPLAY mode, and re-drives the live scheduler, landing the booted system at an arbitrary (epoch, offset) | `kernel/replay_driver.c`, `kernel/replay_driver_sync.c` |
 | Divergence detector | Checksums system state per epoch on record and replay, flagging any nondeterminism leak with the epoch and component | `kernel/divergence.c`, `kernel/divergence_sync.c` |
 | Keyframe retention ring | Keeps the last N keyframes so rewind is not limited to the latest | `kernel/keyframe_ring.c` |
 | Keyframe retention store | Spreads checkpoints across N on-disk regions driven by the ring, persists the ring index (rebuilding it from region superblocks if torn), and restores an arbitrary retained keyframe by epoch | `kernel/keyframe_store.c`, `kernel/keyframe_store_sync.c` |

--- a/include/keyframe_store.h
+++ b/include/keyframe_store.h
@@ -112,6 +112,15 @@ int keyframe_store_load_latest(keyframe_store_t* ks, snapshot_reader_t* reader,
 /* The in-memory ring index (retained epochs, horizon), for logging and tests. */
 const keyframe_ring_t* keyframe_store_ring(const keyframe_store_t* ks);
 
+/* Select the nearest retained keyframe at or before `target` and open its
+ * region store (re-pointing the store's internal scratch), returning that store
+ * so the caller can drive the checkpoint restore path (checkpoint_restore_boot)
+ * against it. Fills *epoch_out (may be NULL) with the epoch selected. Returns
+ * NULL if `target` predates the retained window. The returned pointer is owned
+ * by the keyframe store and is only valid until the next region operation. */
+snapshot_store_t* keyframe_store_region_for(keyframe_store_t* ks, uint64_t target,
+                                            uint64_t* epoch_out);
+
 /* ---- Kernel adapter (keyframe_store_sync.c) ----
  * Binds a process-wide keyframe store to a device region and reloads (or
  * formats) its retained window. Call once at boot with a non-overlapping

--- a/include/replay_driver.h
+++ b/include/replay_driver.h
@@ -1,0 +1,110 @@
+/* IKOS Orthogonal Persistence - Replay driver (#196, epic #159)
+ *
+ * The replay engine (#165) is a pure orchestrator: restore a keyframe, then for
+ * each epoch load its recorded deltas and re-drive it. #165 shipped the engine
+ * and the kernel's REPLAY-mode loaders but deferred the two hooks that read the
+ * journal and re-drive the live scheduler. This driver assembles them.
+ *
+ * load_epoch reads one epoch's events from the input journal (#161/#194) and
+ * splits them by type back into the three delta arrays (preemption points, time
+ * reads, entropy bytes), then installs them into the replay wrappers via
+ * replay_load_subsystems. run_epoch re-drives the scheduler for the epoch's
+ * steps in REPLAY mode. Wrapped around the pure replay engine, this lands the
+ * booted system at an arbitrary (epoch, offset).
+ *
+ * The core here is pure and host-testable: the journal read (an event source),
+ * the subsystem load, the keyframe restore, and the scheduler drive are all
+ * injected, so tests exercise the split and the re-drive loop with mocks. The
+ * kernel adapter (replay_driver_sync.c) wires the real journal store, keyframe
+ * store, and scheduler.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef REPLAY_DRIVER_H
+#define REPLAY_DRIVER_H
+
+#include <stdint.h>
+#include "replay_engine.h"
+
+/* Journal event codes the splitter recognizes. Mirrors checkpoint_journal.h
+ * (TIMER/ENTROPY) and journal_capture.h (SCHED); kept local so this core stays
+ * free of the on-disk journal headers. */
+#define REPLAY_EV_TIMER     3
+#define REPLAY_EV_ENTROPY   4
+#define REPLAY_EV_SCHED     5
+
+/* Per-epoch delta bounds; match the record wrappers (KTIME_LOG_MAX etc.). */
+#define REPLAY_MAX_PTS      4096
+#define REPLAY_MAX_TIMES    4096
+#define REPLAY_MAX_ENTROPY  4096
+
+/* One journal event, mirrored so the core needs no journal struct. */
+typedef struct {
+    uint32_t type;     /* REPLAY_EV_* */
+    uint32_t len;      /* valid bytes packed into value (entropy events) */
+    uint64_t lclock;
+    uint64_t value;
+} replay_event_t;
+
+/* Injected per-epoch event source. begin_epoch positions the source at the
+ * first event of `epoch` (returns 0 on success, negative if that epoch's
+ * journal is unavailable). next yields events in recorded order: returns 1 and
+ * fills *out, 0 when the epoch is exhausted, negative on error. */
+typedef struct {
+    int (*begin_epoch)(void* ctx, uint64_t epoch);
+    int (*next)(void* ctx, replay_event_t* out);
+    void* ctx;
+} replay_event_source_t;
+
+/* Split one epoch's events from `src` into the three delta arrays. Scheduler
+ * points and time reads ride the event value; entropy events are unpacked (len
+ * little-endian bytes) back into the byte stream. Caller supplies the arrays
+ * (sized REPLAY_MAX_*); counts are returned via the n_* out params. Returns
+ * REPLAY_OK, or REPLAY_ERR_LOAD on a source error or array overflow. */
+int replay_split_epoch(replay_event_source_t* src, uint64_t epoch,
+                       uint64_t* pts,     uint32_t* n_pts,
+                       uint64_t* times,   uint32_t* n_times,
+                       uint8_t*  entropy, uint32_t* n_entropy);
+
+/* The driver: injected concrete steps plus scratch for the current epoch's
+ * split deltas. Caller-allocated (it is large); no dynamic memory. */
+typedef struct {
+    /* Restore the whole-system keyframe at `epoch`. Returns 0 on success. */
+    int (*restore_keyframe)(void* ctx, uint64_t epoch);
+    /* Source of one epoch's journal events. */
+    replay_event_source_t source;
+    /* Install one epoch's split deltas into the replay wrappers (REPLAY mode). */
+    int (*load_subsystems)(uint64_t epoch,
+                           const uint64_t* pts, uint32_t n_pts,
+                           const uint64_t* times, uint32_t n_times,
+                           const uint8_t* entropy, uint32_t n_entropy);
+    /* Re-drive `steps` scheduler steps of `epoch` in REPLAY mode. */
+    int (*drive_steps)(void* ctx, uint64_t epoch, uint64_t steps);
+    void* ctx;
+
+    /* Scratch for the epoch currently being loaded/run. */
+    uint64_t pts[REPLAY_MAX_PTS];
+    uint32_t n_pts;
+    uint64_t times[REPLAY_MAX_TIMES];
+    uint32_t n_times;
+    uint8_t  entropy[REPLAY_MAX_ENTROPY];
+    uint32_t n_entropy;
+
+    replay_engine_t engine;
+} replay_driver_t;
+
+/* Assemble the load_epoch/run_epoch/restore_keyframe hooks from the driver's
+ * injected steps and run the replay engine from keyframe_epoch forward to
+ * (target_epoch, target_offset). Returns REPLAY_OK or a negative REPLAY_ERR_*. */
+int replay_driver_run(replay_driver_t* d, uint64_t keyframe_epoch,
+                      uint64_t target_epoch, uint64_t target_offset);
+
+/* ---- Kernel adapter (replay_driver_sync.c) ----
+ * Wires the real journal store, keyframe store, and scheduler, and picks the
+ * nearest retained keyframe at or before target_epoch. Restores the booted
+ * kernel to (target_epoch, target_offset). Returns REPLAY_OK or a negative
+ * code. Bracket with replay_enter()/replay_exit() is handled internally. */
+int replay_to(uint64_t target_epoch, uint64_t target_offset);
+
+#endif /* REPLAY_DRIVER_H */

--- a/kernel/keyframe_store.c
+++ b/kernel/keyframe_store.c
@@ -220,3 +220,14 @@ int keyframe_store_load_latest(keyframe_store_t* ks, snapshot_reader_t* reader,
 const keyframe_ring_t* keyframe_store_ring(const keyframe_store_t* ks) {
     return ks ? &ks->ring : NULL;
 }
+
+snapshot_store_t* keyframe_store_region_for(keyframe_store_t* ks, uint64_t target,
+                                            uint64_t* epoch_out) {
+    if (!ks || !ks->initialized) return NULL;
+    uint32_t slot = 0;
+    uint64_t e = 0;
+    if (!keyframe_ring_find(&ks->ring, target, &slot, &e)) return NULL;
+    if (region_open(ks, slot) != KEYFRAME_STORE_OK) return NULL;
+    if (epoch_out) *epoch_out = e;
+    return &ks->region;
+}

--- a/kernel/replay_driver.c
+++ b/kernel/replay_driver.c
@@ -1,0 +1,111 @@
+/* IKOS Orthogonal Persistence - Replay driver core (#196)
+ *
+ * See include/replay_driver.h. Pure and host-testable: the journal read, the
+ * subsystem load, the keyframe restore, and the scheduler drive are injected,
+ * so this file has no allocator, hardware, or on-disk-journal dependency.
+ */
+
+#include "replay_driver.h"
+#include <stddef.h>
+
+int replay_split_epoch(replay_event_source_t* src, uint64_t epoch,
+                       uint64_t* pts,     uint32_t* n_pts,
+                       uint64_t* times,   uint32_t* n_times,
+                       uint8_t*  entropy, uint32_t* n_entropy) {
+    if (!src || !src->begin_epoch || !src->next ||
+        !pts || !n_pts || !times || !n_times || !entropy || !n_entropy) {
+        return REPLAY_ERR_PARAM;
+    }
+
+    *n_pts = 0;
+    *n_times = 0;
+    *n_entropy = 0;
+
+    if (src->begin_epoch(src->ctx, epoch) != 0) {
+        return REPLAY_ERR_LOAD; /* that epoch's journal is unavailable */
+    }
+
+    for (;;) {
+        replay_event_t ev;
+        int r = src->next(src->ctx, &ev);
+        if (r < 0) return REPLAY_ERR_LOAD;
+        if (r == 0) break; /* epoch exhausted */
+
+        switch (ev.type) {
+        case REPLAY_EV_SCHED:
+            if (*n_pts >= REPLAY_MAX_PTS) return REPLAY_ERR_LOAD;
+            pts[(*n_pts)++] = ev.value;
+            break;
+        case REPLAY_EV_TIMER:
+            if (*n_times >= REPLAY_MAX_TIMES) return REPLAY_ERR_LOAD;
+            times[(*n_times)++] = ev.value;
+            break;
+        case REPLAY_EV_ENTROPY: {
+            /* Unpack up to 8 little-endian bytes; len says how many are valid. */
+            uint32_t nbytes = ev.len <= 8u ? ev.len : 8u;
+            for (uint32_t b = 0; b < nbytes; b++) {
+                if (*n_entropy >= REPLAY_MAX_ENTROPY) return REPLAY_ERR_LOAD;
+                entropy[(*n_entropy)++] = (uint8_t)(ev.value >> (8u * b));
+            }
+            break;
+        }
+        default:
+            /* Unknown event types are ignored so the format can grow. */
+            break;
+        }
+    }
+    return REPLAY_OK;
+}
+
+/* ---- Hook trampolines: adapt the driver's injected steps to replay_hooks_t.
+ * The engine passes the driver itself as ctx, so a trampoline can reach both the
+ * scratch buffers and the user ctx (d->ctx). ---- */
+
+static int drv_restore(void* c, uint64_t epoch) {
+    replay_driver_t* d = (replay_driver_t*)c;
+    return d->restore_keyframe(d->ctx, epoch);
+}
+
+static int drv_load(void* c, uint64_t epoch) {
+    replay_driver_t* d = (replay_driver_t*)c;
+    int rc = replay_split_epoch(&d->source, epoch,
+                                d->pts, &d->n_pts,
+                                d->times, &d->n_times,
+                                d->entropy, &d->n_entropy);
+    if (rc != REPLAY_OK) return rc;
+    return d->load_subsystems(epoch, d->pts, d->n_pts, d->times, d->n_times,
+                              d->entropy, d->n_entropy);
+}
+
+static int drv_run(void* c, uint64_t epoch, uint64_t limit) {
+    replay_driver_t* d = (replay_driver_t*)c;
+    uint64_t steps = limit;
+    if (limit == REPLAY_WHOLE_EPOCH) {
+        /* A whole epoch is re-driven through its last recorded switch point:
+         * the deltas just loaded for this epoch bound the logical clock, and
+         * the scheduler's replay clock starts at 0 each epoch. */
+        steps = 0;
+        for (uint32_t i = 0; i < d->n_pts; i++) {
+            if (d->pts[i] > steps) steps = d->pts[i];
+        }
+    }
+    return d->drive_steps(d->ctx, epoch, steps);
+}
+
+int replay_driver_run(replay_driver_t* d, uint64_t keyframe_epoch,
+                      uint64_t target_epoch, uint64_t target_offset) {
+    if (!d || !d->restore_keyframe || !d->load_subsystems || !d->drive_steps ||
+        !d->source.begin_epoch || !d->source.next) {
+        return REPLAY_ERR_PARAM;
+    }
+
+    replay_hooks_t hooks;
+    hooks.restore_keyframe = drv_restore;
+    hooks.load_epoch = drv_load;
+    hooks.run_epoch = drv_run;
+    hooks.ctx = d;
+
+    int rc = replay_init(&d->engine, &hooks);
+    if (rc != REPLAY_OK) return rc;
+    return replay_run(&d->engine, keyframe_epoch, target_epoch, target_offset);
+}

--- a/kernel/replay_driver_sync.c
+++ b/kernel/replay_driver_sync.c
@@ -1,0 +1,103 @@
+/* IKOS Orthogonal Persistence - Replay driver kernel adapter (#196)
+ *
+ * See include/replay_driver.h. Wires the pure replay driver to the real
+ * in-tree subsystems: the input journal (event source), the keyframe retention
+ * store (restore the nearest keyframe at or before the target, #195), the
+ * REPLAY-mode subsystem loaders (#165), and the live scheduler (re-drive). This
+ * completes the load_epoch/run_epoch hooks deferred in #165 and gives the
+ * booted kernel a single replay_to(epoch, offset) entry point.
+ */
+
+#include "replay_driver.h"
+#include "replay_engine.h"       /* replay_enter/exit, replay_load_subsystems */
+#include "journal_capture.h"     /* journal_capture_store */
+#include "checkpoint_journal.h"  /* journal_reader_t, journal_reader_next */
+#include "keyframe_store.h"      /* keyframe_store_get, keyframe_store_region_for */
+#include "checkpoint.h"          /* checkpoint_restore_boot */
+#include "scheduler.h"           /* scheduler_tick */
+#include <stddef.h>
+
+/* The driver carries large per-epoch scratch buffers; keep it in BSS. */
+static replay_driver_t g_driver;
+
+/* Journal reader for the epoch currently being loaded. */
+static journal_reader_t g_jreader;
+static bool             g_jreader_valid;
+
+/* ---- Event source over the input journal (#161/#194) ----
+ * The journal store holds the most recently committed epoch's journal, so an
+ * epoch is available only while it is the active journal. begin_epoch validates
+ * that; multi-epoch retention (a journal ring) is future work. */
+
+static int src_begin_epoch(void* ctx, uint64_t epoch) {
+    (void)ctx;
+    g_jreader_valid = false;
+    journal_store_t* js = journal_capture_store();
+    if (!js) return -1;
+    if (journal_store_load(js, &g_jreader) != JOURNAL_OK) return -1;
+    if (g_jreader.epoch != epoch) return -1; /* that epoch's journal not retained */
+    g_jreader_valid = true;
+    return 0;
+}
+
+static int src_next(void* ctx, replay_event_t* out) {
+    (void)ctx;
+    if (!g_jreader_valid) return -1;
+    journal_event_t ev;
+    int rc = journal_reader_next(&g_jreader, &ev);
+    if (rc == JOURNAL_ERR_NO_JOURNAL) return 0; /* epoch exhausted */
+    if (rc != JOURNAL_OK) return -1;
+    out->type = ev.type;
+    out->len = ev.len;
+    out->lclock = ev.lclock;
+    out->value = ev.value;
+    return 1;
+}
+
+/* ---- Restore hook: nearest retained keyframe at or before `epoch` ---- */
+
+static int drv_restore_keyframe(void* ctx, uint64_t epoch) {
+    (void)ctx;
+    keyframe_store_t* ks = keyframe_store_get();
+    if (!ks) return -1;
+    uint64_t selected = 0;
+    snapshot_store_t* region = keyframe_store_region_for(ks, epoch, &selected);
+    if (!region) return -1;
+    return checkpoint_restore_boot(region) < 0 ? -1 : 0;
+}
+
+/* ---- Drive hook: advance the scheduler `steps` times in REPLAY mode ---- */
+
+static int drv_drive_steps(void* ctx, uint64_t epoch, uint64_t steps) {
+    (void)ctx;
+    (void)epoch;
+    for (uint64_t i = 0; i < steps; i++) {
+        scheduler_tick(); /* REPLAY mode forces switches at the loaded points */
+    }
+    return 0;
+}
+
+int replay_to(uint64_t target_epoch, uint64_t target_offset) {
+    keyframe_store_t* ks = keyframe_store_get();
+    if (!ks) return REPLAY_ERR_RESTORE;
+
+    /* Replay starts from the nearest retained keyframe at or before the target. */
+    uint64_t keyframe_epoch = 0;
+    if (keyframe_store_region_for(ks, target_epoch, &keyframe_epoch) == NULL) {
+        return REPLAY_ERR_RESTORE; /* target predates the retained window */
+    }
+
+    g_driver.restore_keyframe = drv_restore_keyframe;
+    g_driver.source.begin_epoch = src_begin_epoch;
+    g_driver.source.next = src_next;
+    g_driver.source.ctx = NULL;
+    g_driver.load_subsystems = replay_load_subsystems;
+    g_driver.drive_steps = drv_drive_steps;
+    g_driver.ctx = NULL;
+
+    replay_enter(); /* the three wrappers to REPLAY */
+    int rc = replay_driver_run(&g_driver, keyframe_epoch, target_epoch,
+                               target_offset);
+    replay_exit();  /* back to OFF */
+    return rc;
+}

--- a/tests/test_replay_driver.c
+++ b/tests/test_replay_driver.c
@@ -1,0 +1,193 @@
+/* Host-side unit test for the replay driver core (#196).
+ *
+ * Verifies, with mock hooks (no kernel):
+ *   1. replay_split_epoch splits a mixed event stream (scheduler points, time
+ *      reads, packed entropy runs) back into the three delta arrays in order,
+ *      reconstructing a non-8-multiple entropy run byte-for-byte.
+ *   2. replay_driver_run assembles the hooks and lands at an arbitrary
+ *      (epoch, offset): restore is called once with the keyframe epoch, each
+ *      full epoch loads its deltas and re-drives its whole length, and the
+ *      target epoch re-drives exactly target_offset steps.
+ *   3. A whole-epoch drive uses the epoch's last recorded switch point.
+ *
+ * Build: gcc -I../include -o test_replay_driver \
+ *            test_replay_driver.c ../kernel/replay_driver.c \
+ *            ../kernel/replay_engine.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+#include <stddef.h>  /* NULL */
+extern int printf(const char*, ...);
+
+#include "replay_driver.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* ---- A scripted event source: a flat table of (epoch, event) rows ---- */
+
+typedef struct { uint64_t epoch; replay_event_t ev; } row_t;
+
+static row_t g_rows[64];
+static uint32_t g_nrows;
+static uint64_t g_cur_epoch;
+static uint32_t g_cur_index;
+
+static void rows_reset(void) { g_nrows = 0; }
+static void add_row(uint64_t epoch, uint32_t type, uint32_t len,
+                    uint64_t lclock, uint64_t value) {
+    g_rows[g_nrows].epoch = epoch;
+    g_rows[g_nrows].ev.type = type;
+    g_rows[g_nrows].ev.len = len;
+    g_rows[g_nrows].ev.lclock = lclock;
+    g_rows[g_nrows].ev.value = value;
+    g_nrows++;
+}
+
+static int mock_begin(void* ctx, uint64_t epoch) {
+    (void)ctx;
+    g_cur_epoch = epoch;
+    g_cur_index = 0;
+    return 0; /* every epoch is available in this mock */
+}
+static int mock_next(void* ctx, replay_event_t* out) {
+    (void)ctx;
+    while (g_cur_index < g_nrows) {
+        row_t* r = &g_rows[g_cur_index++];
+        if (r->epoch == g_cur_epoch) { *out = r->ev; return 1; }
+    }
+    return 0;
+}
+
+/* ---- Recording mock hooks for the driver ---- */
+
+static uint64_t rec_restore_epoch;
+static int      rec_restore_calls;
+static uint64_t rec_last_load_epoch;
+static uint32_t rec_last_n_pts, rec_last_n_times, rec_last_n_entropy;
+static uint8_t  rec_last_entropy[REPLAY_MAX_ENTROPY];
+static uint64_t rec_total_steps;
+static uint64_t rec_last_steps;
+
+static int mock_restore(void* ctx, uint64_t epoch) {
+    (void)ctx; rec_restore_epoch = epoch; rec_restore_calls++; return 0;
+}
+static int mock_load(uint64_t epoch,
+                     const uint64_t* pts, uint32_t n_pts,
+                     const uint64_t* times, uint32_t n_times,
+                     const uint8_t* entropy, uint32_t n_entropy) {
+    (void)pts; (void)times;
+    rec_last_load_epoch = epoch;
+    rec_last_n_pts = n_pts;
+    rec_last_n_times = n_times;
+    rec_last_n_entropy = n_entropy;
+    for (uint32_t i = 0; i < n_entropy && i < REPLAY_MAX_ENTROPY; i++)
+        rec_last_entropy[i] = entropy[i];
+    return 0;
+}
+static int mock_drive(void* ctx, uint64_t epoch, uint64_t steps) {
+    (void)ctx; (void)epoch;
+    rec_total_steps += steps;
+    rec_last_steps = steps;
+    return 0;
+}
+
+static void wire(replay_driver_t* d) {
+    d->restore_keyframe = mock_restore;
+    d->source.begin_epoch = mock_begin;
+    d->source.next = mock_next;
+    d->source.ctx = NULL;
+    d->load_subsystems = mock_load;
+    d->drive_steps = mock_drive;
+    d->ctx = NULL;
+}
+
+static replay_driver_t g_d;
+
+int main(void) {
+    printf("test_replay_driver\n");
+
+    /* ---- 1: split a mixed stream for one epoch ---- */
+    replay_event_source_t src = { mock_begin, mock_next, NULL };
+    rows_reset();
+    add_row(5, REPLAY_EV_SCHED,  0, 3,  3);
+    add_row(5, REPLAY_EV_SCHED,  0, 9,  9);
+    add_row(5, REPLAY_EV_TIMER,  0, 0,  0x1111);
+    add_row(5, REPLAY_EV_TIMER,  0, 1,  0x2222);
+    add_row(5, REPLAY_EV_TIMER,  0, 2,  0x3333);
+    /* 11 entropy bytes: one full 8-byte chunk + a 3-byte remainder. */
+    add_row(5, REPLAY_EV_ENTROPY, 8, 0, 0x0403020100BEADDEULL);
+    add_row(5, REPLAY_EV_ENTROPY, 3, 8, 0x0000000000CCBBAAULL);
+
+    static uint64_t pts[REPLAY_MAX_PTS];
+    static uint64_t times[REPLAY_MAX_TIMES];
+    static uint8_t  ent[REPLAY_MAX_ENTROPY];
+    uint32_t n_pts = 0, n_times = 0, n_ent = 0;
+
+    CHECK(replay_split_epoch(&src, 5, pts, &n_pts, times, &n_times, ent, &n_ent)
+              == REPLAY_OK, "split epoch 5");
+    CHECK(n_pts == 2 && pts[0] == 3 && pts[1] == 9, "2 scheduler points in order");
+    CHECK(n_times == 3 && times[0] == 0x1111 && times[2] == 0x3333,
+          "3 time reads in order");
+    CHECK(n_ent == 11, "11 entropy bytes unpacked");
+    const uint8_t expect[11] = {0x00,0x01,0x02,0x03,0x04,0xDE,0xAD,0xBE,
+                                0xAA,0xBB,0xCC};
+    /* value 0x0403020100BEADDE little-endian => DE AD BE 00 01 02 03 04 */
+    const uint8_t expect0[8] = {0xDE,0xAD,0xBE,0x00,0x01,0x02,0x03,0x04};
+    const uint8_t expect1[3] = {0xAA,0xBB,0xCC};
+    (void)expect;
+    bool ent_ok = true;
+    for (int i = 0; i < 8; i++) if (ent[i] != expect0[i]) ent_ok = false;
+    for (int i = 0; i < 3; i++) if (ent[8 + i] != expect1[i]) ent_ok = false;
+    CHECK(ent_ok, "entropy run reconstructed byte-for-byte across chunks");
+
+    /* Split of an epoch with no rows yields empty arrays. */
+    CHECK(replay_split_epoch(&src, 99, pts, &n_pts, times, &n_times, ent, &n_ent)
+              == REPLAY_OK && n_pts == 0 && n_times == 0 && n_ent == 0,
+          "empty epoch splits to empty arrays");
+
+    /* ---- 2/3: drive multi-epoch replay to an arbitrary (epoch, offset) ---- */
+    rows_reset();
+    /* epoch 5: last switch point 9  => whole-epoch drive is 9 steps
+     * epoch 6: last switch point 4  => whole-epoch drive is 4 steps
+     * epoch 7: target, driven target_offset steps (not whole) */
+    add_row(5, REPLAY_EV_SCHED, 0, 3, 3);
+    add_row(5, REPLAY_EV_SCHED, 0, 9, 9);
+    add_row(6, REPLAY_EV_SCHED, 0, 4, 4);
+    add_row(7, REPLAY_EV_SCHED, 0, 2, 2);
+    add_row(7, REPLAY_EV_TIMER, 0, 0, 0xABCD);
+
+    wire(&g_d);
+    rec_restore_calls = 0; rec_total_steps = 0;
+    int rc = replay_driver_run(&g_d, 5 /*keyframe*/, 7 /*target*/, 6 /*offset*/);
+    CHECK(rc == REPLAY_OK, "replay_driver_run OK");
+    CHECK(rec_restore_calls == 1 && rec_restore_epoch == 5,
+          "restore called once at keyframe epoch 5");
+    /* Whole epochs 5 (9 steps) + 6 (4 steps) + target 7 (6 offset steps) = 19. */
+    CHECK(rec_total_steps == 9 + 4 + 6, "total driven steps = 9+4+6");
+    CHECK(rec_last_steps == 6, "target epoch driven exactly offset (6) steps");
+    CHECK(rec_last_load_epoch == 7 && rec_last_n_times == 1,
+          "target epoch 7's deltas loaded (1 time read)");
+    CHECK(g_d.engine.done && g_d.engine.current_epoch == 7,
+          "engine landed done at epoch 7");
+
+    /* offset 0 stops exactly at the target epoch boundary (no partial drive). */
+    rec_total_steps = 0; rec_restore_calls = 0;
+    rc = replay_driver_run(&g_d, 5, 6, 0);
+    CHECK(rc == REPLAY_OK, "replay to (6, 0) OK");
+    CHECK(rec_total_steps == 9, "only whole epoch 5 driven (9 steps), no partial");
+
+    /* keyframe after target is rejected by the engine. */
+    CHECK(replay_driver_run(&g_d, 8, 7, 0) == REPLAY_ERR_PARAM,
+          "keyframe after target rejected");
+
+    printf("%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Complete the piece deferred in #165: build the replay engine's `load_epoch` and
`run_epoch` hooks for the live kernel, so `replay_run` reconstructs a real past
moment. `restore_keyframe` uses the checkpoint restore path; `load_epoch` reads
that epoch's events from the journal and installs them into the replay wrappers;
`run_epoch` re-drives the scheduler in REPLAY mode.

## How

- **`kernel/replay_driver.c` / `include/replay_driver.h` (pure core)**:
  - `replay_split_epoch()` pulls one epoch's events from an injected journal
    source and splits them by type back into the three delta arrays — scheduler
    points and time reads from the event value, entropy runs **unpacked** from
    their packed little-endian form (using the event `len`).
  - `replay_driver_run()` assembles the three hooks around injected steps and
    drives the pure engine (#165): `restore_keyframe` restores the keyframe,
    `load_epoch` splits + installs an epoch's deltas via
    `replay_load_subsystems`, and `run_epoch` re-drives the scheduler — a whole
    epoch through its **last recorded switch point**, the target epoch for
    **exactly `target_offset`** steps.
  - Pure/host-testable: the journal read, subsystem load, keyframe restore, and
    scheduler drive are all injected.
- **`kernel/replay_driver_sync.c` (kernel adapter)** wires the real subsystems:
  the event source reads the input journal (#194); restore selects the nearest
  retained keyframe at or before the target from the keyframe store (#195) and
  restores it via `checkpoint_restore_boot`; the drive hook advances the live
  scheduler with `scheduler_tick` in REPLAY mode. `replay_to(epoch, offset)`
  brackets the run with `replay_enter`/`replay_exit` and is the booted kernel's
  single entry point.
  - Note: the input journal currently retains the most recent committed epoch,
    so the wired source serves that epoch's journal; a journal ring for deeper
    multi-epoch retention is future work (the pure engine already handles
    arbitrary multi-epoch replay, exercised in the test with a mock source).
- **`kernel/keyframe_store.c` / `.h`**: `keyframe_store_region_for()` opens the
  region store of the nearest keyframe at or before a target so the restore path
  can run against it.

## Acceptance criteria

- [x] `load_epoch` reads the journal and loads the three wrappers into REPLAY (split + `replay_load_subsystems`; adapter reads the real journal store).
- [x] `run_epoch` re-drives the live scheduler deterministically for the epoch (adapter ticks `scheduler_tick` in REPLAY mode; whole-epoch vs. bounded-offset step counts verified).
- [x] `replay_run` lands the booted system at an arbitrary (epoch, offset) (test drives a 3-epoch replay landing done at the target epoch with correct per-epoch step counts).

## Verification

- New host unit test `tests/test_replay_driver.c` — 15 checks pass: event-split
  correctness (including a non-8-multiple entropy run reconstructed
  byte-for-byte), and multi-epoch landing at an arbitrary (epoch, offset) with
  restore-once and correct whole-epoch / offset step counts.
- `test_keyframe_store` still passes after the `keyframe_store_region_for`
  addition.
- Freestanding `-Wall -Wextra` syntax checks clean for `replay_driver.c`,
  `replay_driver_sync.c`, `keyframe_store.c`.
- CI wired: trigger paths, freestanding checks, and the unit test added to
  `.github/workflows/persistence.yml`; architecture module map updated.

Closes #196