### PR TITLE
Reframe the README around IKOS as a debugging tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,65 +209,25 @@ The broader subsystems below describe the project's overall scope; several are
 partial or aspirational. The debugging and persistence stacks are the parts
 with end-to-end tests and CI today.
 
-## About
+## The machine
 
-The machine under the microscope is **IKOS** itself: a **microkernel-based operating
-system** for **x86/x86_64 consumer devices** (desktops, laptops, embedded systems),
-organized around the persistence-and-replay thesis above. Alongside it the project
-includes:
+The system being recorded is IKOS's own microkernel for x86/x86_64 consumer
+devices. Two of its properties are what make the debugger work:
 
-- **Orthogonal Persistence** with periodic system checkpoints and resume-on-boot
-- **Custom Multi-Stage Bootloader** with a real mode to long mode transition
-- **Advanced Virtual Memory Manager (VMM)** with copy-on-write and demand paging
-- **Message-Passing IPC** for secure inter-process communication
-- **Audio System** scaffolding with AC97 codec support
-- **GUI Framework** with window management and graphics
-- **TCP/IP Network Stack** with a socket programming interface
-- **Virtual File System (VFS)** targeting multiple filesystems
-- **Security Framework** with authentication and authorization
+- **Copy-on-write virtual memory.** A keyframe is a COW marking pass: mark every
+  writable page read-only, copy nothing, and capture a page lazily on its first
+  write. That makes whole-system checkpoints cheap enough to take on a timer,
+  which is what makes "a keyframe every interval" affordable.
+- **A small, message-passing microkernel.** The kernel surface that must be
+  recorded and reconstructed (scheduler, process table, IPC) is small enough to
+  checksum every epoch and reason about deterministically. Replay is
+  deterministic on a single CPU today; SMP-safe replay is future work.
 
-IKOS is developed with a modular approach, enabling independent evolution of system
-components while maintaining clean interfaces and robust integration.
-
-## Key Concepts
-
-### Microkernel Architecture
-- **Minimal kernel space**: only essential services (IPC, scheduling, memory management)
-- **User-space drivers**: device drivers and system services run in protected user space
-- **Message-passing communication**: secure and efficient inter-process communication
-- **Fault isolation**: a failed component does not crash the entire system
-
-### Advanced Memory Management
-- **Virtual Memory Manager (VMM)**: x86_64 paging with 4-level page tables
-- **Copy-on-Write (COW)**: efficient memory sharing, process forking, and the basis of persistence
-- **Demand Paging**: load pages only when needed
-- **Memory Protection**: hardware-enforced isolation between processes
-
-### Graphics and GUI
-- **Framebuffer Driver**: direct graphics memory access
-- **Window Manager**: windowing system with compositing
-- **GUI Framework**: widget library for application development
-- **Input Handling**: keyboard and mouse support
-
-### Networking
-- **TCP/IP Stack**: IPv4 networking implementation
-- **Socket API**: Berkeley sockets compatible interface
-- **Network Drivers**: Ethernet and Wi-Fi device support
-
-### File System
-- **Virtual File System (VFS)**: unified interface for multiple filesystems
-- **FAT32 Support**: read/write support for FAT32
-- **EXT2/EXT4 Support**: Linux-compatible filesystem support
-
-### Security and Authentication
-- **User Authentication**: authentication framework with multi-factor support
-- **Authorization Framework**: role-based access control
-- **Process Isolation**: hardware-enforced process boundaries
-
-## Architecture Overview
-
-IKOS follows a microkernel architecture with clear separation between kernel space and
-user space:
+Around that core the project carries the scaffolding of a general-purpose OS, in
+varying states of maturity (see the table above): a custom multi-stage
+bootloader (real mode to long mode), a VFS with FAT support, a framebuffer and
+GUI stack, a TCP/IP stack with a sockets API, audio scaffolding, and an
+authentication framework.
 
 ```
 +-----------------------------------------------------------------+
@@ -291,117 +251,98 @@ user space:
 +-----------------------------------------------------------------+
 ```
 
-### Communication Flow
-- **System Calls**: user applications reach the kernel via the system call interface
-- **Message Passing**: inter-process communication through secure message queues
-- **Shared Memory**: high-performance data sharing between authorized processes
-- **Interrupts**: hardware events handled by the kernel and forwarded to drivers
+The recorder lives in the microkernel layer: the checkpoint engine, the input
+journal, and the record/replay wrappers sit beside the scheduler and the VMM.
+That placement is why the unit of replay is the whole machine, kernel and
+schedule included, rather than a single process.
 
-## Getting Started
+## Getting started
 
 ### Prerequisites
 
-IKOS requires a Unix-like development environment with the following tools:
+A Unix-like environment with `nasm`, `gcc`, `make`, `git`, and (to boot the OS)
+`qemu-system-x86`:
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get update
-sudo apt-get install -y \
-    nasm gcc ld make \
-    qemu-system-x86 \
-    build-essential \
-    git
-
+sudo apt-get install -y nasm gcc make qemu-system-x86 build-essential git
 # Fedora/CentOS/RHEL
-sudo dnf install -y \
-    nasm gcc ld make \
-    qemu-system-x86 \
-    gcc-c++ \
-    git
-
-# macOS (using Homebrew)
+sudo dnf install -y nasm gcc make qemu-system-x86 gcc-c++ git
+# macOS (Homebrew)
 brew install nasm gcc make qemu git
 ```
 
-### Quick Start
+### Run the debugger first (no OS build required)
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/Ikey168/IKOS.git
-   cd IKOS
-   ```
+The entire debugging stack is host-testable: every demo compiles the real
+kernel modules with the host `gcc` and drives them headlessly, so you can watch
+record / rewind / reverse work before ever booting the OS:
 
-2. Build the complete system:
-   ```bash
-   make all
-   ```
+```bash
+git clone https://github.com/Ikey168/IKOS.git && cd IKOS
 
-3. Test the ELF-loading bootloader:
-   ```bash
-   make test-elf-compact
-   ```
+./scripts/test/timetravel_live_demo.sh   # boot, record, reverse-step, verify
+./scripts/test/mcp_heisenbug_demo.sh     # an agent hunts a heisenbug by rewinding
+./scripts/test/persistence_demo.sh       # yank power, it remembers
+```
 
-4. Run specific components:
-   ```bash
-   # Audio system
-   cd kernel && make audio-system && make audio-test
+### Build and boot the OS
 
-   # GUI system
-   make gui-system && ./test_gui.sh
+```bash
+make all       # bootloader + kernel image
+make test      # comprehensive test suite
+make debug     # boot in QEMU with a gdb server attached
+```
 
-   # Network stack
-   make network-test
-   ```
+### Debug it, forward and backward
 
-### Build Targets
+Forward debugging uses QEMU's gdb server as usual:
+
+```bash
+make debug
+gdb kernel/kernel.elf
+(gdb) target remote localhost:1234
+(gdb) break kernel_main
+(gdb) continue
+```
+
+Backward debugging talks to IKOS's own stub instead, over the serial port
+(COM1); the stub owns the machine's recorded history, which QEMU's gdb server
+knows nothing about. The MCP server listens on COM2 so the two front ends never
+collide. See [Using the debugger](#using-the-debugger) above and
+[`docs/testing/reverse-debugging.md`](docs/testing/reverse-debugging.md).
+
+### Build targets
 
 | Target | Description |
 |--------|-------------|
 | `make all` | Build complete IKOS system |
 | `make bootloader` | Build all bootloader variants |
 | `make kernel` | Build kernel components |
-| `make audio-system` | Build audio framework |
-| `make gui-system` | Build GUI framework |
-| `make network-stack` | Build networking components |
 | `make test` | Run comprehensive test suite |
+| `make debug` | Boot in QEMU with a gdb server |
 | `make clean` | Clean all build artifacts |
 
-## Testing and Debugging
+## Testing
 
-### Running Tests
+CI runs the debugger's whole verification pyramid on every push
+(`.github/workflows/persistence.yml`): host-side unit tests for every module,
+freestanding compile checks proving the same sources build into the kernel, and
+the headless end-to-end demos as gates:
+
 ```bash
-# Complete system test
-make test
+make test                                 # complete system test
 
-# Orthogonal persistence: "yank power, it remembers" end-to-end demo
-./scripts/test/persistence_demo.sh       # checkpoint/restore over a power cycle
-
-# Component-specific tests
-./scripts/test/test_audio_system.sh      # Audio system validation
-./scripts/test/test_gui.sh               # GUI system testing
-./scripts/test/test_input_system.sh      # Input handling tests
-./scripts/test/test_usb_framework.sh     # USB driver tests
-
-# Hardware testing
-./scripts/test/test_real_hardware.sh     # Real hardware compatibility
-./scripts/test/qemu_test.sh              # QEMU emulation testing
-
-# Memory and process testing
-./scripts/test/test_advanced_memory.sh   # Advanced memory management
-./scripts/test/test_paging.sh            # Paging system tests
+./scripts/test/timetravel_live_demo.sh    # boot, record, reverse-step, no leak
+./scripts/test/mcp_heisenbug_demo.sh      # agent rewinds to find a planted bug
+./scripts/test/scrub_demo.sh              # scrub backwards, match every moment
+./scripts/test/timetravel_demo.sh         # byte-identical replay
+./scripts/test/persistence_demo.sh        # power-cycle resume (file-backed disk)
+./scripts/test/qemu_persistence_demo.sh   # power-cut resume on the IDE store
 ```
 
-### Debugging with QEMU and GDB
-```bash
-# Start QEMU with a GDB server
-make debug
-
-# In another terminal, connect GDB
-gdb kernel/kernel.elf
-(gdb) target remote localhost:1234
-(gdb) break kernel_main
-(gdb) continue
-```
+Component test scripts for the broader OS (audio, GUI, input, USB, memory,
+paging, real hardware) live under `scripts/test/`.
 
 ## Project Structure
 
@@ -414,14 +355,18 @@ IKOS/
     boot_elf_loader.asm  ELF kernel loading bootloader
     boot.ld              Bootloader linker script
   kernel/                Microkernel implementation
-    checkpoint*.c        Orthogonal persistence: engine, store, restore
-    scheduler.c          Process scheduler
-    interrupts.c         Interrupt handling
-    vmm.c                Virtual memory manager
-    ipc.c                Inter-process communication
-    gui.c                GUI framework
-    framebuffer.c        Graphics framebuffer driver
-    network_driver.c     Network stack implementation
+    checkpoint*.c        Checkpoint engine, snapshot store, restore (keyframes)
+    *_record*.c          Record/replay wrappers: preemption, time, entropy
+    journal_capture*.c   Per-epoch input journal, written beside each checkpoint
+    keyframe_*.c         Keyframe retention ring + N-deep on-disk store
+    replay_*.c           Replay engine + driver (land at any epoch/offset)
+    rewind*.c reverse*.c revbreak*.c   The time-travel verbs
+    divergence*.c        Byte-exact replay verification
+    gdbstub*.c gdb_serial*.c   gdb reverse-execution front end (serial)
+    mcp*.c               MCP JSON-RPC front end for AI agents
+    scheduler.c          Process scheduler (the deterministic-preemption seam)
+    vmm.c                Virtual memory manager (COW: what makes keyframes cheap)
+    interrupts.c ipc.c gui.c framebuffer.c network_driver.c ...   The OS proper
     Makefile             Kernel build system
   include/               System headers and definitions
   tests/                 Component and integration test suites
@@ -489,11 +434,13 @@ Contributions are welcome from developers of all skill levels.
 - **Pull Requests**: provide detailed descriptions of changes
 
 ### Areas Looking for Contributors
-- The persistence stack: the in-QEMU boot demo on real hardware images
-- Time-travel debugging: deterministic replay and the divergence detector
-- Device drivers (graphics, sound, network)
-- Documentation and tutorials
-- Testing and quality assurance
+- Deepen the journal: a multi-epoch journal ring (the live journal retains the
+  latest epoch today)
+- The live in-QEMU run: drive `reverse-stepi` from a real gdb against a booted image
+- More divergence components (user pages, file table, IPC) to tighten the
+  byte-exact guarantee
+- SMP-safe deterministic replay
+- Device drivers, documentation, and testing for the broader OS
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,132 @@
-# IKOS Operating System
+# IKOS
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Orthogonal Persistence](https://github.com/Ikey168/IKOS/actions/workflows/persistence.yml/badge.svg)](https://github.com/Ikey168/IKOS/actions/workflows/persistence.yml)
 [![Architecture](https://img.shields.io/badge/Architecture-x86__64-blue.svg)]()
 [![Kernel](https://img.shields.io/badge/Kernel-Microkernel-orange.svg)]()
 
-> **IKOS is a microkernel with orthogonal persistence: no save, no load, no shutdown.**
-> The entire running system is the durable state. Pull the power cord, plug it back
-> in, and your work is exactly where you left it, mid-instruction.
+> **IKOS is a time-traveling debugger built as an operating system.** Record a
+> session, then scrub the whole machine backward: step back from the crash,
+> run backward to a breakpoint, or ask where a value was last written and land
+> there.
 
-This is a real, proven idea (KeyKOS, EROS, Phantom OS, and IBM i's single-level store
-in production) that no other hobby-tier microkernel implements. It is IKOS's reason to
-exist, and it rides directly on the kernel's copy-on-write virtual memory.
+Heisenbugs die on the operating table: rerun the program and the schedule
+shifts, the timer reads change, the entropy differs, and the crash is gone.
+IKOS attacks that at the root. The OS records every nondeterministic input as
+it runs, so any past moment of the whole machine can be reconstructed exactly,
+as many times as you need. The bug cannot escape into a different interleaving,
+because the interleaving is part of the recording.
 
-## The headline: pull the plug, keep your work
+Two front ends drive it:
 
-A program does **nothing special** to be durable. The counter below has no `save()`,
-no `load()`, no serialization. The OS checkpoints the whole system periodically and
-resumes from the last checkpoint on boot:
+- **gdb**: `reverse-stepi` / `reverse-continue` against the running OS over the
+  serial port, using gdb's native reverse-execution protocol.
+- **MCP**: `list_checkpoints`, `rewind_to`, `reverse_step`, and
+  `watch_last_write` exposed as JSON-RPC tools, so an AI agent can drive the
+  machine backward. Agents are bad at exactly what this is good at: reproducing
+  a flaky bug and keeping the world stable between attempts. IKOS turns an
+  agent into a time-traveling debugger.
+
+## See it
+
+The live end-to-end run: boot the stack, record a session, then drive
+rewind/reverse over the MCP loop and verify every reconstructed moment,
+byte-exact:
+
+```
+=== In-QEMU-style time-travel end-to-end (#200) ===
+[record] retained window: epochs 3..6 (last 4 of 6)
+[agent] driving rewind/reverse over the MCP JSON-RPC loop
+        rewound to epoch=5 offset=0  ->  stepped back to epoch=4  ->  epoch=3
+[verify] epoch 3..6: state=match divergence=clean
+  divergence detector reports NO leak over the live run
+PASSED: booted, recorded, reverse-stepped, no leak
+```
+
+(Recording: `asciinema play docs/media/timetravel-live.cast`.)
+
+All the demos run headless against the real modules and gate CI:
+
+```bash
+# Boot, record, reverse-step: keyframe store + journal + divergence detector +
+# MCP front end, with every reconstructed moment verified leak-free:
+./scripts/test/timetravel_live_demo.sh
+
+# An AI agent debugs a planted heisenbug by rewinding the machine:
+./scripts/test/mcp_heisenbug_demo.sh
+
+# Record a session, scrub it backward, and match every past moment:
+./scripts/test/scrub_demo.sh
+
+# A recorded session replays byte-identically:
+./scripts/test/timetravel_demo.sh
+```
+
+## Using the debugger
+
+From gdb, over the serial port (the stub advertises `ReverseStep+` /
+`ReverseContinue+`, so gdb's stock reverse commands just work):
+
+```
+(gdb) target remote <serial>
+(gdb) reverse-stepi      # one step back: restore the prior keyframe, replay to
+                         # just before the current point
+(gdb) reverse-continue   # run backward to the previous stop / oldest keyframe
+```
+
+From an MCP client, as newline-delimited JSON-RPC (one response line per
+request):
+
+```
+{"jsonrpc":"2.0","id":1,"method":"tools/list"}
+{"id":2,"method":"tools/call","params":{"name":"rewind_to","arguments":{"epoch":35,"offset":2}}}
+{"id":3,"method":"tools/call","params":{"name":"reverse_step","arguments":{}}}
+{"id":4,"method":"tools/call","params":{"name":"watch_last_write","arguments":{}}}
+```
+
+How-tos: [gdb reverse debugging](docs/testing/reverse-debugging.md) and
+[driving time-travel from MCP](docs/testing/mcp-server.md).
+
+## Why the debugger is an operating system
+
+Record/replay debuggers exist: rr records single Linux processes from the
+outside, and emulator-level record/replay (QEMU, Simics) records a virtual
+machine from underneath. IKOS moves the recorder inside: time travel is an OS
+service. The kernel owns its keyframes, its input journal, its replay engine,
+and a divergence detector that checksums system state every epoch on both runs
+to prove each reconstruction is byte-exact. Nothing is instrumented and no
+emulator sits in the loop; the unit of replay is the whole machine, kernel and
+schedule included.
+
+It works like film: a **keyframe** (a whole-system checkpoint) every interval,
+and between keyframes a CRC-protected **journal** of every nondeterministic
+input, each entry stamped with a logical clock:
+
+- preemption points: the exact logical moment of every context switch
+- timer and cycle reads (RDTSC virtualized on replay)
+- entropy draws
+
+Restoring the nearest keyframe and re-driving execution with the journaled
+inputs reconstructs any `(epoch, offset)` in the recorded window. Reverse-step
+is "restore the prior keyframe, replay to just before here"; a reverse
+watchpoint scans backward for the last write. The retention ring keeps the last
+N keyframes on disk (the rewind horizon), and its index survives a reboot.
+
+Full design and the module map:
+[`docs/architecture/time-travel.md`](docs/architecture/time-travel.md).
+
+## The substrate: orthogonal persistence
+
+The recorder falls out of a stranger property: IKOS is a persistent OS. There
+is no save, no load, and no shutdown; the running system is the durable state.
+Pull the power cord, plug it back in, and your work is where you left it. The
+periodic whole-system checkpoints that make that true are exactly the keyframes
+time travel needs, which is why the debugger could be built as an OS at all.
+(The lineage is real: KeyKOS, EROS, Phantom OS, IBM i's single-level store. No
+other hobby-tier microkernel implements it.)
+
+A program does **nothing special** to be durable. The counter below has no
+`save()`, no `load()`, no serialization:
 
 ```c
 /* user/persistent_counter.c - the entire persistence "logic" */
@@ -25,8 +134,9 @@ uint64_t counter = 0;
 for (;;) { counter++; print_u64(counter); yield(); }
 ```
 
-The end-to-end demo (`scripts/test/persistence_demo.sh`) proves it against the real
-checkpoint engine and on-disk store, modeling a power cut as a process restart:
+The end-to-end demo (`scripts/test/persistence_demo.sh`) proves it against the
+real checkpoint engine and on-disk store, modeling a power cut as a process
+restart:
 
 ```
 [cycle 1] boot fresh, count to 5
@@ -42,19 +152,14 @@ checkpoint engine and on-disk store, modeling a power cut as a process restart:
 PASSED: the counter remembered itself across every power cycle
 ```
 
-### How it works
-
-A checkpoint marks every writable page read-only and copy-on-write (cheap; it copies
-nothing). The first write to a marked page faults, and the kernel preserves the page's
-pre-checkpoint contents before letting the write proceed. A background pass streams
-those pages into the **inactive** one of two on-disk slots. A single superblock-sector
-write flips the active slot and is the only commit point, so a crash before the flip
-always leaves the previous checkpoint intact (CRC32 guards every slot). On boot, if a
-valid checkpoint exists, the kernel reloads it instead of cold-starting.
-
-Full design: [`docs/architecture/orthogonal-persistence.md`](docs/architecture/orthogonal-persistence.md).
-
-### Try it
+How: a checkpoint marks every writable page read-only and copy-on-write (cheap;
+it copies nothing). The first write to a marked page faults, and the kernel
+preserves the pre-checkpoint contents before letting the write proceed. A
+background pass streams those pages into the **inactive** one of two on-disk
+slots; a single superblock-sector write flips the active slot and is the only
+commit point, so a crash mid-checkpoint always leaves the previous one intact
+(CRC32 guards every slot). On boot, a valid checkpoint is reloaded instead of
+cold-starting.
 
 ```bash
 # Headless proof against the real checkpoint engine (no emulator needed):
@@ -66,89 +171,50 @@ Full design: [`docs/architecture/orthogonal-persistence.md`](docs/architecture/o
 ./scripts/test/qemu_persistence_demo.sh
 ```
 
-The checkpoint store can live on the volatile RAM disk (survives a warm reboot) or, for
-true power-cut durability, on a real IDE disk via `checkpoint_ide_bind` - which the kernel
-now selects at boot, falling back to the RAM disk when no IDE drive is present. Recording of
-the yank-power/boot/resume cycle: `docs/media/qemu-resume.cast`
-(`asciinema play docs/media/qemu-resume.cast`).
+The checkpoint store lives on a real IDE disk when one is present (true
+power-cut durability; the kernel binds it at boot and falls back to the
+volatile RAM disk otherwise). Recording of the yank-power/boot/resume cycle:
+`asciinema play docs/media/qemu-resume.cast`. Full design:
+[`docs/architecture/orthogonal-persistence.md`](docs/architecture/orthogonal-persistence.md).
 
 ## What actually works vs. roadmap
 
-Being honest about maturity:
+Being honest about maturity. The debugging stack:
 
-| Area | Status |
-|------|--------|
-| Orthogonal persistence: snapshot store (double-buffered slots + CRC) | Implemented, unit-tested |
-| Checkpoint engine: stop-the-world COW marking, page-fault capture, writeback | Implemented, unit-tested |
-| Restore + boot decision (restore vs cold boot) | Implemented, unit-tested |
-| Periodic checkpoint trigger (scheduler tick) | Implemented, unit-tested |
-| External-state policy (sockets/DMA/devices severed on restore) | Implemented, unit-tested |
-| Context persistence + process-table/scheduler reconstruction on restore | Implemented, unit-tested |
-| End-to-end "yank power" proof over a file-backed disk | Passing in CI |
-| Boot store wired to a block device (RAM disk, volatile) | Implemented, unit-tested |
-| IDE-backed durable store (survives a real power cut) | Wired into the boot path (prefers the IDE disk, falls back to the RAM disk); durability + counter-resume across a power cut gated headlessly in CI, with a scripted QEMU booted-system demo |
+| Layer | Status |
+|-------|--------|
+| Deterministic replay core: input journal, deterministic preemption, virtualized time, deterministic entropy | Implemented, unit-tested |
+| Live capture: every checkpoint commit journals its epoch's inputs and divergence checksums | Implemented, unit-tested |
+| Keyframe retention store: last N checkpoints across on-disk regions, index survives reboot | Implemented, unit-tested |
+| Replay driver: land the booted system at an arbitrary (epoch, offset) | Implemented, unit-tested; the live journal retains the latest epoch (a deeper journal ring is future work) |
+| Divergence detector fed by real component checksums (process table, scheduler) | Implemented, unit-tested |
+| Rewind-to, reverse-step/continue, reverse breakpoints and watchpoints | Implemented, unit-tested |
+| gdb front end: RSP stub (bs/bc) + serial transport loop | Implemented, unit-tested |
+| MCP front end: JSON-RPC tools + server loop | Implemented, unit-tested |
+| End-to-end: byte-identical replay, scrub-backwards, agent heisenbug hunt, live boot/record/reverse-step | Passing headlessly in CI; the in-QEMU layer runs when an emulator + image are present |
+
+And the persistence substrate it rides on:
+
+| Layer | Status |
+|-------|--------|
+| Snapshot store: double-buffered slots + CRC, single superblock-flip commit | Implemented, unit-tested |
+| Checkpoint engine: stop-the-world COW marking, page-fault capture, background writeback | Implemented, unit-tested |
+| Restore + boot decision; context and process-table reconstruction | Implemented, unit-tested |
+| Periodic trigger + external-state policy (sockets/DMA/devices severed on restore) | Implemented, unit-tested |
+| IDE-backed durable store wired into the boot path (falls back to the RAM disk) | Implemented; durability + counter resume across a power cut gated headlessly in CI, with a scripted QEMU booted-system demo |
 | Process register/scheduler-state resume actually executing | Table/context restore done; scheduler bridge + QEMU boot pending |
-| Live boot/record/reverse-step end-to-end (headless CI gate + recording) | Passing in CI; QEMU boot layer runs when an image is present |
-| Persisting kernel-internal and driver state | v2 (v1 cold-inits the kernel/drivers and restores user spaces on top) |
+| Kernel-internal and driver state | v2 design (v1 cold-inits the kernel/drivers and restores user spaces on top) |
 
-The broader subsystems below describe the project's overall scope; several are partial
-or aspirational. The persistence stack is the part with end-to-end tests and CI today.
-
-## Time-travel: scrub the machine backwards
-
-Because the checkpoint engine already snapshots the whole system periodically, IKOS goes a
-step further than "resume the last moment": it records the nondeterministic inputs between
-keyframes (preemptions, timer and cycle reads, entropy) into a CRC-protected journal, so
-any past moment can be reconstructed by restoring the nearest keyframe and replaying
-forward. That makes the running system rewindable: `rewind-to <epoch>` lands at a past
-moment, and reverse-step / reverse-continue walk it backward, driven from a normal gdb
-session (`reverse-stepi`).
-
-```bash
-# Boot, record, reverse-step: the whole live stack (keyframe store, journal,
-# divergence detector, MCP front end) drives an agent through rewind/reverse and
-# confirms every reconstructed moment matches with no divergence leak.
-./scripts/test/timetravel_live_demo.sh
-
-# Headless proof: record a session, then scrub it backward and show every
-# reconstructed past moment matches the recorded timeline.
-./scripts/test/scrub_demo.sh
-
-# Headless proof that a recorded session replays byte-identically:
-./scripts/test/timetravel_demo.sh
-```
-
-Recording of the live boot -> record -> reverse-step run (asciicast, playable with
-`asciinema play docs/media/timetravel-live.cast`):
-
-```
-=== In-QEMU-style time-travel end-to-end (#200) ===
-[record] retained window: epochs 3..6 (last 4 of 6)
-[agent] driving rewind/reverse over the MCP JSON-RPC loop
-        rewound to epoch=5 offset=0  ->  stepped back to epoch=4  ->  epoch=3
-[verify] epoch 3..6: state=match divergence=clean
-  divergence detector reports NO leak over the live run
-PASSED: booted, recorded, reverse-stepped, no leak
-```
-
-The whole stack is implemented and unit-tested, with headless end-to-end demos
-that gate it in CI: the deterministic replay core (input journal, deterministic
-preemption, virtualized time and entropy) and a divergence detector that proves a
-replay is byte-exact; live per-epoch journal capture and an N-deep keyframe
-retention store on disk; the replay driver that lands the booted system at any
-`(epoch, offset)`; the time-travel verbs (rewind-to, reverse execution, reverse
-breakpoints and watchpoints); and two front ends, a gdb reverse-execution bridge
-over the serial port and an MCP JSON-RPC server an AI agent can call.
-
-Full design and the module map: [`docs/architecture/time-travel.md`](docs/architecture/time-travel.md);
-driving it from gdb: [`docs/testing/reverse-debugging.md`](docs/testing/reverse-debugging.md);
-from an MCP client: [`docs/testing/mcp-server.md`](docs/testing/mcp-server.md).
+The broader subsystems below describe the project's overall scope; several are
+partial or aspirational. The debugging and persistence stacks are the parts
+with end-to-end tests and CI today.
 
 ## About
 
-**IKOS** is a **microkernel-based operating system** for **x86/x86_64 consumer devices**
-(desktops, laptops, embedded systems), organized around the orthogonal-persistence thesis
-above. Alongside it the project includes:
+The machine under the microscope is **IKOS** itself: a **microkernel-based operating
+system** for **x86/x86_64 consumer devices** (desktops, laptops, embedded systems),
+organized around the persistence-and-replay thesis above. Alongside it the project
+includes:
 
 - **Orthogonal Persistence** with periodic system checkpoints and resume-on-boot
 - **Custom Multi-Stage Bootloader** with a real mode to long mode transition
@@ -369,9 +435,9 @@ IKOS/
 
 ## Roadmap
 
-The persistence stack and the time-travel debugging that builds on it are the mature
-parts of IKOS, with unit tests and CI demos (see the sections above). The items below
-are the broader OS scaffolding, in rough priority order.
+The time-travel debugging stack and the persistence substrate it rides on are the
+mature parts of IKOS, with unit tests and CI demos (see the sections above). The items
+below are the broader OS scaffolding, in rough priority order.
 
 Recently landed: the IDE-backed durable store wired into the boot path, the in-QEMU
 persistence-resume demo, and the full live time-travel stack (see the maturity table

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,12 @@
 # IKOS Documentation
 
-IKOS is an x86/x86_64 microkernel whose defining feature is **orthogonal
-persistence**: the whole running system is the durable state, and the checkpoint
-engine that provides it also powers **time-travel debugging** (record a session
-and step the machine backward). Those two are the parts with end-to-end tests and
-CI; the rest of the tree documents the broader OS scaffolding.
+IKOS is a **time-traveling debugger built as an operating system**: an x86/x86_64
+microkernel that records every nondeterministic input as it runs, so any past
+moment of the whole machine can be reconstructed and stepped backward (from gdb
+or from an MCP client). The substrate that makes it possible is **orthogonal
+persistence**: the running system is the durable state, checkpointed whole. Those
+two stacks are the parts with end-to-end tests and CI; the rest of the tree
+documents the broader OS scaffolding.
 
 Start with the root [`README.md`](../README.md) for the project overview and the
 "try it" demos. This folder holds the design and reference docs.


### PR DESCRIPTION
## What

Lead with what IKOS is *for*, not what it is: **a time-traveling debugger built as
an operating system**. Orthogonal persistence is repositioned as the substrate
that makes the debugger possible (and a headline feature in its own right),
instead of the other way around.

## The new structure

1. **Tagline + pitch** — record a session, scrub the whole machine backward; a
   heisenbug cannot escape into a different interleaving because the
   interleaving is part of the recording.
2. **See it** — the live boot/record/reverse-step transcript now leads the page,
   plus all four time-travel demos (including the agent heisenbug hunt,
   previously unlisted in the README).
3. **Using the debugger** — concrete snippets for both front ends: gdb
   (`reverse-stepi` / `reverse-continue` over serial) and MCP (`tools/list`,
   `rewind_to`, `reverse_step`, `watch_last_write` as newline-delimited
   JSON-RPC).
4. **Why the debugger is an operating system** — contrast with rr (records a
   process from outside) and emulator-level record/replay (records a VM from
   underneath): IKOS moves the recorder inside, so the unit of replay is the
   whole machine. Brief keyframe + journal + replay + divergence model.
5. **The substrate: orthogonal persistence** — the same counter demo,
   transcript, mechanism explanation, try-it commands, and IDE durability notes
   as before, now framed as what makes the keyframes free.
6. **Maturity table** split into the debugging stack (first) and the persistence
   substrate — every honesty caveat is preserved (latest-epoch journal
   retention, scheduler bridge pending, v2 kernel-state persistence).

Below the fold, the About/roadmap intros are retouched to match ("the machine
under the microscope is IKOS itself"), and `docs/README.md`'s intro adopts the
same framing. No content was dropped: all demos, links, transcripts, and
maturity rows carry over.

## Verification

- All `docs/` links in the README verified to resolve.
- No em-dashes, arrows, or emoji introduced (house style).
- No dangling anchors to removed section headings.