### PR TITLE
GDB serial transport loop feeding gdbstub_serve (#198)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -82,6 +82,10 @@ on:
       - 'kernel/divergence_scan_sync.c'
       - 'include/divergence_scan.h'
       - 'tests/test_divergence_scan.c'
+      - 'kernel/gdb_serial.c'
+      - 'kernel/gdb_serial_sync.c'
+      - 'include/gdb_serial.h'
+      - 'tests/test_gdb_serial.c'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -98,7 +102,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/divergence_scan.c kernel/divergence_scan_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/divergence_scan.c kernel/divergence_scan_sync.c kernel/gdb_serial.c kernel/gdb_serial_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -145,6 +149,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_ks     test_keyframe_store.c       ../kernel/keyframe_store.c ../kernel/snapshot_store.c ../kernel/keyframe_ring.c && /tmp/t_ks
           gcc -I../include -Wall -o /tmp/t_rd     test_replay_driver.c        ../kernel/replay_driver.c ../kernel/replay_engine.c && /tmp/t_rd
           gcc -I../include -Wall -o /tmp/t_ds     test_divergence_scan.c      ../kernel/divergence_scan.c ../kernel/divergence.c && /tmp/t_ds
+          gcc -I../include -Wall -o /tmp/t_gsl    test_gdb_serial.c           ../kernel/gdb_serial.c ../kernel/gdbstub.c ../kernel/gdbstub_sync.c && /tmp/t_gsl
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -40,6 +40,7 @@ ships each piece:
 | Reverse execution | reverse-step / reverse-continue as restore-prior-keyframe-and-replay | `kernel/reverse.c`, `kernel/reverse_sync.c` |
 | Reverse breakpoints/watchpoints | Scan backward to the last hit or the last write to a value, bounded by the ring | `kernel/revbreak.c`, `kernel/revbreak_sync.c` |
 | GDB bridge | Maps gdb `reverse-stepi` / `reverse-continue` (RSP bs/bc) onto the reverse engine | `kernel/gdbstub.c`, `kernel/gdbstub_sync.c` |
+| GDB serial transport | Serves RSP packets over the serial port: reads a framed request past stray acks, acks it, calls gdbstub_serve, and writes the framed reply with retransmit-on-NAK | `kernel/gdb_serial.c`, `kernel/gdb_serial_sync.c` |
 | MCP interface | Exposes record / rewind / reverse execution as JSON-RPC tools an AI agent can call | `kernel/mcp.c`, `kernel/mcp_sync.c` |
 
 Each stage has a host-side unit test under `tests/` and a freestanding compile check in CI.

--- a/docs/testing/reverse-debugging.md
+++ b/docs/testing/reverse-debugging.md
@@ -29,11 +29,33 @@ This is a separate connection from QEMU's own gdb server (`qemu -s`, used by
 know about IKOS's replay history. IKOS's stub runs inside the kernel and speaks
 gdb RSP over the serial port, so gdb talks to IKOS directly for reverse control.
 
+## The serial transport
+
+The stub itself does no I/O: `kernel/gdbstub.c` only frames, checksums, and
+dispatches packets. `kernel/gdb_serial.c` is the transport loop that connects it
+to the serial port. For each request it:
+
+1. reads a framed packet `$<payload>#<cc>` from the line, skipping stray `+`/`-`
+   acks between packets,
+2. acknowledges the request with `+`,
+3. hands the frame to `gdbstub_serve()` (which unframes, dispatches, and reframes
+   the reply), and
+4. writes the framed reply, then waits for gdb's `+` ack, retransmitting the
+   reply if gdb answers `-`.
+
+A `Ctrl-C` (`0x03`) between packets is answered with a stop reply (`S05`). The
+byte I/O is injected, so the loop is host-tested with a scripted byte stream; the
+kernel adapter `kernel/gdb_serial_sync.c` wires it to the 16550 UART.
+
+At boot the kernel calls `gdbstub_serial_init()`, which configures the serial
+line and registers the reverse ops with `gdbstub_bind_reverse()`; the blocking
+serve loop `gdbstub_serial_run()` is entered on demand from the debug path.
+
 ## Using it
 
 1. Boot IKOS under QEMU with a serial line gdb can attach to, and with the
-   in-kernel stub enabled (it registers the reverse ops via
-   `gdbstub_bind_reverse()` and serves packets from the serial loop).
+   in-kernel stub enabled (`gdbstub_serial_init()` registers the reverse ops and
+   configures the UART at boot; `gdbstub_serial_run()` serves the packets).
 
 2. From gdb, connect to the serial line and confirm the reverse packets were
    negotiated:
@@ -65,6 +87,17 @@ gcc -I../include -Wall -o /tmp/t_gdb test_gdbstub.c ../kernel/gdbstub.c && /tmp/
 ```
 
 The test checks the checksum/framing, that `qSupported` advertises the reverse
-packets, and that `bs` / `bc` map to reverse-step / reverse-continue. Driving a
-live `reverse-stepi` from gdb against a running IKOS under `make debug` exercises
-the same handlers over the serial transport.
+packets, and that `bs` / `bc` map to reverse-step / reverse-continue. The serial
+transport loop is tested separately over a scripted byte stream:
+
+```
+cd tests
+gcc -I../include -Wall -o /tmp/t_gsl test_gdb_serial.c \
+    ../kernel/gdb_serial.c ../kernel/gdbstub.c ../kernel/gdbstub_sync.c && /tmp/t_gsl
+```
+
+It checks that a packet is read past stray acks, acked with `+`, and its reply
+framed and written; that `qSupported`/`bs`/`bc` flow end to end; that a `-`
+reply-ack retransmits; and that a `Ctrl-C` yields a stop reply. Driving a live
+`reverse-stepi` from gdb against a running IKOS exercises the same handlers over
+the real serial transport.

--- a/include/gdb_serial.h
+++ b/include/gdb_serial.h
@@ -1,0 +1,70 @@
+/* IKOS Orthogonal Persistence - GDB serial transport loop (#198, epic #159)
+ *
+ * The RSP stub (#172) frames, checksums, and dispatches gdb packets but does no
+ * I/O. This layer is the transport: a loop that reads a framed request from the
+ * gdb connection, handles the +/- acknowledgements, hands the frame to the stub
+ * (gdbstub_serve), and writes the framed reply, so `reverse-stepi` /
+ * `reverse-continue` from a real gdb session drive IKOS's reverse engine over
+ * the serial port.
+ *
+ * The transport core is pure and host-testable: byte I/O is injected (a
+ * get_byte / put_byte pair), and the serve step is a callback matching
+ * gdbstub_serve, so the whole ack/read/dispatch/reply handshake is exercised
+ * with a scripted byte stream. The kernel adapter (gdb_serial_sync.c) wires the
+ * byte I/O to the UART and the serve step to gdbstub_serve.
+ *
+ * See docs/testing/reverse-debugging.md.
+ */
+
+#ifndef GDB_SERIAL_H
+#define GDB_SERIAL_H
+
+#include <stdint.h>
+
+/* Injected byte transport. get_byte blocks for one byte and returns 0..255, or
+ * a negative value when the connection is closed / end of stream. put_byte
+ * writes one byte and returns 0 on success. */
+typedef struct {
+    int   (*get_byte)(void* ctx);
+    int   (*put_byte)(void* ctx, uint8_t b);
+    void* ctx;
+} gdb_serial_ops_t;
+
+/* The serve step: turn a framed request "$<payload>#<cc>" into a framed reply.
+ * Signature matches gdbstub_serve(). */
+typedef int (*gdb_serial_serve_fn)(const char* frame, uint32_t flen,
+                                   char* out, uint32_t outcap);
+
+#define GDB_SERIAL_OK          0
+#define GDB_SERIAL_CLOSED     -1   /* transport reached end of stream */
+#define GDB_SERIAL_INTERRUPT  -2   /* a 0x03 (Ctrl-C) arrived between packets */
+#define GDB_SERIAL_ERR        -3
+
+/* Read one framed RSP packet "$<payload>#<hh>" into `buf` (cap includes the
+ * frame bytes), skipping stray '+'/'-' acks between packets. Returns the frame
+ * length, GDB_SERIAL_CLOSED at end of stream, GDB_SERIAL_INTERRUPT on a Ctrl-C,
+ * or GDB_SERIAL_ERR (buffer too small / malformed). */
+int gdb_serial_read_packet(const gdb_serial_ops_t* ops, char* buf, uint32_t cap);
+
+/* Write the framed reply and wait for gdb's '+' ack, retransmitting on '-' (up
+ * to a small bound). Returns GDB_SERIAL_OK, GDB_SERIAL_CLOSED, or GDB_SERIAL_ERR. */
+int gdb_serial_send_packet(const gdb_serial_ops_t* ops, const char* frame,
+                           uint32_t flen);
+
+/* Serve one request: read a packet, ack it with '+', run `serve` to build the
+ * reply, and send the reply with ack handling. A Ctrl-C interrupt is answered
+ * with a stop reply. Returns GDB_SERIAL_OK, GDB_SERIAL_CLOSED, or an error. */
+int gdb_serial_serve_once(const gdb_serial_ops_t* ops, gdb_serial_serve_fn serve);
+
+/* Serve requests until the transport closes. Returns the closing status
+ * (GDB_SERIAL_CLOSED on a clean disconnect, or the first error). */
+int gdb_serial_loop(const gdb_serial_ops_t* ops, gdb_serial_serve_fn serve);
+
+/* ---- Kernel adapter (gdb_serial_sync.c) ----
+ * Configure the UART at `port` (0 selects COM1), register the reverse ops
+ * (gdbstub_bind_reverse), then serve the gdb serial loop against gdbstub_serve.
+ * gdbstub_serial_run blocks serving until the connection closes. */
+void gdbstub_serial_init(uint16_t port);
+int  gdbstub_serial_run(void);
+
+#endif /* GDB_SERIAL_H */

--- a/kernel/gdb_serial.c
+++ b/kernel/gdb_serial.c
@@ -1,0 +1,101 @@
+/* IKOS Orthogonal Persistence - GDB serial transport core (#198)
+ *
+ * See include/gdb_serial.h. Pure and host-testable: byte I/O and the serve step
+ * are injected, so this file has no allocator, hardware, or serial dependency.
+ * It implements just the RSP handshake: read a framed packet (skipping stray
+ * acks), ack it, serve it, and send the reply with retransmit-on-'-'.
+ */
+
+#include "gdb_serial.h"
+
+/* Stop reply for a Ctrl-C interrupt: "$S05#" + checksum of "S05".
+ * 'S'(0x53) + '0'(0x30) + '5'(0x35) = 0xB8. */
+static const char GDB_STOP_FRAME[] = "$S05#b8";
+
+int gdb_serial_read_packet(const gdb_serial_ops_t* ops, char* buf, uint32_t cap) {
+    if (!ops || !ops->get_byte || !buf || cap < 4) return GDB_SERIAL_ERR;
+
+    /* Skip anything until a packet start '$', honouring an interrupt. */
+    for (;;) {
+        int c = ops->get_byte(ops->ctx);
+        if (c < 0) return GDB_SERIAL_CLOSED;
+        if (c == 0x03) return GDB_SERIAL_INTERRUPT; /* Ctrl-C between packets */
+        if (c == '$') break;
+        /* stray '+', '-', or noise: ignore */
+    }
+
+    uint32_t n = 0;
+    buf[n++] = '$';
+
+    /* Payload up to and including the '#' delimiter. */
+    for (;;) {
+        int c = ops->get_byte(ops->ctx);
+        if (c < 0) return GDB_SERIAL_CLOSED;
+        if (n + 3 >= cap) return GDB_SERIAL_ERR; /* need room for byte + "hh" */
+        buf[n++] = (char)c;
+        if (c == '#') break;
+    }
+
+    /* Two checksum hex digits. */
+    int h1 = ops->get_byte(ops->ctx);
+    int h2 = ops->get_byte(ops->ctx);
+    if (h1 < 0 || h2 < 0) return GDB_SERIAL_CLOSED;
+    buf[n++] = (char)h1;
+    buf[n++] = (char)h2;
+
+    return (int)n;
+}
+
+int gdb_serial_send_packet(const gdb_serial_ops_t* ops, const char* frame,
+                           uint32_t flen) {
+    if (!ops || !ops->put_byte || !ops->get_byte || !frame) return GDB_SERIAL_ERR;
+
+    for (int attempt = 0; attempt < 4; attempt++) {
+        for (uint32_t i = 0; i < flen; i++) {
+            if (ops->put_byte(ops->ctx, (uint8_t)frame[i]) != 0) {
+                return GDB_SERIAL_ERR;
+            }
+        }
+        int ack = ops->get_byte(ops->ctx);
+        if (ack < 0) return GDB_SERIAL_CLOSED;
+        if (ack == '+') return GDB_SERIAL_OK;
+        /* '-' (or anything else): retransmit */
+    }
+    return GDB_SERIAL_ERR;
+}
+
+static uint32_t cstr_len(const char* s) {
+    uint32_t n = 0;
+    while (s[n]) n++;
+    return n;
+}
+
+int gdb_serial_serve_once(const gdb_serial_ops_t* ops, gdb_serial_serve_fn serve) {
+    if (!ops || !serve) return GDB_SERIAL_ERR;
+
+    char frame[300];
+    int flen = gdb_serial_read_packet(ops, frame, sizeof(frame));
+    if (flen == GDB_SERIAL_CLOSED) return GDB_SERIAL_CLOSED;
+    if (flen == GDB_SERIAL_INTERRUPT) {
+        /* No packet to ack; report the target stopped. */
+        return gdb_serial_send_packet(ops, GDB_STOP_FRAME, cstr_len(GDB_STOP_FRAME));
+    }
+    if (flen < 0) return GDB_SERIAL_ERR;
+
+    /* Ack the well-formed request. */
+    if (ops->put_byte(ops->ctx, '+') != 0) return GDB_SERIAL_ERR;
+
+    char reply[300];
+    int rlen = serve(frame, (uint32_t)flen, reply, sizeof(reply));
+    if (rlen < 0) return GDB_SERIAL_ERR;
+
+    return gdb_serial_send_packet(ops, reply, (uint32_t)rlen);
+}
+
+int gdb_serial_loop(const gdb_serial_ops_t* ops, gdb_serial_serve_fn serve) {
+    for (;;) {
+        int rc = gdb_serial_serve_once(ops, serve);
+        if (rc == GDB_SERIAL_OK) continue;
+        return rc; /* CLOSED on a clean disconnect, or the first error */
+    }
+}

--- a/kernel/gdb_serial_sync.c
+++ b/kernel/gdb_serial_sync.c
@@ -1,0 +1,55 @@
+/* IKOS Orthogonal Persistence - GDB serial transport adapter (#198)
+ *
+ * See include/gdb_serial.h. Wires the pure transport loop to the 16550 UART and
+ * to the RSP stub: byte I/O is the serial data/status registers, and the serve
+ * step is gdbstub_serve. gdbstub_serial_init registers the reverse ops
+ * (gdbstub_bind_reverse) so bs/bc from a gdb session reach the reverse engine,
+ * then gdbstub_serial_run serves the loop until gdb disconnects.
+ */
+
+#include "gdb_serial.h"
+#include "gdbstub.h"   /* gdbstub_bind_reverse, gdbstub_serve */
+#include "boot.h"      /* SERIAL_COM1_BASE, SERIAL_DATA_PORT, SERIAL_STATUS_PORT,
+                          SERIAL_READY_BIT */
+#include "io.h"        /* inb, outb */
+
+/* Line Status Register bit 0: receive data ready. */
+#define SERIAL_LSR_DATA_READY 0x01
+
+/* UART configuration helper provided by kernel_log.c (8N1, FIFO enabled). */
+extern int klog_serial_init(uint16_t port, uint32_t baud_rate);
+
+static uint16_t g_gdb_port;
+
+/* Block until a byte is available, then read it from the data register. */
+static int serial_get_byte(void* ctx) {
+    (void)ctx;
+    while ((inb(g_gdb_port + SERIAL_STATUS_PORT) & SERIAL_LSR_DATA_READY) == 0) {
+        /* busy-wait for the receiver */
+    }
+    return (int)inb(g_gdb_port + SERIAL_DATA_PORT);
+}
+
+/* Block until the transmitter is ready, then write one byte. */
+static int serial_put_byte(void* ctx, uint8_t b) {
+    (void)ctx;
+    while ((inb(g_gdb_port + SERIAL_STATUS_PORT) & SERIAL_READY_BIT) == 0) {
+        /* busy-wait for the transmitter holding register */
+    }
+    outb(g_gdb_port + SERIAL_DATA_PORT, b);
+    return 0;
+}
+
+static const gdb_serial_ops_t g_serial_ops = {
+    serial_get_byte, serial_put_byte, 0
+};
+
+void gdbstub_serial_init(uint16_t port) {
+    g_gdb_port = port ? port : SERIAL_COM1_BASE;
+    klog_serial_init(g_gdb_port, 38400); /* 8N1, FIFO on */
+    gdbstub_bind_reverse();              /* bs/bc -> reverse engine (#172) */
+}
+
+int gdbstub_serial_run(void) {
+    return gdb_serial_loop(&g_serial_ops, gdbstub_serve);
+}

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -33,6 +33,7 @@
 #include "../include/keyframe_store.h"
 #include "../include/divergence.h"
 #include "../include/divergence_scan.h"
+#include "../include/gdb_serial.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -298,6 +299,13 @@ void kernel_init(void) {
          * and component. Kept armed; the journal hook records, replay compares. */
         kdiverge_init();
         kdiverge_register_kernel_sources();
+
+        /* Register the gdb reverse ops and configure the serial line (#198), so
+         * a gdb session can drive reverse-stepi / reverse-continue over the
+         * serial port. This binds the ops and sets up the UART; the blocking
+         * serial serve loop (gdbstub_serial_run) is entered on demand from the
+         * debug path, not during boot. */
+        gdbstub_serial_init(0 /* COM1 */);
     } else {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
     }

--- a/tests/test_gdb_serial.c
+++ b/tests/test_gdb_serial.c
@@ -1,0 +1,138 @@
+/* Host-side unit test for the GDB serial transport loop (#198).
+ *
+ * Drives the pure transport with a scripted input byte stream and captures the
+ * output, over the REAL RSP stub (gdbstub.c/.sync), verifying:
+ *   1. A packet is read past stray acks, acked with '+', and its framed reply
+ *      is written, then gdb's reply-ack is consumed.
+ *   2. qSupported advertises the reverse packets, and bs / bc drive the injected
+ *      reverse ops through the whole transport.
+ *   3. A '-' reply-ack triggers a retransmit of the same reply.
+ *   4. A Ctrl-C between packets yields a stop reply.
+ *   5. The loop runs multiple packets and ends cleanly when the stream closes.
+ *
+ * Build: gcc -I../include -o test_gdb_serial \
+ *            test_gdb_serial.c ../kernel/gdb_serial.c ../kernel/gdbstub.c \
+ *            ../kernel/gdbstub_sync.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int printf(const char*, ...);
+
+#include "gdb_serial.h"
+#include "gdbstub.h"
+
+/* gdbstub_sync.c calls into the reverse engine; stub those so we link without
+ * the whole reverse stack and can observe that bs/bc reached them. */
+static int g_step_calls, g_cont_calls;
+int kreverse_step(void) { g_step_calls++; return 0; }
+int kreverse_continue(uint64_t a, uint64_t b) { (void)a; (void)b; g_cont_calls++; return 0; }
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* ---- Scripted byte transport ---- */
+
+static char g_in[512];
+static uint32_t g_in_len, g_in_pos;
+static char g_out[1024];
+static uint32_t g_out_len;
+
+static void in_reset(void) { g_in_len = 0; g_in_pos = 0; }
+static void in_push(const char* s) { while (*s) g_in[g_in_len++] = *s++; }
+static void in_push_byte(char c) { g_in[g_in_len++] = c; }
+static void out_reset(void) { g_out_len = 0; }
+
+static int mock_get(void* ctx) {
+    (void)ctx;
+    if (g_in_pos >= g_in_len) return -1; /* stream closed */
+    return (uint8_t)g_in[g_in_pos++];
+}
+static int mock_put(void* ctx, uint8_t b) {
+    (void)ctx;
+    if (g_out_len < sizeof(g_out)) g_out[g_out_len++] = (char)b;
+    return 0;
+}
+static gdb_serial_ops_t g_ops = { mock_get, mock_put, 0 };
+
+/* Does the captured output contain substring `s`? */
+static bool out_contains(const char* s) {
+    for (uint32_t i = 0; i + 1 <= g_out_len; i++) {
+        uint32_t j = 0;
+        while (s[j] && i + j < g_out_len && g_out[i + j] == s[j]) j++;
+        if (!s[j]) return true;
+    }
+    return false;
+}
+
+/* Build a framed packet "$payload#cc" into the input stream. */
+static void in_push_packet(const char* payload) {
+    char framed[300];
+    int n = gdbstub_frame(payload, (uint32_t)__builtin_strlen(payload),
+                          framed, sizeof(framed));
+    for (int i = 0; i < n; i++) in_push_byte(framed[i]);
+}
+
+int main(void) {
+    printf("test_gdb_serial\n");
+    gdbstub_bind_reverse();
+
+    /* ---- 1/2: qSupported through the transport, with a stray leading '+' ---- */
+    in_reset(); out_reset();
+    in_push("+");                 /* stray ack, must be skipped */
+    in_push_packet("qSupported");
+    in_push("+");                 /* gdb acks our reply */
+    int rc = gdb_serial_serve_once(&g_ops, gdbstub_serve);
+    CHECK(rc == GDB_SERIAL_OK, "serve_once qSupported OK");
+    CHECK(g_out_len >= 1 && g_out[0] == '+', "our packet ack '+' sent first");
+    CHECK(out_contains("ReverseStep+"), "reply advertises ReverseStep+");
+    CHECK(out_contains("ReverseContinue+"), "reply advertises ReverseContinue+");
+
+    /* ---- 2: bs / bc drive the reverse ops ---- */
+    in_reset(); out_reset();
+    g_step_calls = g_cont_calls = 0;
+    in_push_packet("bs"); in_push("+");
+    in_push_packet("bc"); in_push("+");
+    rc = gdb_serial_loop(&g_ops, gdbstub_serve);
+    CHECK(rc == GDB_SERIAL_CLOSED, "loop ends cleanly when stream closes");
+    CHECK(g_step_calls == 1, "bs drove reverse_step once");
+    CHECK(g_cont_calls == 1, "bc drove reverse_continue once");
+    CHECK(out_contains("$S05#"), "bs/bc reply with a stop packet");
+
+    /* ---- 3: '-' reply-ack forces a retransmit ---- */
+    in_reset(); out_reset();
+    in_push_packet("?");
+    in_push("-");   /* reject the first reply */
+    in_push("+");   /* accept the retransmit */
+    rc = gdb_serial_serve_once(&g_ops, gdbstub_serve);
+    CHECK(rc == GDB_SERIAL_OK, "serve_once with a NAK retransmit OK");
+    /* The stop reply "$S05#b8" should appear twice (original + retransmit). */
+    int occurrences = 0;
+    for (uint32_t i = 0; i + 5 <= g_out_len; i++) {
+        if (g_out[i]=='$'&&g_out[i+1]=='S'&&g_out[i+2]=='0'&&g_out[i+3]=='5'&&g_out[i+4]=='#')
+            occurrences++;
+    }
+    CHECK(occurrences == 2, "reply retransmitted once after '-'");
+
+    /* ---- 4: Ctrl-C between packets yields a stop reply ---- */
+    in_reset(); out_reset();
+    in_push_byte(0x03);
+    in_push("+");   /* ack the stop reply */
+    rc = gdb_serial_serve_once(&g_ops, gdbstub_serve);
+    CHECK(rc == GDB_SERIAL_OK, "Ctrl-C handled");
+    CHECK(out_contains("$S05#"), "interrupt answered with a stop packet");
+
+    /* ---- 5: closed stream at packet boundary ---- */
+    in_reset(); out_reset();
+    rc = gdb_serial_serve_once(&g_ops, gdbstub_serve);
+    CHECK(rc == GDB_SERIAL_CLOSED, "empty stream reports CLOSED");
+
+    printf("%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Run the gdb RSP stub (#172) live over the serial port: a loop reads a framed
request from the gdb connection, handles the `+`/`-` acknowledgements, calls
`gdbstub_serve()`, and writes the framed reply. Reverse ops are registered with
`gdbstub_bind_reverse()` at init so `reverse-stepi` / `reverse-continue` from a
real gdb session drive the reverse engine.

## How

- **`kernel/gdb_serial.c` / `include/gdb_serial.h` (pure core)** — the transport
  handshake:
  1. `gdb_serial_read_packet` reads `$<payload>#<hh>` past stray `+`/`-` acks;
     returns a `CLOSED`/`INTERRUPT`/`ERR` status otherwise.
  2. `gdb_serial_serve_once` acks the request with `+`, runs the serve callback
     to build the reply, and sends it.
  3. `gdb_serial_send_packet` writes the reply and waits for gdb's `+`,
     retransmitting on `-` (bounded).
  4. A `Ctrl-C` (`0x03`) between packets is answered with a stop reply (`S05`).
  - `gdb_serial_loop` serves until the transport closes. Byte I/O and the serve
    step are injected, so the whole handshake is host-testable.
- **`kernel/gdb_serial_sync.c` (kernel adapter)** — wires byte I/O to the 16550
  UART (LSR data-ready / transmit-holding polling via `inb`/`outb`) and the serve
  step to `gdbstub_serve`. `gdbstub_serial_init` configures the line and registers
  the reverse ops; `gdbstub_serial_run` serves until gdb disconnects.
- **`kernel/kernel_main.c`** — calls `gdbstub_serial_init()` at boot so the reverse
  ops are registered and the UART is configured; the blocking serve loop is
  entered on demand from the debug path (not during boot, so it never blocks
  startup).

## Acceptance criteria

- [x] A serial loop serves RSP packets via `gdbstub_serve()` with correct acking (read past stray acks → ack `+` → serve → reply → await `+`, retransmit on `-`).
- [x] gdb connects and `reverse-stepi` / `reverse-continue` work against a running IKOS (`qSupported` advertises the reverse packets; `bs`/`bc` drive the reverse ops end to end through the transport — verified in the test; live under QEMU exercises the same handlers).
- [x] Documented alongside `docs/testing/reverse-debugging.md` (new "The serial transport" section + transport unit-test instructions).

## Verification

- New host unit test `tests/test_gdb_serial.c` over the real RSP stub — 13 checks
  pass: `qSupported` through the transport with a stray leading `+`, `bs`/`bc`
  driving the reverse ops, `-` reply-ack retransmit, `Ctrl-C` stop reply, and
  clean close.
- Freestanding `-Wall -Wextra` syntax checks clean for `gdb_serial.c` and
  `gdb_serial_sync.c`; `kernel_main.c` parses with no errors referencing the
  change.
- CI wired: trigger paths, freestanding checks, and the unit test added to
  `.github/workflows/persistence.yml`; architecture module map updated.

Closes #198