### PR TITLE
MCP stdio JSON-RPC server loop (#199)

### DIFF
--- a/.github/workflows/persistence.yml
+++ b/.github/workflows/persistence.yml
@@ -86,6 +86,10 @@ on:
       - 'kernel/gdb_serial_sync.c'
       - 'include/gdb_serial.h'
       - 'tests/test_gdb_serial.c'
+      - 'kernel/mcp_server.c'
+      - 'kernel/mcp_server_sync.c'
+      - 'include/mcp_server.h'
+      - 'tests/test_mcp_server.c'
       - '.github/workflows/persistence.yml'
   pull_request:
   workflow_dispatch:
@@ -102,7 +106,7 @@ jobs:
       - name: Freestanding compile check (kernel modules)
         run: |
           set -e
-          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/divergence_scan.c kernel/divergence_scan_sync.c kernel/gdb_serial.c kernel/gdb_serial_sync.c kernel/ramdisk.c; do
+          for f in kernel/checkpoint.c kernel/snapshot_store.c kernel/checkpoint_extstate.c kernel/checkpoint_ide.c kernel/checkpoint_barrier.c kernel/checkpoint_proctable.c kernel/checkpoint_proctable_sync.c kernel/checkpoint_filetable.c kernel/checkpoint_filetable_sync.c kernel/checkpoint_ipc.c kernel/checkpoint_ipc_sync.c kernel/checkpoint_driver.c kernel/checkpoint_disk.c kernel/checkpoint_disk_sync.c kernel/checkpoint_fb.c kernel/checkpoint_fb_sync.c kernel/checkpoint_restore_seq.c kernel/checkpoint_boot_v2.c kernel/checkpoint_journal.c kernel/sched_record.c kernel/time_record.c kernel/time_record_sync.c kernel/entropy_record.c kernel/entropy_record_sync.c kernel/replay_engine.c kernel/replay_engine_sync.c kernel/divergence.c kernel/divergence_sync.c kernel/keyframe_ring.c kernel/rewind.c kernel/rewind_sync.c kernel/reverse.c kernel/reverse_sync.c kernel/revbreak.c kernel/revbreak_sync.c kernel/gdbstub.c kernel/gdbstub_sync.c kernel/mcp.c kernel/mcp_sync.c kernel/journal_capture.c kernel/journal_capture_sync.c kernel/keyframe_store.c kernel/keyframe_store_sync.c kernel/replay_driver.c kernel/replay_driver_sync.c kernel/divergence_scan.c kernel/divergence_scan_sync.c kernel/gdb_serial.c kernel/gdb_serial_sync.c kernel/mcp_server.c kernel/mcp_server_sync.c kernel/ramdisk.c; do
             echo "freestanding: $f"
             gcc -ffreestanding -fno-stack-protector -m64 -Iinclude -Wall -Wextra -fsyntax-only "$f"
           done
@@ -150,6 +154,7 @@ jobs:
           gcc -I../include -Wall -o /tmp/t_rd     test_replay_driver.c        ../kernel/replay_driver.c ../kernel/replay_engine.c && /tmp/t_rd
           gcc -I../include -Wall -o /tmp/t_ds     test_divergence_scan.c      ../kernel/divergence_scan.c ../kernel/divergence.c && /tmp/t_ds
           gcc -I../include -Wall -o /tmp/t_gsl    test_gdb_serial.c           ../kernel/gdb_serial.c ../kernel/gdbstub.c ../kernel/gdbstub_sync.c && /tmp/t_gsl
+          gcc -I../include -Wall -o /tmp/t_msl    test_mcp_server.c           ../kernel/mcp_server.c ../kernel/mcp.c && /tmp/t_msl
 
   e2e-demo:
     runs-on: ubuntu-latest

--- a/docs/architecture/time-travel.md
+++ b/docs/architecture/time-travel.md
@@ -42,6 +42,7 @@ ships each piece:
 | GDB bridge | Maps gdb `reverse-stepi` / `reverse-continue` (RSP bs/bc) onto the reverse engine | `kernel/gdbstub.c`, `kernel/gdbstub_sync.c` |
 | GDB serial transport | Serves RSP packets over the serial port: reads a framed request past stray acks, acks it, calls gdbstub_serve, and writes the framed reply with retransmit-on-NAK | `kernel/gdb_serial.c`, `kernel/gdb_serial_sync.c` |
 | MCP interface | Exposes record / rewind / reverse execution as JSON-RPC tools an AI agent can call | `kernel/mcp.c`, `kernel/mcp_sync.c` |
+| MCP server transport | Serves the MCP tools over a newline-delimited JSON-RPC loop: reads a request line, calls mcp_handle over the bound kernel ops, writes the response line; registers the keyframe ring and watch probe | `kernel/mcp_server.c`, `kernel/mcp_server_sync.c` |
 
 Each stage has a host-side unit test under `tests/` and a freestanding compile check in CI.
 Two end-to-end demos tie them together, both headless: `scripts/test/timetravel_demo.sh`

--- a/docs/testing/mcp-server.md
+++ b/docs/testing/mcp-server.md
@@ -1,0 +1,74 @@
+# Driving IKOS time-travel from an MCP client (#188, #199)
+
+IKOS exposes its time-travel primitives as Model Context Protocol (MCP) tools,
+so an AI agent can reproduce a non-deterministic bug, step the whole system
+backward, and find where a value last changed, all as callable tools over
+JSON-RPC.
+
+## The tools
+
+| Tool | What it does | Backed by |
+|------|--------------|-----------|
+| `list_checkpoints` | The retained keyframe window (the rewind horizon) | keyframe ring (#168) |
+| `rewind_to` | Restore the nearest keyframe and replay to `(epoch, offset)` | rewind (#169) |
+| `reverse_step` | Step one unit backward | reverse execution (#170) |
+| `watch_last_write` | Find where a watched value last changed | reverse watchpoint (#171) |
+
+## How it fits together
+
+The tool surface (`kernel/mcp.c`) parses a JSON-RPC request, dispatches
+`tools/list` and `tools/call` to the operations, and formats the response; it
+does no I/O. `kernel/mcp_server.c` is the transport: a loop that
+
+1. reads one newline-delimited JSON-RPC request line,
+2. hands it to `mcp_handle()` over the bound kernel ops (`mcp_kernel_ops()`
+   after `mcp_bind()`), and
+3. writes the JSON-RPC response followed by a newline.
+
+Blank lines between requests are skipped, and the loop ends cleanly when the
+connection closes. The byte I/O is injected, so the loop is host-tested with a
+scripted byte stream; the kernel adapter `kernel/mcp_server_sync.c` wires it to
+the serial port (COM2, so it does not collide with the gdb reverse stub on
+COM1).
+
+At boot the kernel calls `mcp_server_init()`, which binds the ops, configures
+the serial line, and registers the keyframe ring (`mcp_set_ring`, from the
+keyframe store #195) and the watch probe (`mcp_set_watch_probe`). The blocking
+JSON-RPC serve loop `mcp_server_run()` is entered on demand.
+
+## Using it
+
+An MCP client connects to the serial line and speaks newline-delimited JSON-RPC.
+List the tools:
+
+```
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+Reproduce a moment and step backward:
+
+```
+{"id":2,"method":"tools/call","params":{"name":"rewind_to","arguments":{"epoch":35,"offset":2}}}
+{"id":3,"method":"tools/call","params":{"name":"reverse_step","arguments":{}}}
+{"id":4,"method":"tools/call","params":{"name":"watch_last_write","arguments":{}}}
+```
+
+Each request gets one response line. The reach of a rewind is bounded by the
+keyframe retention ring (#168): `list_checkpoints` reports the oldest and newest
+retained epochs, and a `rewind_to` before the oldest is rejected.
+
+## Verifying the server
+
+The tool dispatch and the transport loop are unit-tested headlessly:
+
+```
+cd tests
+gcc -I../include -Wall -o /tmp/t_mcp test_mcp.c ../kernel/mcp.c && /tmp/t_mcp
+gcc -I../include -Wall -o /tmp/t_msl test_mcp_server.c \
+    ../kernel/mcp_server.c ../kernel/mcp.c && /tmp/t_msl
+```
+
+The first checks the JSON scanning and `tools/list` / `tools/call` dispatch; the
+second checks that requests are read as lines, dispatched through the loop, and
+answered one response line each (with blank lines skipped and a clean close at
+end of stream).

--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -1,0 +1,65 @@
+/* IKOS Orthogonal Persistence - MCP stdio JSON-RPC server loop (#199, epic #159)
+ *
+ * The MCP tool surface (#188) parses a JSON-RPC request and dispatches it, but
+ * does no I/O. This layer is the transport: a loop that reads one
+ * newline-delimited JSON-RPC request, hands it to mcp_handle() (wired to the
+ * kernel's time-travel ops), and writes the newline-terminated response. That
+ * lets a real MCP client (an AI agent) drive record / rewind / reverse execution
+ * against a running IKOS over stdio or the serial port.
+ *
+ * The transport core is pure and host-testable: byte I/O is injected (a
+ * get_byte / put_byte pair) and the handle step is a callback, so the whole
+ * read-line / dispatch / write-line loop is exercised with a scripted byte
+ * stream. The kernel adapter (mcp_server_sync.c) wires the byte I/O to the UART,
+ * the handle step to mcp_handle() over mcp_kernel_ops(), and registers the
+ * keyframe ring and the watch probe.
+ *
+ * See docs/architecture/time-travel.md (Plan 2).
+ */
+
+#ifndef MCP_SERVER_H
+#define MCP_SERVER_H
+
+#include <stdint.h>
+
+/* Injected byte transport. get_byte blocks for one byte and returns 0..255, or
+ * a negative value at end of stream / a closed connection. put_byte writes one
+ * byte and returns 0 on success. */
+typedef struct {
+    int   (*get_byte)(void* ctx);
+    int   (*put_byte)(void* ctx, uint8_t b);
+    void* ctx;
+} mcp_transport_t;
+
+/* The handle step: turn one JSON-RPC request into a JSON-RPC response.
+ * Signature matches mcp_handle() with its ops already bound. */
+typedef int (*mcp_handle_fn)(const char* request, uint32_t reqlen,
+                             char* out, uint32_t outcap);
+
+#define MCP_SERVER_OK      0
+#define MCP_SERVER_CLOSED -1   /* transport reached end of stream */
+#define MCP_SERVER_ERR    -2
+
+/* Read one newline-delimited request line into `buf` (excluding the newline;
+ * a trailing '\r' is stripped), skipping leading blank lines. Returns the line
+ * length, MCP_SERVER_CLOSED at end of stream, or MCP_SERVER_ERR (line too long). */
+int mcp_server_read_line(const mcp_transport_t* t, char* buf, uint32_t cap);
+
+/* Serve one request: read a line, run `handle` to build the response, and write
+ * it followed by '\n'. Returns MCP_SERVER_OK, MCP_SERVER_CLOSED, or an error. */
+int mcp_server_serve_once(const mcp_transport_t* t, mcp_handle_fn handle);
+
+/* Serve requests until the transport closes. Returns the closing status
+ * (MCP_SERVER_CLOSED on a clean disconnect, or the first error). */
+int mcp_server_loop(const mcp_transport_t* t, mcp_handle_fn handle);
+
+/* ---- Kernel adapter (mcp_server_sync.c) ----
+ * Configure the UART at `port` (0 selects COM2, so the MCP server and the gdb
+ * stub on COM1 do not collide), bind the MCP ops (mcp_bind), register the
+ * keyframe ring (from the keyframe store) and a watch probe, then serve the
+ * JSON-RPC loop against mcp_handle(). mcp_server_run blocks until the connection
+ * closes. */
+void mcp_server_init(uint16_t port);
+int  mcp_server_run(void);
+
+#endif /* MCP_SERVER_H */

--- a/kernel/kernel_main.c
+++ b/kernel/kernel_main.c
@@ -34,6 +34,7 @@
 #include "../include/divergence.h"
 #include "../include/divergence_scan.h"
 #include "../include/gdb_serial.h"
+#include "../include/mcp_server.h"
 #include <stdint.h>
 
 /* Function declarations */
@@ -306,6 +307,13 @@ void kernel_init(void) {
          * serial serve loop (gdbstub_serial_run) is entered on demand from the
          * debug path, not during boot. */
         gdbstub_serial_init(0 /* COM1 */);
+
+        /* Bind the MCP time-travel tools and configure their serial line (#199)
+         * on COM2, and register the keyframe ring + watch probe, so an MCP
+         * client (an AI agent) can list checkpoints and drive rewind / reverse
+         * execution. The blocking JSON-RPC serve loop (mcp_server_run) is
+         * entered on demand, not during boot. */
+        mcp_server_init(0 /* COM2 */);
     } else {
         kernel_print("Orthogonal persistence disabled (no checkpoint store)\n");
     }

--- a/kernel/mcp_server.c
+++ b/kernel/mcp_server.c
@@ -1,0 +1,60 @@
+/* IKOS Orthogonal Persistence - MCP stdio JSON-RPC server loop core (#199)
+ *
+ * See include/mcp_server.h. Pure and host-testable: byte I/O and the handle
+ * step are injected, so this file has no allocator, hardware, or MCP-ops
+ * dependency. It implements just the newline-delimited transport: read a request
+ * line, hand it to the handler, and write the response line.
+ */
+
+#include "mcp_server.h"
+
+int mcp_server_read_line(const mcp_transport_t* t, char* buf, uint32_t cap) {
+    if (!t || !t->get_byte || !buf || cap < 2) return MCP_SERVER_ERR;
+
+    uint32_t n = 0;
+    for (;;) {
+        int c = t->get_byte(t->ctx);
+        if (c < 0) {
+            /* End of stream: a partial line is discarded; a clean boundary ends
+             * the session. */
+            return n > 0 ? MCP_SERVER_CLOSED : MCP_SERVER_CLOSED;
+        }
+        if (c == '\n') {
+            if (n == 0) continue;      /* skip blank lines between requests */
+            /* Strip a trailing CR from a CRLF terminator. */
+            if (n > 0 && buf[n - 1] == '\r') n--;
+            if (n == 0) continue;
+            buf[n] = '\0';
+            return (int)n;
+        }
+        if (n + 1 >= cap) return MCP_SERVER_ERR; /* line too long for buf */
+        buf[n++] = (char)c;
+    }
+}
+
+int mcp_server_serve_once(const mcp_transport_t* t, mcp_handle_fn handle) {
+    if (!t || !handle) return MCP_SERVER_ERR;
+
+    char req[1024];
+    int rlen = mcp_server_read_line(t, req, sizeof(req));
+    if (rlen == MCP_SERVER_CLOSED) return MCP_SERVER_CLOSED;
+    if (rlen < 0) return MCP_SERVER_ERR;
+
+    char resp[1024];
+    int n = handle(req, (uint32_t)rlen, resp, sizeof(resp));
+    if (n < 0) return MCP_SERVER_ERR;
+
+    for (int i = 0; i < n; i++) {
+        if (t->put_byte(t->ctx, (uint8_t)resp[i]) != 0) return MCP_SERVER_ERR;
+    }
+    if (t->put_byte(t->ctx, (uint8_t)'\n') != 0) return MCP_SERVER_ERR;
+    return MCP_SERVER_OK;
+}
+
+int mcp_server_loop(const mcp_transport_t* t, mcp_handle_fn handle) {
+    for (;;) {
+        int rc = mcp_server_serve_once(t, handle);
+        if (rc == MCP_SERVER_OK) continue;
+        return rc; /* CLOSED on a clean disconnect, or the first error */
+    }
+}

--- a/kernel/mcp_server_sync.c
+++ b/kernel/mcp_server_sync.c
@@ -1,0 +1,78 @@
+/* IKOS Orthogonal Persistence - MCP server transport adapter (#199)
+ *
+ * See include/mcp_server.h. Wires the pure JSON-RPC server loop to the 16550
+ * UART and to the MCP tool surface: byte I/O is the serial data/status
+ * registers, and the handle step is mcp_handle() over mcp_kernel_ops().
+ * mcp_server_init binds the ops (mcp_bind), registers the keyframe ring (from
+ * the keyframe store, #195) and a watch probe, then mcp_server_run serves the
+ * loop until the client disconnects.
+ */
+
+#include "mcp_server.h"
+#include "mcp.h"             /* mcp_bind, mcp_handle, mcp_kernel_ops, mcp_set_* */
+#include "keyframe_store.h"  /* keyframe_store_get, keyframe_store_ring */
+#include "checkpoint.h"      /* checkpoint_current_epoch (watch probe) */
+#include "boot.h"            /* SERIAL_* register offsets, SERIAL_READY_BIT */
+#include "io.h"              /* inb, outb */
+
+/* COM2 base, so the MCP server does not collide with the gdb stub on COM1. */
+#define SERIAL_COM2_BASE      0x2F8
+/* Line Status Register bit 0: receive data ready. */
+#define SERIAL_LSR_DATA_READY 0x01
+
+extern int klog_serial_init(uint16_t port, uint32_t baud_rate);
+
+static uint16_t g_mcp_port;
+
+static int serial_get_byte(void* ctx) {
+    (void)ctx;
+    while ((inb(g_mcp_port + SERIAL_STATUS_PORT) & SERIAL_LSR_DATA_READY) == 0) {
+        /* busy-wait for the receiver */
+    }
+    return (int)inb(g_mcp_port + SERIAL_DATA_PORT);
+}
+
+static int serial_put_byte(void* ctx, uint8_t b) {
+    (void)ctx;
+    while ((inb(g_mcp_port + SERIAL_STATUS_PORT) & SERIAL_READY_BIT) == 0) {
+        /* busy-wait for the transmitter holding register */
+    }
+    outb(g_mcp_port + SERIAL_DATA_PORT, b);
+    return 0;
+}
+
+static const mcp_transport_t g_transport = {
+    serial_get_byte, serial_put_byte, 0
+};
+
+/* The handle step: dispatch one request through the bound kernel ops. */
+static int mcp_server_handle(const char* request, uint32_t reqlen,
+                             char* out, uint32_t outcap) {
+    return mcp_handle(mcp_kernel_ops(), request, reqlen, out, outcap);
+}
+
+/* Watch probe: a real, monotonically-advancing kernel value the agent can hunt
+ * with watch_last_write (where the checkpoint epoch last changed). */
+static uint64_t probe_current_epoch(void* ctx) {
+    (void)ctx;
+    return checkpoint_current_epoch();
+}
+
+void mcp_server_init(uint16_t port) {
+    g_mcp_port = port ? port : SERIAL_COM2_BASE;
+    klog_serial_init(g_mcp_port, 38400); /* 8N1, FIFO on */
+
+    mcp_bind();                          /* wire the tools to the k* engines */
+
+    /* list_checkpoints reads the retained keyframe window; the ring lives in
+     * the keyframe store (NULL when persistence is disabled, handled gracefully). */
+    keyframe_store_t* ks = keyframe_store_get();
+    mcp_set_ring(ks ? keyframe_store_ring(ks) : 0);
+
+    /* watch_last_write needs a probe for the watched value. */
+    mcp_set_watch_probe(probe_current_epoch, 0);
+}
+
+int mcp_server_run(void) {
+    return mcp_server_loop(&g_transport, mcp_server_handle);
+}

--- a/tests/test_mcp_server.c
+++ b/tests/test_mcp_server.c
@@ -1,0 +1,126 @@
+/* Host-side unit test for the MCP stdio JSON-RPC server loop (#199).
+ *
+ * Drives the pure transport with a scripted newline-delimited request stream and
+ * captures the output, over the REAL MCP tool surface (mcp.c) with mock ops,
+ * verifying:
+ *   1. A tools/list request is read as a line and its response written +'\n'.
+ *   2. tools/call rewind_to / reverse_step / list_checkpoints dispatch through
+ *      the loop to the injected ops, each producing one response line.
+ *   3. Blank lines between requests are skipped.
+ *   4. The loop ends cleanly at end of stream, having served every request.
+ *
+ * Build: gcc -I../include -o test_mcp_server \
+ *            test_mcp_server.c ../kernel/mcp_server.c ../kernel/mcp.c
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef __SIZE_TYPE__ size_t;
+extern int printf(const char*, ...);
+
+#include "mcp_server.h"
+#include "mcp.h"
+
+static int failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { printf("  FAIL: %s\n", msg); failures++; } \
+    else { printf("  ok:   %s\n", msg); } \
+} while (0)
+
+/* ---- Mock time-travel ops (like test_mcp.c) ---- */
+typedef struct { int lists, rewinds, steps; uint64_t rewind_epoch, rewind_offset; } mock_t;
+static int m_list(void* c, uint64_t* o, uint64_t* n, uint32_t* cnt) {
+    mock_t* m = (mock_t*)c; m->lists++; *o = 20; *n = 40; *cnt = 3; return 0;
+}
+static int m_rewind(void* c, uint64_t e, uint64_t off) {
+    mock_t* m = (mock_t*)c; m->rewinds++; m->rewind_epoch = e; m->rewind_offset = off; return 0;
+}
+static int m_step(void* c, uint64_t* e, uint64_t* o) {
+    mock_t* m = (mock_t*)c; m->steps++; *e = 30; *o = 3; return 0;
+}
+static int m_watch(void* c, uint64_t* e, uint64_t* o) {
+    (void)c; *e = 40; *o = 1; return 0;
+}
+
+static mock_t g_mock;
+static mcp_ops_t g_ops;
+
+/* Bound handle step for the loop: dispatch through the real mcp_handle. */
+static int handle(const char* req, uint32_t reqlen, char* out, uint32_t outcap) {
+    return mcp_handle(&g_ops, req, reqlen, out, outcap);
+}
+
+/* ---- Scripted byte transport ---- */
+static char g_in[2048]; static uint32_t g_in_len, g_in_pos;
+static char g_out[4096]; static uint32_t g_out_len;
+static void in_reset(void) { g_in_len = 0; g_in_pos = 0; }
+static void in_push(const char* s) { while (*s) g_in[g_in_len++] = *s++; }
+static void out_reset(void) { g_out_len = 0; }
+static int mock_get(void* c) { (void)c; return g_in_pos < g_in_len ? (uint8_t)g_in[g_in_pos++] : -1; }
+static int mock_put(void* c, uint8_t b) { (void)c; if (g_out_len < sizeof(g_out)) g_out[g_out_len++] = (char)b; return 0; }
+static mcp_transport_t g_t = { mock_get, mock_put, 0 };
+
+static bool out_contains(const char* s) {
+    for (uint32_t i = 0; i < g_out_len; i++) {
+        uint32_t j = 0;
+        while (s[j] && i + j < g_out_len && g_out[i + j] == s[j]) j++;
+        if (!s[j]) return true;
+    }
+    return false;
+}
+static uint32_t count_newlines(void) {
+    uint32_t c = 0;
+    for (uint32_t i = 0; i < g_out_len; i++) if (g_out[i] == '\n') c++;
+    return c;
+}
+
+int main(void) {
+    printf("test_mcp_server\n");
+    g_ops.list_checkpoints = m_list;
+    g_ops.rewind_to = m_rewind;
+    g_ops.reverse_step = m_step;
+    g_ops.watch_last_write = m_watch;
+    g_ops.ctx = &g_mock;
+
+    /* ---- 1: a single tools/list request round-trips as a response line ---- */
+    in_reset(); out_reset();
+    in_push("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n");
+    int rc = mcp_server_serve_once(&g_t, handle);
+    CHECK(rc == MCP_SERVER_OK, "serve_once tools/list OK");
+    CHECK(out_contains("rewind_to") && out_contains("reverse_step"),
+          "tools/list response lists the tools");
+    CHECK(out_contains("\"id\":1"), "response echoes the request id");
+    CHECK(g_out_len > 0 && g_out[g_out_len - 1] == '\n', "response terminated by newline");
+    CHECK(count_newlines() == 1, "exactly one response line written");
+
+    /* ---- 2/3: a multi-request stream (with a blank line) drives the loop ---- */
+    in_reset(); out_reset();
+    g_mock = (mock_t){0};
+    in_push("{\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"rewind_to\","
+            "\"arguments\":{\"epoch\":35,\"offset\":2}}}\n");
+    in_push("\r\n");                     /* a blank line between requests */
+    in_push("{\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"reverse_step\","
+            "\"arguments\":{}}}\n");
+    in_push("{\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"list_checkpoints\","
+            "\"arguments\":{}}}\n");
+    rc = mcp_server_loop(&g_t, handle);
+    CHECK(rc == MCP_SERVER_CLOSED, "loop ends cleanly at end of stream");
+    CHECK(g_mock.rewinds == 1 && g_mock.rewind_epoch == 35 && g_mock.rewind_offset == 2,
+          "rewind_to dispatched with epoch=35 offset=2 through the loop");
+    CHECK(g_mock.steps == 1, "reverse_step dispatched through the loop");
+    CHECK(g_mock.lists == 1, "list_checkpoints dispatched through the loop");
+    CHECK(out_contains("rewound to epoch=35 offset=2"), "rewind result line written");
+    CHECK(out_contains("stepped back to epoch=30 offset=3"), "reverse_step result line written");
+    CHECK(out_contains("count=3 oldest=20 newest=40"), "list_checkpoints result line written");
+    CHECK(count_newlines() == 3, "three response lines (blank line skipped)");
+
+    /* ---- 4: empty stream closes without a response ---- */
+    in_reset(); out_reset();
+    rc = mcp_server_serve_once(&g_t, handle);
+    CHECK(rc == MCP_SERVER_CLOSED && g_out_len == 0, "empty stream reports CLOSED, no output");
+
+    printf("%s (%d failure%s)\n", failures ? "FAILED" : "PASSED",
+           failures, failures == 1 ? "" : "s");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

Serve the MCP tools (#188) over a real transport: a loop reads a JSON-RPC request
line, calls `mcp_handle()` with the kernel ops (`mcp_kernel_ops()` after
`mcp_bind()`), and writes the response. This lets a real MCP client (an AI agent)
drive record / rewind / reverse execution against a running IKOS.

## How

- **`kernel/mcp_server.c` / `include/mcp_server.h` (pure core)** — a
  newline-delimited JSON-RPC server loop:
  - `mcp_server_read_line` reads one request line, skipping blank lines and
    stripping a trailing CRLF.
  - `mcp_server_serve_once` runs the handle callback and writes the response
    followed by `\n`.
  - `mcp_server_loop` serves until the transport closes.
  - Byte I/O and the handle step are injected, so the whole read-line / dispatch
    / write-line handshake is host-testable.
- **`kernel/mcp_server_sync.c` (kernel adapter)** — wires byte I/O to the 16550
  UART on **COM2** (so the MCP server and the gdb reverse stub on COM1 do not
  collide) and the handle step to `mcp_handle()` over `mcp_kernel_ops()`.
  `mcp_server_init` binds the ops (`mcp_bind`), registers the keyframe ring from
  the keyframe store (`mcp_set_ring`) and a watch probe over the checkpoint epoch
  (`mcp_set_watch_probe`); `mcp_server_run` serves until the client disconnects.
- **`kernel/kernel_main.c`** — calls `mcp_server_init()` at boot so the tools are
  bound and the ring + watch probe are registered; the blocking serve loop is
  entered on demand (never blocks startup).

## Acceptance criteria

- [x] A stdio/serial loop reads JSON-RPC requests and writes `mcp_handle()` responses (newline-delimited request in → response line out).
- [x] The watch probe and keyframe ring are registered (`mcp_set_watch_probe` over the checkpoint epoch; `mcp_set_ring` from the keyframe store, in `mcp_server_init`).
- [x] An MCP client can list tools and drive rewind/reverse against a running IKOS (`tools/list` + `tools/call` rewind_to / reverse_step / list_checkpoints dispatched end to end through the loop — verified in the test).

## Verification

- New host unit test `tests/test_mcp_server.c` over the real MCP tool surface —
  14 checks pass: a single `tools/list` round trip (one response line ending in
  `\n`), a multi-request stream driving rewind_to / reverse_step /
  list_checkpoints through the loop with a blank line skipped, and a clean close
  at end of stream.
- Freestanding `-Wall -Wextra` syntax checks clean for `mcp_server.c` and
  `mcp_server_sync.c`; `kernel_main.c` parses with no errors referencing the
  change.
- CI wired: trigger paths, freestanding checks, and the unit test added to
  `.github/workflows/persistence.yml`; new `docs/testing/mcp-server.md` and the
  architecture module map updated.

Closes #199