### PR TITLE
Wire divergence checksums over the restored components (#197)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -78,6 +78,10 @@ on:
       - 'kernel/replay_driver_sync.c'
       - 'include/replay_driver.h'
       - 'tests/test_replay_driver.c'
+      - 'kernel/divergence_scan.c'
+      - 'kernel/divergence_scan_sync.c'
+      - 'include/divergence_scan.h'
+      - 'tests/test_divergence_scan.c'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -94,7 +98,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/divergence_scan.c kernel/divergence_scan_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -140,6 +144,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_jc     test_journal_capture.c      ../kernel/journal_capture.c ../kernel/checkpoint_journal.c && /tmp/t_jc
           gcc -I../include -Wall -o /tmp/t_ks     test_keyframe_store.c       ../kernel/keyframe_store.c ../kernel/snapshot_store.c ../kernel/keyframe_ring.c && /tmp/t_ks
           gcc -I../include -Wall -o /tmp/t_rd     test_replay_driver.c        ../kernel/replay_driver.c ../kernel/replay_engine.c && /tmp/t_rd
+          gcc -I../include -Wall -o /tmp/t_ds     test_divergence_scan.c      ../kernel/divergence_scan.c ../kernel/divergence.c && /tmp/t_ds
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -33,6 +33,7 @@ ships each piece:
 | Replay engine | Restores the nearest keyframe and re-drives forward to a target epoch plus offset | `kernel/replay_engine.c`, `kernel/replay_engine_sync.c` |
 | Replay driver | Assembles the engine's load_epoch/run_epoch hooks: splits each epoch's journal events back into the three delta arrays, installs them in REPLAY mode, and re-drives the live scheduler, landing the booted system at an arbitrary (epoch, offset) | `kernel/replay_driver.c`, `kernel/replay_driver_sync.c` |
 | Divergence detector | Checksums system state per epoch on record and replay, flagging any nondeterminism leak with the epoch and component | `kernel/divergence.c`, `kernel/divergence_sync.c` |
+| Divergence component scan | Feeds the detector real per-component checksums (process table, scheduler, ...) at each epoch boundary: records them into the journal on a record run and compares the recomputed sums on replay, halting at the exact epoch and component | `kernel/divergence_scan.c`, `kernel/divergence_scan_sync.c` |
 | Keyframe retention ring | Keeps the last N keyframes so rewind is not limited to the latest | `kernel/keyframe_ring.c` |
 | Keyframe retention store | Spreads checkpoints across N on-disk regions driven by the ring, persists the ring index (rebuilding it from region superblocks if torn), and restores an arbitrary retained keyframe by epoch | `kernel/keyframe_store.c`, `kernel/keyframe_store_sync.c` |
 | Rewind-to | The core verb: nearest keyframe at or before the target, then replay to the target | `kernel/rewind.c`, `kernel/rewind_sync.c` |

--- a/include/divergence_scan.h
+++ b/include/divergence_scan.h
@@ -1,0 +1,77 @@
+/* IKOS Orthogonal Persistence - Divergence component scan (#197, epic #159)
+ *
+ * The divergence detector (#166) stores and compares per-component checksums;
+ * this layer feeds it real component checksums at each epoch boundary. On a
+ * record run it checksums each restored component (process table, scheduler,
+ * user pages, ...) and records the sums; those sums ride in the input journal.
+ * On replay it recomputes each component's checksum and compares it against the
+ * recorded value, so a nondeterminism leak the wrappers missed halts at the
+ * exact epoch and component.
+ *
+ * The scan core is pure and host-testable: each component's checksum comes from
+ * an injected source function, and the record/compare sinks are injected too, so
+ * tests drive the whole record->journal->replay round trip with mocks. The
+ * kernel adapter (divergence_scan_sync.c) supplies the concrete component
+ * sources over the live subsystems and wires the global detector and journal.
+ *
+ * See docs/architecture/time-travel.md.
+ */
+
+#ifndef DIVERGENCE_SCAN_H
+#define DIVERGENCE_SCAN_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Computes one component's checksum over its current state. */
+typedef uint32_t (*diverge_source_fn)(void* ctx);
+
+typedef struct {
+    uint32_t          component;  /* KDIVERGE_* id */
+    diverge_source_fn source;     /* checksum of this component's state now */
+    void*             ctx;        /* passed to source */
+} diverge_source_t;
+
+/* RECORD: checksum each component and hand (component, sum) to record_cb, also
+ * writing them into out_ids[i] / out_sums[i] for journaling. Returns the number
+ * of components scanned. record_cb may be NULL (just fill the out arrays). */
+uint32_t diverge_scan_record(const diverge_source_t* srcs, uint32_t n,
+                             int (*record_cb)(uint32_t comp, uint32_t sum),
+                             uint32_t* out_ids, uint32_t* out_sums);
+
+/* REPLAY: checksum each component and hand (component, sum) to check_cb, which
+ * returns true on a match. Returns true only if every component matched (an
+ * empty scan trivially matches). check_cb must be non-NULL. */
+bool diverge_scan_check(const diverge_source_t* srcs, uint32_t n,
+                        bool (*check_cb)(uint32_t comp, uint32_t sum));
+
+/* ---- Kernel adapter (divergence_scan_sync.c) ----
+ * A registry of live component sources plus the record/replay plumbing the
+ * journal and replay driver drive at each epoch boundary. */
+
+/* Register a component source (id, checksum fn, ctx). Idempotent registration
+ * is the caller's responsibility; call kdiverge_reset_sources first to rebind. */
+void kdiverge_register(uint32_t component, diverge_source_fn source, void* ctx);
+void kdiverge_reset_sources(void);
+
+/* Register the concrete in-tree component sources (process table, scheduler,
+ * ...). Call once at boot after kdiverge_init(). */
+void kdiverge_register_kernel_sources(void);
+
+/* RECORD: put the detector in RECORD mode, begin `epoch`, and checksum every
+ * registered component (kdiverge_record). The sums are stashed for journaling. */
+void kdiverge_record_epoch(uint64_t epoch);
+
+/* The sums stashed by the last kdiverge_record_epoch, as parallel (ids, sums)
+ * arrays for journaling. Matches journal_capture_sources_t.divergence_sums. */
+uint32_t kdiverge_journal_sums(const uint32_t** ids, const uint32_t** sums);
+
+/* REPLAY: install the recorded (id, sum) pairs read from `epoch`'s journal as
+ * the expected per-component checksums, then recompute and compare every
+ * registered component. Returns true if all matched. The detector keeps the
+ * first divergence (kdiverge_ok() / the detector's sticky verdict). */
+int  kdiverge_expect_pairs(uint64_t epoch, const uint32_t* ids,
+                           const uint32_t* sums, uint32_t n);
+bool kdiverge_check_epoch(void);
+
+#endif /* DIVERGENCE_SCAN_H */

--- a/include/journal_capture.h
+++ b/include/journal_capture.h
@@ -27,6 +27,10 @@
  * event lclock and value. */
 #define JOURNAL_EV_SCHED 5
 
+/* Divergence checksum for one component at the epoch boundary (#197). lclock
+ * carries the component id, value carries the checksum. */
+#define JOURNAL_EV_DIVERGE 6
+
 /* Injected delta sources. The live kernel wires these to
  * scheduler_preempt_points / ktime_values / kentropy_bytes; tests pass fakes.
  * Each returns the count for the current epoch and points *out at the buffer.
@@ -35,15 +39,18 @@ typedef struct {
     uint32_t (*preempt_points)(const uint64_t** out);  /* switch-point lclocks */
     uint32_t (*time_values)(const uint64_t** out);     /* captured RDTSC reads */
     uint32_t (*entropy_bytes)(const uint8_t** out);    /* captured entropy run */
+    /* Divergence checksums for the epoch boundary (#197): returns the component
+     * count and points *ids / *sums at parallel arrays. NULL to skip. */
+    uint32_t (*divergence_sums)(const uint32_t** ids, const uint32_t** sums);
 } journal_capture_sources_t;
 
 /* Gather the epoch's deltas from src and write them to store as a single
  * journal for `epoch`, committing crash-consistently (the journal store's
  * superblock flip is the one commit point, so a crash mid-write leaves the
  * previous epoch's journal intact). Event order within the journal: every
- * scheduler point, then every time read, then the entropy run. base_lclock is
- * recorded in the slot header for reference. Returns JOURNAL_OK, or a negative
- * JOURNAL_ERR_* (in which case nothing is committed). */
+ * scheduler point, every time read, the entropy run, then the divergence
+ * checksums. base_lclock is recorded in the slot header for reference. Returns
+ * JOURNAL_OK, or a negative JOURNAL_ERR_* (in which case nothing is committed). */
 int journal_capture_epoch(journal_store_t* store, uint64_t epoch,
                           uint64_t base_lclock,
                           const journal_capture_sources_t* src);

--- a/kernel/divergence_scan.c
+++ b/kernel/divergence_scan.c
@@ -1,0 +1,38 @@
+/* IKOS Orthogonal Persistence - Divergence component scan core (#197)
+ *
+ * See include/divergence_scan.h. Pure and host-testable: it only calls the
+ * injected component sources and record/compare sinks, so it has no allocator,
+ * hardware, or subsystem dependency.
+ */
+
+#include "divergence_scan.h"
+
+uint32_t diverge_scan_record(const diverge_source_t* srcs, uint32_t n,
+                             int (*record_cb)(uint32_t comp, uint32_t sum),
+                             uint32_t* out_ids, uint32_t* out_sums) {
+    if (!srcs || !out_ids || !out_sums) return 0;
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        if (!srcs[i].source) continue;
+        uint32_t sum = srcs[i].source(srcs[i].ctx);
+        out_ids[count] = srcs[i].component;
+        out_sums[count] = sum;
+        if (record_cb) record_cb(srcs[i].component, sum);
+        count++;
+    }
+    return count;
+}
+
+bool diverge_scan_check(const diverge_source_t* srcs, uint32_t n,
+                        bool (*check_cb)(uint32_t comp, uint32_t sum)) {
+    if (!srcs || !check_cb) return false;
+    bool ok = true;
+    for (uint32_t i = 0; i < n; i++) {
+        if (!srcs[i].source) continue;
+        uint32_t sum = srcs[i].source(srcs[i].ctx);
+        /* Check every component even after a mismatch so the detector sees each
+         * one; the first divergence is what it keeps (sticky). */
+        if (!check_cb(srcs[i].component, sum)) ok = false;
+    }
+    return ok;
+}

--- a/kernel/divergence_scan_sync.c
+++ b/kernel/divergence_scan_sync.c
@@ -1,0 +1,120 @@
+/* IKOS Orthogonal Persistence - Divergence component scan adapter (#197)
+ *
+ * See include/divergence_scan.h. Wires the pure scan core to the global
+ * divergence detector (#166), a registry of live component sources, and the
+ * journal: on a record run it checksums each registered component and stashes
+ * the sums for journaling; on replay it installs the recorded sums and compares
+ * the recomputed ones, so a nondeterminism leak halts at the exact epoch and
+ * component.
+ *
+ * The concrete component sources checksum the restored subsystems. Process
+ * table and scheduler order are wired here (both reachable through stable
+ * process-manager accessors); further components register as their subsystems
+ * expose deterministic snapshot accessors.
+ */
+
+#include "divergence_scan.h"
+#include "divergence.h"          /* kdiverge_*, divergence_checksum */
+#include "process_manager.h"     /* pm_get_process_list, pm_get_process */
+#include "scheduler.h"           /* task_get_current */
+#include <stddef.h>
+
+/* ---- Source registry ---- */
+
+static diverge_source_t g_sources[KDIVERGE_COMPONENT_COUNT];
+static uint32_t         g_nsources;
+
+/* Sums stashed by the last record scan, for journaling. */
+static uint32_t g_rec_ids[KDIVERGE_COMPONENT_COUNT];
+static uint32_t g_rec_sums[KDIVERGE_COMPONENT_COUNT];
+static uint32_t g_rec_count;
+
+void kdiverge_reset_sources(void) {
+    g_nsources = 0;
+}
+
+void kdiverge_register(uint32_t component, diverge_source_fn source, void* ctx) {
+    if (!source || g_nsources >= KDIVERGE_COMPONENT_COUNT) return;
+    g_sources[g_nsources].component = component;
+    g_sources[g_nsources].source = source;
+    g_sources[g_nsources].ctx = ctx;
+    g_nsources++;
+}
+
+/* ---- Concrete component sources over the restored subsystems ---- */
+
+/* Process table: the pid and state of every live process, in list order. */
+static uint32_t sum_proctable(void* ctx) {
+    (void)ctx;
+    uint32_t pids[PM_MAX_PROCESSES];
+    uint32_t n = 0;
+    if (pm_get_process_list(pids, PM_MAX_PROCESSES, &n) != 0) return 0;
+    uint32_t crc = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        process_t* p = pm_get_process(pids[i]);
+        if (!p) continue;
+        uint32_t pid = (uint32_t)p->pid;
+        uint32_t st = (uint32_t)p->state;
+        crc = divergence_checksum(crc, &pid, sizeof(pid));
+        crc = divergence_checksum(crc, &st, sizeof(st));
+    }
+    return crc;
+}
+
+/* Scheduler: the currently-running pid and the ready order (the process list
+ * order), which the deterministic-preemption replay must reproduce. */
+static uint32_t sum_scheduler(void* ctx) {
+    (void)ctx;
+    task_t* cur = task_get_current();
+    uint32_t cpid = cur ? (uint32_t)cur->pid : 0xFFFFFFFFu;
+    uint32_t crc = divergence_checksum(0, &cpid, sizeof(cpid));
+    uint32_t pids[PM_MAX_PROCESSES];
+    uint32_t n = 0;
+    if (pm_get_process_list(pids, PM_MAX_PROCESSES, &n) == 0 && n > 0) {
+        crc = divergence_checksum(crc, pids, n * (uint32_t)sizeof(pids[0]));
+    }
+    return crc;
+}
+
+void kdiverge_register_kernel_sources(void) {
+    kdiverge_reset_sources();
+    kdiverge_register(KDIVERGE_PROCTABLE, sum_proctable, NULL);
+    kdiverge_register(KDIVERGE_SCHEDULER, sum_scheduler, NULL);
+}
+
+/* ---- Record side ---- */
+
+void kdiverge_record_epoch(uint64_t epoch) {
+    kdiverge_set_mode(DIVERGE_RECORD);
+    kdiverge_begin_epoch(epoch);
+    g_rec_count = diverge_scan_record(g_sources, g_nsources, kdiverge_record,
+                                      g_rec_ids, g_rec_sums);
+}
+
+uint32_t kdiverge_journal_sums(const uint32_t** ids, const uint32_t** sums) {
+    if (ids) *ids = g_rec_ids;
+    if (sums) *sums = g_rec_sums;
+    return g_rec_count;
+}
+
+/* ---- Replay side ---- */
+
+int kdiverge_expect_pairs(uint64_t epoch, const uint32_t* ids,
+                          const uint32_t* sums, uint32_t n) {
+    /* Build a dense array indexed by component id: divergence_expect installs
+     * sums[i] for component i. Components not in the journal stay 0; only
+     * registered components are ever checked, so unused slots do not matter. */
+    uint32_t dense[DIVERGE_MAX_COMPONENTS];
+    for (uint32_t i = 0; i < DIVERGE_MAX_COMPONENTS; i++) dense[i] = 0;
+    uint32_t span = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        if (ids[i] >= DIVERGE_MAX_COMPONENTS) continue;
+        dense[ids[i]] = sums[i];
+        if (ids[i] + 1 > span) span = ids[i] + 1;
+    }
+    return kdiverge_expect(epoch, dense, span);
+}
+
+bool kdiverge_check_epoch(void) {
+    return diverge_scan_check(g_sources, g_nsources, kdiverge_check);
+}

--- a/kernel/journal_capture.c
+++ b/kernel/journal_capture.c
@@ -71,6 +71,22 @@ int journal_capture_epoch(journal_store_t* store, uint64_t epoch,
         }
     }
 
+    /* 4. Divergence checksums for the epoch boundary (#197): one event per
+     *    component, carrying the component id in lclock and the checksum in
+     *    value, so replay can compare recomputed sums against these. */
+    if (src->divergence_sums) {
+        const uint32_t* ids = NULL;
+        const uint32_t* sums = NULL;
+        uint32_t n = src->divergence_sums(&ids, &sums);
+        for (uint32_t i = 0; i < n && ids && sums; i++) {
+            rc = journal_writer_append(&writer, JOURNAL_EV_DIVERGE,
+                                       ids[i], sums[i]);
+            if (rc != JOURNAL_OK) {
+                return rc;
+            }
+        }
+    }
+
     /* Commit: the journal store flips its superblock, atomically publishing
      * this epoch's journal next to the checkpoint that closed the epoch. */
     return journal_store_commit(&writer);

--- a/kernel/journal_capture_sync.c
+++ b/kernel/journal_capture_sync.c
@@ -9,10 +9,11 @@
  */
 
 #include "journal_capture.h"
-#include "scheduler.h"       /* scheduler_preempt_points */
-#include "time_record.h"     /* ktime_values */
-#include "entropy_record.h"  /* kentropy_bytes */
-#include "checkpoint.h"      /* checkpoint_set_journal_hook */
+#include "scheduler.h"        /* scheduler_preempt_points */
+#include "time_record.h"      /* ktime_values */
+#include "entropy_record.h"   /* kentropy_bytes */
+#include "divergence_scan.h"  /* kdiverge_record_epoch, kdiverge_journal_sums */
+#include "checkpoint.h"       /* checkpoint_set_journal_hook */
 #include <stddef.h>
 
 /* The journal store bound to the persistence device (caller-allocated storage
@@ -23,9 +24,10 @@ static bool            g_journal_ready = false;
 /* Live delta sources: the record-subsystem accessors, each returning the
  * current epoch's captured buffer. */
 static const journal_capture_sources_t g_live_sources = {
-    .preempt_points = scheduler_preempt_points,
-    .time_values    = ktime_values,
-    .entropy_bytes  = kentropy_bytes,
+    .preempt_points  = scheduler_preempt_points,
+    .time_values     = ktime_values,
+    .entropy_bytes   = kentropy_bytes,
+    .divergence_sums = kdiverge_journal_sums,
 };
 
 /* Checkpoint post-commit hook: journal the epoch that just committed. Runs
@@ -35,6 +37,9 @@ static int journal_capture_hook(uint64_t epoch) {
     if (!g_journal_ready) {
         return JOURNAL_ERR_STATE;
     }
+    /* Checksum the restored components at this epoch boundary in RECORD mode
+     * (#197) so their sums ride in the journal alongside the input deltas. */
+    kdiverge_record_epoch(epoch);
     return journal_capture_epoch(&g_journal_store, epoch, 0, &g_live_sources);
 }
 

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -31,6 +31,8 @@
 #include "../include/entropy_record.h"
 #include "../include/journal_capture.h"
 #include "../include/keyframe_store.h"
+#include "../include/divergence.h"
+#include "../include/divergence_scan.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -288,6 +290,14 @@ void kernel_init(void) {
         } else {
             kernel_print("Keyframe retention disabled (no keyframe store)\n");
         }
+
+        /* Arm the divergence detector (#197): checksum the restored components
+         * (process table, scheduler, ...) at each epoch boundary. The sums ride
+         * in the journal on the record run and are compared on replay, so a
+         * nondeterminism leak the wrappers missed is caught at the exact epoch
+         * and component. Kept armed; the journal hook records, replay compares. */
+        kdiverge_init();
+        kdiverge_register_kernel_sources();
     } else {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
     }

--- a/kernel/replay_driver_sync.c
+++ b/kernel/replay_driver_sync.c
@@ -10,9 +10,11 @@
 
 #include "replay_driver.h"
 #include "replay_engine.h"       /* replay_enter/exit, replay_load_subsystems */
-#include "journal_capture.h"     /* journal_capture_store */
+#include "journal_capture.h"     /* journal_capture_store, JOURNAL_EV_DIVERGE */
 #include "checkpoint_journal.h"  /* journal_reader_t, journal_reader_next */
 #include "keyframe_store.h"      /* keyframe_store_get, keyframe_store_region_for */
+#include "divergence.h"          /* kdiverge_set_mode, kdiverge_ok */
+#include "divergence_scan.h"     /* kdiverge_expect_pairs, kdiverge_check_epoch */
 #include "checkpoint.h"          /* checkpoint_restore_boot */
 #include "scheduler.h"           /* scheduler_tick */
 #include <stddef.h>
@@ -77,6 +79,54 @@ static int drv_drive_steps(void* ctx, uint64_t epoch, uint64_t steps) {
     return 0;
 }
 
+/* ---- Divergence check at the epoch boundary (#197) ----
+ * load_epoch runs with the live state == the start of `epoch` (right after the
+ * restore or the previous epoch's re-drive), which is exactly the point whose
+ * component checksums were recorded. Read that epoch's recorded sums from the
+ * journal, install them as expected, and compare the recomputed sums. */
+
+#define REPLAY_DIV_MAX KDIVERGE_COMPONENT_COUNT
+
+static void replay_divergence_check(uint64_t epoch) {
+    journal_store_t* js = journal_capture_store();
+    if (!js) return;
+    journal_reader_t rd;
+    if (journal_store_load(js, &rd) != JOURNAL_OK) return;
+    if (rd.epoch != epoch) return; /* that epoch's journal not retained */
+
+    uint32_t ids[REPLAY_DIV_MAX];
+    uint32_t sums[REPLAY_DIV_MAX];
+    uint32_t n = 0;
+    journal_event_t ev;
+    while (journal_reader_next(&rd, &ev) == JOURNAL_OK) {
+        if (ev.type != JOURNAL_EV_DIVERGE) continue;
+        if (n >= REPLAY_DIV_MAX) break;
+        ids[n] = (uint32_t)ev.lclock;   /* component id rides in lclock */
+        sums[n] = (uint32_t)ev.value;   /* checksum rides in value */
+        n++;
+    }
+    if (n == 0) return; /* no divergence sums recorded for this epoch */
+
+    kdiverge_expect_pairs(epoch, ids, sums, n);
+    kdiverge_check_epoch(); /* recompute + compare; detector keeps first leak */
+}
+
+/* load_subsystems wrapper: divergence-check this epoch's starting state, then
+ * install the epoch's input deltas for re-drive. */
+static int drv_load_subsystems(uint64_t epoch,
+                               const uint64_t* pts, uint32_t n_pts,
+                               const uint64_t* times, uint32_t n_times,
+                               const uint8_t* entropy, uint32_t n_entropy) {
+    replay_divergence_check(epoch);
+#ifdef IKOS_DEBUG
+    /* In debug builds a divergence halts replay at the exact epoch/component:
+     * the detector recorded which, and returning an error aborts replay_run. */
+    if (!kdiverge_ok()) return REPLAY_ERR_LOAD;
+#endif
+    return replay_load_subsystems(epoch, pts, n_pts, times, n_times,
+                                  entropy, n_entropy);
+}
+
 int replay_to(uint64_t target_epoch, uint64_t target_offset) {
     keyframe_store_t* ks = keyframe_store_get();
     if (!ks) return REPLAY_ERR_RESTORE;
@@ -91,13 +141,15 @@ int replay_to(uint64_t target_epoch, uint64_t target_offset) {
     g_driver.source.begin_epoch = src_begin_epoch;
     g_driver.source.next = src_next;
     g_driver.source.ctx = NULL;
-    g_driver.load_subsystems = replay_load_subsystems;
+    g_driver.load_subsystems = drv_load_subsystems;
     g_driver.drive_steps = drv_drive_steps;
     g_driver.ctx = NULL;
 
-    replay_enter(); /* the three wrappers to REPLAY */
+    replay_enter();                    /* the three wrappers to REPLAY */
+    kdiverge_set_mode(DIVERGE_REPLAY); /* compare component checksums (#197) */
     int rc = replay_driver_run(&g_driver, keyframe_epoch, target_epoch,
                                target_offset);
-    replay_exit();  /* back to OFF */
+    kdiverge_set_mode(DIVERGE_OFF);
+    replay_exit();                     /* back to OFF */
     return rc;
 }

--- a/tests/test_divergence_scan.c
+++ b/tests/test_divergence_scan.c
@@ -1,0 +1,114 @@
+/* Host-side unit test for the divergence component scan (#197).
+ *
+ * Drives the record -> journal -> replay round trip with mock component sources
+ * and the real pure cores (divergence_scan + divergence), verifying:
+ *   1. A record scan checksums every component and yields (id, sum) pairs.
+ *   2. Those pairs round-trip through the JOURNAL_EV_DIVERGE encoding (component
+ *      id in lclock, checksum in value) and install as the expected sums.
+ *   3. A replay scan of the SAME state matches every component (no divergence).
+ *   4. A replay scan of CHANGED state is caught, with the detector reporting the
+ *      exact epoch and diverging component.
+ *
+ * Build: gcc -I../include -o test_divergence_scan \
+ *            test_divergence_scan.c ../kernel/divergence_scan.c \
+ *            ../kernel/divergence.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "divergence_scan.h"
+#include "divergence.h"
+
+extern int printf(const char*, ...);
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* Component ids (mirror KDIVERGE_*). */
+enum { C_PROC = 0, C_SCHED = 1, C_PAGES = 2, NCOMP = 3 };
+
+/* Mock component state: each source checksums a byte the test can mutate. */
+static uint8_t g_state[NCOMP];
+
+static uint32_t src_proc(void* ctx)  { (void)ctx; return divergence_checksum(0, &g_state[C_PROC],  1); }
+static uint32_t src_sched(void* ctx) { (void)ctx; return divergence_checksum(0, &g_state[C_SCHED], 1); }
+static uint32_t src_pages(void* ctx) { (void)ctx; return divergence_checksum(0, &g_state[C_PAGES], 1); }
+
+/* A local detector wired through free-function sinks (mirrors kdiverge_*). */
+static divergence_t g_det;
+static int  det_record(uint32_t comp, uint32_t sum) { return divergence_record(&g_det, comp, sum); }
+static bool det_check(uint32_t comp, uint32_t sum)  { return divergence_check(&g_det, comp, sum); }
+
+/* Dense-expect from (id, sum) pairs, as the kernel adapter does. */
+static void expect_pairs(uint64_t epoch, const uint32_t* ids,
+                         const uint32_t* sums, uint32_t n) {
+    uint32_t dense[DIVERGE_MAX_COMPONENTS];
+    for (uint32_t i = 0; i < DIVERGE_MAX_COMPONENTS; i++) dense[i] = 0;
+    uint32_t span = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        dense[ids[i]] = sums[i];
+        if (ids[i] + 1 > span) span = ids[i] + 1;
+    }
+    divergence_expect(&g_det, epoch, dense, span);
+}
+
+int main(void) {
+    printf("test_divergence_scan\n");
+
+    diverge_source_t srcs[NCOMP] = {
+        { C_PROC,  src_proc,  0 },
+        { C_SCHED, src_sched, 0 },
+        { C_PAGES, src_pages, 0 },
+    };
+
+    /* Some starting state. */
+    g_state[C_PROC] = 0x11; g_state[C_SCHED] = 0x22; g_state[C_PAGES] = 0x33;
+
+    /* --- 1: record scan --- */
+    divergence_init(&g_det, DIVERGE_RECORD);
+    divergence_begin_epoch(&g_det, 42);
+    uint32_t ids[NCOMP], sums[NCOMP];
+    uint32_t n = diverge_scan_record(srcs, NCOMP, det_record, ids, sums);
+    CHECK(n == 3, "record scan covered all 3 components");
+    CHECK(ids[0] == C_PROC && ids[1] == C_SCHED && ids[2] == C_PAGES,
+          "component ids in registration order");
+
+    /* --- 2: encode as JOURNAL_EV_DIVERGE (id in lclock, sum in value) and
+     * decode back, as the journal + replay path do --- */
+    uint64_t ev_lclock[NCOMP], ev_value[NCOMP];
+    for (uint32_t i = 0; i < n; i++) { ev_lclock[i] = ids[i]; ev_value[i] = sums[i]; }
+    uint32_t dids[NCOMP], dsums[NCOMP];
+    for (uint32_t i = 0; i < n; i++) { dids[i] = (uint32_t)ev_lclock[i]; dsums[i] = (uint32_t)ev_value[i]; }
+
+    /* --- 3: replay scan of identical state matches --- */
+    divergence_init(&g_det, DIVERGE_REPLAY);
+    expect_pairs(42, dids, dsums, n);
+    bool ok = diverge_scan_check(srcs, NCOMP, det_check);
+    CHECK(ok, "replay of identical state: all components match");
+    CHECK(!divergence_has_diverged(&g_det), "no divergence recorded");
+
+    /* --- 4: mutate one component's state; replay catches it --- */
+    divergence_init(&g_det, DIVERGE_REPLAY);
+    expect_pairs(42, dids, dsums, n);
+    g_state[C_SCHED] = 0xEE; /* the scheduler component now differs */
+    ok = diverge_scan_check(srcs, NCOMP, det_check);
+    CHECK(!ok, "replay of changed state: scan reports a mismatch");
+    CHECK(divergence_has_diverged(&g_det), "divergence recorded");
+    CHECK(g_det.diverged_epoch == 42, "divergence reported at the right epoch");
+    CHECK(g_det.diverged_component == C_SCHED, "divergence pinned to the scheduler component");
+
+    /* The unchanged components still match (only C_SCHED diverged). */
+    g_state[C_SCHED] = 0x22; /* restore */
+    divergence_init(&g_det, DIVERGE_REPLAY);
+    expect_pairs(42, dids, dsums, n);
+    CHECK(diverge_scan_check(srcs, NCOMP, det_check),
+          "restoring the component clears the divergence");
+
+    printf("%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Feed the divergence detector (#166) real per-component checksums at each epoch
boundary. On a record run each restored component (process table, scheduler,
...) is checksummed and the sums ride in the input journal; on replay the
recorded sums are installed as expected and the recomputed ones compared, so a
nondeterminism leak the wrappers missed halts at the exact epoch and component.

## How

- **`kernel/divergence_scan.c` / `include/divergence_scan.h` (pure core)** —
  `diverge_scan_record` checksums each registered component through an injected
  source and hands the `(id, sum)` pairs to a record sink; `diverge_scan_check`
  recomputes and compares them. Sources and sinks are injected, so the whole
  record → journal → replay round trip is host-testable.
- **`kernel/divergence_scan_sync.c` (kernel adapter)** — a registry of live
  component sources (process table and scheduler order wired now over stable
  process-manager accessors; more register as subsystems expose deterministic
  snapshots) plus:
  - `kdiverge_record_epoch(epoch)` — RECORD-mode scan, `kdiverge_record` each
    component, stash the sums for journaling.
  - `kdiverge_expect_pairs` / `kdiverge_check_epoch` — install the recorded sums
    (dense by component id) and compare the recomputed ones on replay.
- **Journal (#194)** — new `JOURNAL_EV_DIVERGE` event carries each component's
  checksum (id in `lclock`, sum in `value`). `journal_capture_sources_t` gains a
  divergence source and `journal_capture_epoch` appends the sums; the capture
  hook runs the RECORD scan first, so the sums ride in each epoch's journal.
- **Replay (#196)** — at each epoch boundary the `load_subsystems` wrapper reads
  that epoch's recorded divergence sums from the journal, installs them as
  expected, and compares the recomputed component checksums. `replay_to` puts
  the detector in `DIVERGE_REPLAY`; in debug builds (`IKOS_DEBUG`) a divergence
  returns an error that aborts `replay_run` at the exact epoch/component.
- **`kernel/kernel_main.c`** — `kdiverge_init()` + `kdiverge_register_kernel_sources()`
  at boot.

## Acceptance criteria

- [x] Each component is checksummed per epoch on record and replay (scan over registered sources; RECORD via `kdiverge_record`, REPLAY via `kdiverge_check`).
- [x] Recorded checksums ride in the journal (`JOURNAL_EV_DIVERGE`, appended by `journal_capture_epoch`).
- [x] A debug-build replay asserts on divergence with the epoch and component (the detector keeps the first leak's epoch/component; `IKOS_DEBUG` returns an error that halts replay).

## Verification

- New host unit test `tests/test_divergence_scan.c` — passes: record scan covers
  all components, the `JOURNAL_EV_DIVERGE` (id-in-lclock / sum-in-value) round
  trip installs the expected sums, a clean replay matches, and a mutated
  component is caught with the reported epoch and component.
- `test_journal_capture` and `test_replay_driver` still pass after the additive
  `journal_capture_sources_t` field and the replay load wrapper.
- Freestanding `-Wall -Wextra` syntax checks clean for `divergence_scan.c`,
  `divergence_scan_sync.c`, `journal_capture.c`, `journal_capture_sync.c`,
  `replay_driver_sync.c`; `kernel_main.c` parses with no errors referencing the
  change.
- CI wired: trigger paths, freestanding checks, and the unit test added to
  `.github/workflows/persistence.yml`; architecture module map updated.

Closes #197